### PR TITLE
docs: make the working order strictly sequential

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,8 +46,12 @@ Tasks live in **GitHub Issues**, not in a markdown checklist. One milestone per 
 
 - Issues #1–#14 — Phase 0, detailed. #15–#23 — Phase 1, detailed.
 - Issues #24–#29 — one outline per remaining phase, broken down at the preceding gate.
-- Issue #30 — dependency order and working index; read it before picking up work.
+- **Issue #30 is the working order. Read it before touching anything, and do the next unchecked item.**
 - `CHECKPOINT` issues are phase gates. **No phase starts until the previous gate is fully ticked.**
 - `.github/planning/` holds the scripts that generated those issues, and the issue-body template to reuse when a later phase is broken down. See its README.
+
+**One issue at a time, one PR each, in #30's order. Never work two in parallel.** Issue numbers are creation order and carry no meaning — #30's list is the order, and in one place it deliberately runs backwards through the numbers. Parallel work on items that merely look independent produces interleaved history nobody can bisect, and settles a shared interface against three simultaneous guesses instead of one refinement.
+
+`main` is protected: CI must be green and direct pushes are rejected, so every change lands as a PR.
 
 When implementing, work from the issue: its acceptance criteria and verification steps are the definition of done for that task. If reality contradicts an acceptance criterion, say so and amend the issue rather than quietly doing something else.


### PR DESCRIPTION
#30 listed #6-#9 as `parallel, all need #4 + #5`. That was wrong, and the `#include` edges in the old build prove it: `paths.cpp:112` calls `str::Trim`, and `files.cpp` calls `paths::Parent`, `paths::EnsureDirectory` and `str::ToUtf8`. Taking them in parallel means writing `paths` against a `strings` that does not exist.

#30 is now a single numbered line with no parallel branches, and it records why the order runs backwards through the numbers at steps 7-10 (#9 -> #8 -> #7 -> #6). Issue numbers are creation order, assigned before anyone read the old sources; the list is the order.

Also states why pairs with no compile-time edge are still sequenced: a reviewer reads a linear history and cannot bisect four interleaved PRs, an interface settles by being used rather than against three simultaneous guesses, and `do the next unchecked item` is a rule that survives a context reset in a way that `these four are parallel, pick one` does not.

AGENTS.md now says one issue at a time and notes that `main` is protected, so everything lands as a PR.