### PR TITLE
ci: verify failure annotations land on the failing source line

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,16 +28,17 @@ jobs:
     timeout-minutes: 30
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      # Needed only for the Velopack `vpk` packaging tool in Phase 6, but
-      # installed here so Test-Toolchain.ps1 can verify global.json resolves.
-      # An unresolvable pin is a build failure waiting for the first release.
-      - uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: 9.0.304
+      - uses: microsoft/setup-msbuild@v3
 
-      - uses: microsoft/setup-msbuild@v2
+      # Deliberately no actions/setup-dotnet. Nothing in the build or test path
+      # invokes dotnet — the runner image already ships a 9.0.3xx SDK, and
+      # global.json's rollForward: latestPatch resolves to it. Installing a
+      # pinned SDK downloaded 298 MB and took 6 of the job's 6.5 minutes, then
+      # Test-Toolchain reported the preinstalled 9.0.316 anyway, so the download
+      # was entirely discarded. Velopack's vpk tool is the first real dotnet
+      # dependency; add setup-dotnet back in Phase 6 when packaging needs it.
 
       # Runs before the build so a toolchain mismatch is reported as itself
       # rather than as a confusing compile error 10 minutes later.
@@ -100,7 +101,7 @@ jobs:
           }
 
       - name: Upload test results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: test-results
@@ -111,7 +112,7 @@ jobs:
       # Release build. This is not that: it is the build-tree binary, uploaded so
       # a reviewer can check size and hardening flags without a local toolchain.
       - name: Upload Release binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: dhepz-release-x64
           path: build/x64/Release/dhepz.exe

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,8 +62,15 @@ jobs:
         shell: pwsh
         run: ./tools/Test.ps1 -JUnitPath artifacts/test-results/results.xml
 
-      # if: always() so a failing suite still uploads its report — the report is
-      # most useful in exactly the case where the previous step failed.
+      # if: always() so a failing suite still reports — the report is most
+      # useful in exactly the case where the previous step failed.
+      #
+      # use-actions-summary: false is load-bearing. Left at its default the
+      # action writes a job summary and creates no check run, which means no
+      # inline annotation on the failing line. RepoRelative() in test_main.cpp
+      # exists solely to make those annotations land, so the default would waste
+      # it. fail-on-error: false because the build step already failed the job;
+      # a second failure here only obscures the real one.
       - name: Publish test results
         uses: dorny/test-reporter@v1
         if: always()
@@ -72,6 +79,7 @@ jobs:
           path: artifacts/test-results/*.xml
           reporter: java-junit
           fail-on-error: false
+          use-actions-summary: false
 
       - name: Upload test results
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,6 @@ on:
 
 permissions:
   contents: read
-  # test-reporter creates a check run to surface failures as inline
-  # annotations. Without checks:write it silently degrades to a plain upload.
-  checks: write
 
 concurrency:
   # A superseded run on the same branch is wasted compute. main is excluded:
@@ -62,24 +59,45 @@ jobs:
         shell: pwsh
         run: ./tools/Test.ps1 -JUnitPath artifacts/test-results/results.xml
 
-      # if: always() so a failing suite still reports — the report is most
-      # useful in exactly the case where the previous step failed.
+      # Emits GitHub annotations from the JUnit report directly, rather than via
+      # a third-party reporter action. dorny/test-reporter's java-junit parser
+      # ignores the `file`/`line` attributes on <testcase> and annotates the XML
+      # file itself, which puts the marker on a build artifact instead of the
+      # failing source line. RepoRelative() in test_main.cpp exists specifically
+      # to make source annotations possible, so parsing the report here is what
+      # actually delivers them. It also drops a third-party action from the
+      # supply chain.
       #
-      # use-actions-summary: false is load-bearing. Left at its default the
-      # action writes a job summary and creates no check run, which means no
-      # inline annotation on the failing line. RepoRelative() in test_main.cpp
-      # exists solely to make those annotations land, so the default would waste
-      # it. fail-on-error: false because the build step already failed the job;
-      # a second failure here only obscures the real one.
-      - name: Publish test results
-        uses: dorny/test-reporter@v1
+      # if: always() because the report matters most when the previous step
+      # failed. This step never fails the job on its own — the test step already
+      # did, and a second failure would only obscure the real one.
+      - name: Annotate test failures
+        shell: pwsh
         if: always()
-        with:
-          name: tests
-          path: artifacts/test-results/*.xml
-          reporter: java-junit
-          fail-on-error: false
-          use-actions-summary: false
+        run: |
+          $reports = @(Get-ChildItem -Path artifacts/test-results -Filter *.xml -ErrorAction SilentlyContinue)
+          if ($reports.Count -eq 0) {
+            Write-Host '::warning::No JUnit report was produced.'
+            exit 0
+          }
+          foreach ($report in $reports) {
+            $config = if ($report.BaseName -match '\.(\w+)$') { $Matches[1] } else { $report.BaseName }
+            $xml = [xml](Get-Content -LiteralPath $report.FullName -Raw)
+            # The runner reports a crash as a <failure> too, and emits no
+            # `errors` attribute, so there is deliberately no <error> handling
+            # here. Reading $xml.testsuites.errors would yield empty string.
+            foreach ($case in $xml.SelectNodes('//testcase/failure')) {
+              # A newline truncates an annotation at its first line, so the
+              # expected/actual detail is encoded rather than lost.
+              $message = ($case.InnerText -replace '%', '%25' -replace "`r", '' -replace "`n", '%0A')
+              $testcase = $case.ParentNode
+              $title = "$config - $($testcase.classname).$($testcase.name)"
+              Write-Host "::error file=$($testcase.file),line=$($testcase.line),title=$title::$message"
+            }
+            $suite = $xml.testsuites
+            $verdict = if ([int]$suite.failures -eq 0) { 'all passed' } else { "$($suite.failures) failed" }
+            "$config`: $($suite.tests) tests, $verdict" >> $env:GITHUB_STEP_SUMMARY
+          }
 
       - name: Upload test results
         uses: actions/upload-artifact@v4

--- a/tests/core/ci_probe_test.cpp
+++ b/tests/core/ci_probe_test.cpp
@@ -1,6 +1,0 @@
-#include "framework/test_case.h"
-
-// Temporary: proves CI turns a JUnit failure into an inline annotation.
-DHEPZ_TEST(CiProbe, DeliberateFailure) {
-  DHEPZ_CHECK_EQ(1, 2);
-}

--- a/tests/core/ci_probe_test.cpp
+++ b/tests/core/ci_probe_test.cpp
@@ -1,0 +1,6 @@
+#include "framework/test_case.h"
+
+// Temporary: proves CI turns a JUnit failure into an inline annotation.
+DHEPZ_TEST(CiProbe.DeliberateFailure) {
+  DHEPZ_CHECK_EQ(1, 2);
+}

--- a/tests/core/ci_probe_test.cpp
+++ b/tests/core/ci_probe_test.cpp
@@ -1,6 +1,6 @@
 #include "framework/test_case.h"
 
 // Temporary: proves CI turns a JUnit failure into an inline annotation.
-DHEPZ_TEST(CiProbe.DeliberateFailure) {
+DHEPZ_TEST(CiProbe, DeliberateFailure) {
   DHEPZ_CHECK_EQ(1, 2);
 }


### PR DESCRIPTION
Verifies the CI workflow end to end by pushing a deliberately failing test, confirming it produced an inline annotation on the failing source line, then removing it. The net diff is `.github/workflows/ci.yml` only.

Three real problems were found and fixed by doing this rather than assuming:

**Annotations never landed.** `dorny/test-reporter`'s `java-junit` parser ignores the `file`/`line` attributes on `<testcase>` and annotates the report XML itself, so the marker pointed at `artifacts/test-results/results.Debug.xml#0` — a build artifact — instead of the failing line. `RepoRelative()` in `test_main.cpp` exists solely to make source annotations possible, so this quietly wasted it. The report is now parsed directly in a pwsh step, which lands the annotation on `tests/core/ci_probe_test.cpp#5` and drops a third-party action from the supply chain.

**`setup-dotnet` cost 6 of the job's 6.5 minutes for nothing.** It downloaded a 298 MB pinned SDK, and then `Test-Toolchain.ps1` reported the runner's preinstalled `9.0.316` anyway — `global.json`'s `rollForward: latestPatch` resolves to it, and nothing in the build or test path invokes `dotnet` at all. Removed; the job is now 56s. Velopack's `vpk` is the first real dotnet dependency, so `setup-dotnet` comes back in Phase 6 when packaging needs it.

**Actions were on deprecated Node 20 majors.** Bumped to `checkout@v7`, `setup-msbuild@v3`, `upload-artifact@v7`.

Also confirmed: `Test.ps1` writes a separate report per configuration and both upload; a failing suite still reports because the annotate step is `if: always()`; and the all-pass path emits no annotations.