### PR TITLE
feat(platform): add strings with CommandLineToArgvW-correct QuoteArg

### DIFF
--- a/src/platform/strings.cpp
+++ b/src/platform/strings.cpp
@@ -1,0 +1,171 @@
+#include "platform/strings.h"
+
+#include <windows.h>
+
+#include <string>
+
+namespace str {
+namespace {
+
+// MultiByteToWideChar and its counterpart take int lengths. A string longer than
+// INT_MAX is not something this app produces, but the cast is unchecked
+// otherwise and /W4 is right to care.
+core::Status CheckLength(std::size_t size, const wchar_t* what) {
+  if (size > static_cast<std::size_t>(INT_MAX)) {
+    return DHEPZ_ERR(core::ErrorCode::InvalidArgument,
+                     std::wstring(what) + L" exceeds the maximum convertible length");
+  }
+  return core::Ok();
+}
+
+}  // namespace
+
+core::Status FromUtf8(std::string_view utf8, std::wstring* out) {
+  if (out == nullptr) {
+    return DHEPZ_ERR(core::ErrorCode::InvalidArgument, L"FromUtf8 requires an output string");
+  }
+  out->clear();
+  if (utf8.empty()) {
+    return core::Ok();
+  }
+  DHEPZ_RETURN_IF_ERROR(CheckLength(utf8.size(), L"UTF-8 input"));
+
+  const int size = static_cast<int>(utf8.size());
+  // MB_ERR_INVALID_CHARS is what makes this strict. Without it, an invalid byte
+  // is replaced by U+FFFD and the caller cannot tell a corrupt config from a
+  // valid one that happens to contain a replacement character.
+  const int needed = MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, utf8.data(), size, nullptr, 0);
+  if (needed <= 0) {
+    return DHEPZ_ERR(core::ErrorCode::ParseError, L"Input is not valid UTF-8");
+  }
+
+  out->resize(static_cast<std::size_t>(needed));
+  const int written =
+      MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, utf8.data(), size, out->data(), needed);
+  if (written != needed) {
+    out->clear();
+    return DHEPZ_ERR(core::ErrorCode::Internal, L"UTF-8 conversion length changed between calls");
+  }
+  return core::Ok();
+}
+
+core::Status ToUtf8(std::wstring_view text, std::string* out) {
+  if (out == nullptr) {
+    return DHEPZ_ERR(core::ErrorCode::InvalidArgument, L"ToUtf8 requires an output string");
+  }
+  out->clear();
+  if (text.empty()) {
+    return core::Ok();
+  }
+  DHEPZ_RETURN_IF_ERROR(CheckLength(text.size(), L"UTF-16 input"));
+
+  const int size = static_cast<int>(text.size());
+  // WC_ERR_INVALID_CHARS rejects unpaired surrogates, which have no UTF-8
+  // encoding. A std::wstring can hold one, and a filesystem name can contain
+  // one, so this path is reachable rather than theoretical.
+  const int needed =
+      WideCharToMultiByte(CP_UTF8, WC_ERR_INVALID_CHARS, text.data(), size, nullptr, 0, nullptr, nullptr);
+  if (needed <= 0) {
+    return DHEPZ_ERR(core::ErrorCode::ParseError,
+                     L"Text contains an unpaired surrogate and cannot be encoded as UTF-8");
+  }
+
+  out->resize(static_cast<std::size_t>(needed));
+  const int written = WideCharToMultiByte(CP_UTF8, WC_ERR_INVALID_CHARS, text.data(), size, out->data(),
+                                          needed, nullptr, nullptr);
+  if (written != needed) {
+    out->clear();
+    return DHEPZ_ERR(core::ErrorCode::Internal, L"UTF-16 conversion length changed between calls");
+  }
+  return core::Ok();
+}
+
+std::wstring Trim(std::wstring_view text) {
+  const auto is_space = [](wchar_t c) {
+    return c == L' ' || c == L'\t' || c == L'\r' || c == L'\n';
+  };
+  std::size_t begin = 0;
+  std::size_t end = text.size();
+  while (begin < end && is_space(text[begin])) {
+    ++begin;
+  }
+  while (end > begin && is_space(text[end - 1])) {
+    --end;
+  }
+  return std::wstring(text.substr(begin, end - begin));
+}
+
+std::wstring QuoteArg(std::wstring_view value) {
+  // CommandLineToArgvW splits only on space and tab. CR, LF and vertical tab are
+  // included here anyway: they cannot appear in an argument that survives a
+  // round trip through a shell, and quoting them costs two characters while
+  // leaving them bare risks a caller that does route through cmd.exe.
+  const bool needs_quotes = value.empty() || value.find_first_of(L" \t\n\v\r\"") != std::wstring_view::npos;
+  if (!needs_quotes) {
+    return std::wstring(value);
+  }
+
+  std::wstring out;
+  // Worst case is every character a backslash immediately before the close
+  // quote, which doubles the body: 2n + 2 for the quotes.
+  out.reserve(value.size() * 2 + 2);
+  out.push_back(L'"');
+
+  for (std::size_t i = 0; i < value.size(); ++i) {
+    // Backslashes are only escapes when a quote follows, so count the run first
+    // and decide what it means afterwards.
+    std::size_t backslashes = 0;
+    while (i < value.size() && value[i] == L'\\') {
+      ++backslashes;
+      ++i;
+    }
+
+    if (i == value.size()) {
+      // The run ends the argument. Double it, or the final backslash would
+      // escape the closing quote and swallow the next argument into this one.
+      out.append(backslashes * 2, L'\\');
+      break;
+    }
+
+    if (value[i] == L'"') {
+      // Double the run so it survives as literal backslashes, then one more to
+      // escape the quote itself.
+      out.append(backslashes * 2 + 1, L'\\');
+    } else {
+      // Nothing special follows, so the backslashes are literal as written.
+      out.append(backslashes, L'\\');
+    }
+    out.push_back(value[i]);
+  }
+
+  out.push_back(L'"');
+  return out;
+}
+
+std::wstring EscapePowerShellSingleQuoted(std::wstring_view value) {
+  std::wstring out;
+  out.reserve(value.size());
+  for (wchar_t c : value) {
+    out.push_back(c);
+    if (c == L'\'') {
+      out.push_back(L'\'');
+    }
+  }
+  return out;
+}
+
+std::wstring EscapePosixSingleQuoted(std::wstring_view value) {
+  std::wstring out;
+  out.reserve(value.size());
+  for (wchar_t c : value) {
+    if (c == L'\'') {
+      // Close the string, emit a backslash-escaped quote outside it, reopen.
+      out.append(L"'\\''");
+    } else {
+      out.push_back(c);
+    }
+  }
+  return out;
+}
+
+}  // namespace str

--- a/src/platform/strings.h
+++ b/src/platform/strings.h
@@ -1,0 +1,78 @@
+// String helpers, and the command-line quoting that guards every process launch.
+//
+// QuoteArg is the security-relevant part of this header. Windows has no argv:
+// CreateProcess takes one flat string, and the child pulls arguments back out of
+// it with CommandLineToArgvW. That means anything appended into a command line is
+// parsed by the child, so a folder name containing a quote is not a display bug,
+// it is an injected argument. Once directory names reach a command line from JSON
+// config or a user-typed path, naive concatenation is a command-injection vector.
+//
+// Unlike core/, this layer is allowed to know about Windows — but the knowledge
+// stays in the .cpp so callers do not transitively pull in windows.h.
+#pragma once
+
+#include <string>
+#include <string_view>
+
+#include "core/status.h"
+
+namespace str {
+
+// UTF-8 to UTF-16, strictly. Invalid or truncated UTF-8 is a ParseError rather
+// than a silently empty string.
+//
+// The strictness is the point. The old build returned {} on failure, so a config
+// file with one bad byte parsed as an empty document and the UI just came up
+// blank with nothing to explain it. core/json (#6) needs a real error here to
+// report a line and column.
+core::Status FromUtf8(std::string_view utf8, std::wstring* out);
+
+// UTF-16 to UTF-8. Fails on unpaired surrogates, which have no UTF-8 encoding.
+// A std::wstring can hold them, so this is reachable from a filesystem name.
+core::Status ToUtf8(std::wstring_view text, std::string* out);
+
+// Strips leading and trailing space, tab, CR and LF. Not locale-aware, and
+// deliberately not Unicode-whitespace-aware: it is used on config values and
+// path strings, where the only realistic input is ASCII whitespace from hand
+// editing.
+std::wstring Trim(std::wstring_view text);
+
+// Wraps one argument so CommandLineToArgvW recovers it exactly, implementing the
+// real rules rather than a plausible approximation:
+//
+//   - Backslashes are only special immediately before a quote. `a\b` needs no
+//     escaping at all, but `a\"` needs the backslash doubled, because otherwise
+//     the child sees an escaped quote and the token never terminates.
+//   - A run of backslashes at the very end of a quoted argument is doubled, or
+//     the last one would escape the closing quote.
+//   - An empty argument must still appear, as `""`. Dropping it shifts every
+//     later positional argument by one.
+//
+// Round-trip guarantee, covered by tests: CommandLineToArgvW applied to a
+// command line built from QuoteArg output returns the original strings exactly.
+//
+// NOT valid for argv[0]. The program-name token at the front of a command line
+// is parsed by different rules — backslashes are never escapes there, since the
+// token is a path, and quotes merely toggle quoting. Quoting a path with
+// QuoteArg and placing it first would corrupt any path containing a backslash
+// before a quote. Pass the executable to CreateProcess as lpApplicationName, or
+// wrap it in plain quotes.
+std::wstring QuoteArg(std::wstring_view value);
+
+// Escapes a value for interpolation inside a PowerShell single-quoted string.
+// Only the quote itself is special there — no backslash escapes, no expansion —
+// so doubling it is the complete rule.
+//
+// The caller still supplies the surrounding quotes. That is deliberate: a helper
+// that added them would look safe when used to build an unquoted fragment, which
+// is the one case where it does nothing.
+std::wstring EscapePowerShellSingleQuoted(std::wstring_view value);
+
+// Escapes a value for interpolation inside a POSIX shell single-quoted string,
+// for the WSL path. A single-quoted string cannot contain its own quote at all,
+// so the only encoding is to close, emit an escaped quote, and reopen: '\''.
+//
+// Same contract as above: the caller supplies the outer quotes.
+std::wstring EscapePosixSingleQuoted(std::wstring_view value);
+
+}  // namespace str

--- a/tests/platform/strings_test.cpp
+++ b/tests/platform/strings_test.cpp
@@ -1,0 +1,247 @@
+#include "platform/strings.h"
+
+#include <windows.h>
+#include <shellapi.h>
+
+#include <string>
+#include <vector>
+
+#include "framework/test_case.h"
+
+namespace {
+
+// Builds a command line the way a real caller does, then parses it back with the
+// same function the OS gives a child process. This is the whole point of the
+// test: QuoteArg is only correct if CommandLineToArgvW is the one confirming it,
+// not a second implementation of the same rules that could share a bug.
+//
+// A dummy program name goes first because argv[0] is parsed by different rules —
+// backslashes are never escapes there. Passing a QuoteArg result as argv[0] is
+// exactly the mistake the header warns against, so the test does not make it.
+std::vector<std::wstring> RoundTrip(const std::vector<std::wstring>& args) {
+  std::wstring command_line = L"program.exe";
+  for (const std::wstring& arg : args) {
+    command_line.push_back(L' ');
+    command_line.append(str::QuoteArg(arg));
+  }
+
+  int count = 0;
+  wchar_t** argv = CommandLineToArgvW(command_line.c_str(), &count);
+  if (argv == nullptr) {
+    return {};
+  }
+
+  std::vector<std::wstring> parsed;
+  for (int i = 1; i < count; ++i) {  // skip the program name
+    parsed.emplace_back(argv[i]);
+  }
+  LocalFree(argv);
+  return parsed;
+}
+
+void CheckRoundTrip(const std::wstring& arg, const char* file, int line) {
+  const std::vector<std::wstring> parsed = RoundTrip({arg});
+  if (parsed.size() != 1) {
+    ::testing::Fail("expected exactly one argument back, got " +
+                        ::testing::Describe(static_cast<unsigned long long>(parsed.size())),
+                    file, line);
+  }
+  if (parsed[0] != arg) {
+    ::testing::Fail(std::string("round trip changed the argument\n    expected: ") +
+                        ::testing::Describe(std::wstring_view(arg)) + "\n    actual:   " +
+                        ::testing::Describe(std::wstring_view(parsed[0])),
+                    file, line);
+  }
+}
+
+}  // namespace
+
+#define CHECK_ROUND_TRIP(arg) CheckRoundTrip((arg), __FILE__, __LINE__)
+
+// The hostile table from the issue, plus the cases that motivated the real rules.
+// Each entry is here because a naive implementation gets it wrong in a specific
+// way, noted alongside.
+DHEPZ_TEST(QuoteArg, RoundTripsHostileInputs) {
+  CHECK_ROUND_TRIP(L"plain");
+  CHECK_ROUND_TRIP(L"");                       // dropped entirely if not emitted as ""
+  CHECK_ROUND_TRIP(L"has space");
+  CHECK_ROUND_TRIP(L"has\ttab");
+  CHECK_ROUND_TRIP(L"C:\\path with space\\");  // trailing \ escapes the close quote
+  CHECK_ROUND_TRIP(L"a\"b");                   // bare quote ends the token early
+  CHECK_ROUND_TRIP(L"a\\\\");                  // run of backslashes at the end
+  CHECK_ROUND_TRIP(L"\"\"");
+  CHECK_ROUND_TRIP(L"a\\\"b\\\\");             // both cases in one argument
+  CHECK_ROUND_TRIP(L"\\");
+  CHECK_ROUND_TRIP(L"\\\\server\\share");      // UNC: leading backslashes are literal
+  CHECK_ROUND_TRIP(L"--flag=value with space");
+  CHECK_ROUND_TRIP(L"trailing backslash \\");
+  CHECK_ROUND_TRIP(L"quote at end\"");
+  CHECK_ROUND_TRIP(L"\"quote at start");
+  CHECK_ROUND_TRIP(L"embedded\"quote\"pairs");
+  CHECK_ROUND_TRIP(L"unicode \u00e9\u4e2d\U0001F600");
+}
+
+// Multiple arguments matter separately: a single argument can survive while the
+// boundary between two is still wrong, which is how an injected argument appears.
+DHEPZ_TEST(QuoteArg, PreservesArgumentBoundaries) {
+  const std::vector<std::wstring> args = {
+      L"C:\\Program Files\\app\\", L"", L"a\"b", L"--flag=x y", L"\\\\",
+  };
+  const std::vector<std::wstring> parsed = RoundTrip(args);
+  DHEPZ_CHECK_EQ(parsed.size(), args.size());
+  for (std::size_t i = 0; i < args.size() && i < parsed.size(); ++i) {
+    DHEPZ_CHECK_EQ(parsed[i], args[i]);
+  }
+}
+
+// The injection case in concrete terms. Without quoting, a folder name ending in
+// a quote lets the value close the token and start a new one, so the child sees
+// an argument nobody passed.
+DHEPZ_TEST(QuoteArg, BlocksArgumentInjection) {
+  const std::wstring hostile = L"dir\" --elevate --exec=calc.exe \"";
+  const std::vector<std::wstring> parsed = RoundTrip({hostile, L"real-second-arg"});
+
+  DHEPZ_CHECK_EQ(parsed.size(), static_cast<std::size_t>(2));
+  if (parsed.size() == 2) {
+    DHEPZ_CHECK_EQ(parsed[0], hostile);
+    DHEPZ_CHECK_EQ(parsed[1], std::wstring(L"real-second-arg"));
+  }
+}
+
+// An argument needing no quoting must come back byte-identical rather than
+// gratuitously wrapped: callers log these, and a diff in a trace is noise.
+DHEPZ_TEST(QuoteArg, LeavesSafeArgumentsUntouched) {
+  DHEPZ_CHECK_EQ(str::QuoteArg(L"simple"), std::wstring(L"simple"));
+  DHEPZ_CHECK_EQ(str::QuoteArg(L"C:\\no\\spaces"), std::wstring(L"C:\\no\\spaces"));
+  DHEPZ_CHECK_EQ(str::QuoteArg(L"a\\b"), std::wstring(L"a\\b"));
+  DHEPZ_CHECK_EQ(str::QuoteArg(L"--flag=value"), std::wstring(L"--flag=value"));
+}
+
+// The empty argument is quoted rather than skipped. If it vanished, every later
+// positional argument would shift down by one.
+DHEPZ_TEST(QuoteArg, EmptyArgumentBecomesQuotedPair) {
+  DHEPZ_CHECK_EQ(str::QuoteArg(L""), std::wstring(L"\"\""));
+}
+
+// Pins the exact backslash-doubling rule, so a future refactor that still passes
+// the round-trip by accident cannot quietly change the encoding.
+DHEPZ_TEST(QuoteArg, DoublesBackslashesOnlyWhereRequired) {
+  // Trailing run doubles: it would otherwise escape the closing quote.
+  DHEPZ_CHECK_EQ(str::QuoteArg(L"a b\\"), std::wstring(L"\"a b\\\\\""));
+  // Run before a quote doubles, then one more escapes the quote.
+  DHEPZ_CHECK_EQ(str::QuoteArg(L"a\\\"b"), std::wstring(L"\"a\\\\\\\"b\""));
+  // Interior run with no quote after it stays as written.
+  DHEPZ_CHECK_EQ(str::QuoteArg(L"a\\b c"), std::wstring(L"\"a\\b c\""));
+}
+
+DHEPZ_TEST(Utf8, RoundTripsAscii) {
+  std::string utf8;
+  DHEPZ_CHECK(str::ToUtf8(L"hello", &utf8).ok());
+  DHEPZ_CHECK_EQ(utf8, std::string("hello"));
+
+  std::wstring wide;
+  DHEPZ_CHECK(str::FromUtf8(utf8, &wide).ok());
+  DHEPZ_CHECK_EQ(wide, std::wstring(L"hello"));
+}
+
+DHEPZ_TEST(Utf8, RoundTripsNonAsciiIncludingAstralPlane) {
+  // A surrogate pair, which is where a length-based implementation goes wrong.
+  const std::wstring original = L"caf\u00e9 \u4e2d\u6587 \U0001F600";
+
+  std::string utf8;
+  DHEPZ_CHECK(str::ToUtf8(original, &utf8).ok());
+  std::wstring wide;
+  DHEPZ_CHECK(str::FromUtf8(utf8, &wide).ok());
+  DHEPZ_CHECK_EQ(wide, original);
+}
+
+DHEPZ_TEST(Utf8, EmptyInputSucceedsWithEmptyOutput) {
+  std::wstring wide = L"stale";
+  DHEPZ_CHECK(str::FromUtf8("", &wide).ok());
+  DHEPZ_CHECK(wide.empty());
+
+  std::string utf8 = "stale";
+  DHEPZ_CHECK(str::ToUtf8(L"", &utf8).ok());
+  DHEPZ_CHECK(utf8.empty());
+}
+
+// The behaviour the old build got wrong: invalid input returned an empty string
+// indistinguishable from success, so a config file with one bad byte silently
+// parsed as empty and the UI came up blank with nothing to explain it.
+DHEPZ_TEST(Utf8, InvalidUtf8IsAParseErrorNotEmptyString) {
+  const std::string invalid = "\xC3\x28";  // truncated two-byte sequence
+  std::wstring wide;
+  const core::Status status = str::FromUtf8(invalid, &wide);
+  DHEPZ_CHECK_FALSE(status.ok());
+  DHEPZ_CHECK_EQ(status.Code(), core::ErrorCode::ParseError);
+  DHEPZ_CHECK(wide.empty());
+}
+
+DHEPZ_TEST(Utf8, LoneContinuationByteIsRejected) {
+  std::wstring wide;
+  DHEPZ_CHECK_FALSE(str::FromUtf8("\x80", &wide).ok());
+}
+
+DHEPZ_TEST(Utf8, UnpairedSurrogateIsRejected) {
+  // A high surrogate with nothing following it has no UTF-8 encoding. A
+  // std::wstring can hold it, and so can a filesystem name.
+  const std::wstring lone_surrogate(1, static_cast<wchar_t>(0xD800));
+  std::string utf8;
+  const core::Status status = str::ToUtf8(lone_surrogate, &utf8);
+  DHEPZ_CHECK_FALSE(status.ok());
+  DHEPZ_CHECK_EQ(status.Code(), core::ErrorCode::ParseError);
+  DHEPZ_CHECK(utf8.empty());
+}
+
+DHEPZ_TEST(Utf8, NullOutputIsInvalidArgument) {
+  DHEPZ_CHECK_EQ(str::FromUtf8("x", nullptr).Code(), core::ErrorCode::InvalidArgument);
+  DHEPZ_CHECK_EQ(str::ToUtf8(L"x", nullptr).Code(), core::ErrorCode::InvalidArgument);
+}
+
+// A BOM is a zero-width no-break space to a converter, not a marker, so it comes
+// through as U+FEFF. Stripping it is the file layer's job (#7), and this pins
+// that division so neither layer starts doing it twice.
+DHEPZ_TEST(Utf8, BomIsPreservedAsACharacterNotStripped) {
+  std::wstring wide;
+  DHEPZ_CHECK(str::FromUtf8("\xEF\xBB\xBFtext", &wide).ok());
+  DHEPZ_CHECK_EQ(wide, std::wstring(L"\uFEFFtext"));
+}
+
+DHEPZ_TEST(Trim, RemovesAsciiWhitespaceFromBothEnds) {
+  DHEPZ_CHECK_EQ(str::Trim(L"  padded  "), std::wstring(L"padded"));
+  DHEPZ_CHECK_EQ(str::Trim(L"\t\r\n mixed \n\r\t"), std::wstring(L"mixed"));
+  DHEPZ_CHECK_EQ(str::Trim(L"none"), std::wstring(L"none"));
+  DHEPZ_CHECK_EQ(str::Trim(L""), std::wstring(L""));
+  DHEPZ_CHECK_EQ(str::Trim(L"   "), std::wstring(L""));
+}
+
+DHEPZ_TEST(Trim, LeavesInteriorWhitespaceAlone) {
+  DHEPZ_CHECK_EQ(str::Trim(L"  a b  c  "), std::wstring(L"a b  c"));
+}
+
+// Doubling is the whole rule inside a PowerShell single-quoted string: nothing
+// else is special there, so escaping a backslash would corrupt every path.
+DHEPZ_TEST(EscapeShell, PowerShellDoublesQuotesAndLeavesBackslashesAlone) {
+  DHEPZ_CHECK_EQ(str::EscapePowerShellSingleQuoted(L"plain"), std::wstring(L"plain"));
+  DHEPZ_CHECK_EQ(str::EscapePowerShellSingleQuoted(L"C:\\Program Files\\app"),
+                 std::wstring(L"C:\\Program Files\\app"));
+  DHEPZ_CHECK_EQ(str::EscapePowerShellSingleQuoted(L"it's"), std::wstring(L"it''s"));
+  DHEPZ_CHECK_EQ(str::EscapePowerShellSingleQuoted(L"''"), std::wstring(L"''''"));
+  DHEPZ_CHECK_EQ(str::EscapePowerShellSingleQuoted(L""), std::wstring(L""));
+  // The injection shape: without doubling, the quote closes the string and the
+  // rest becomes executable script.
+  DHEPZ_CHECK_EQ(str::EscapePowerShellSingleQuoted(L"x'; Remove-Item C:\\ -Recurse; '"),
+                 std::wstring(L"x''; Remove-Item C:\\ -Recurse; ''"));
+}
+
+DHEPZ_TEST(EscapeShell, PosixClosesAndReopensAroundEachQuote) {
+  DHEPZ_CHECK_EQ(str::EscapePosixSingleQuoted(L"plain"), std::wstring(L"plain"));
+  DHEPZ_CHECK_EQ(str::EscapePosixSingleQuoted(L"it's"), std::wstring(L"it'\\''s"));
+  DHEPZ_CHECK_EQ(str::EscapePosixSingleQuoted(L""), std::wstring(L""));
+  DHEPZ_CHECK_EQ(str::EscapePosixSingleQuoted(L"'"), std::wstring(L"'\\''"));
+  // A backslash is literal inside POSIX single quotes too, so /mnt/c paths pass
+  // through unchanged.
+  DHEPZ_CHECK_EQ(str::EscapePosixSingleQuoted(L"/mnt/c/a\\b"), std::wstring(L"/mnt/c/a\\b"));
+  DHEPZ_CHECK_EQ(str::EscapePosixSingleQuoted(L"x'; rm -rf /; '"),
+                 std::wstring(L"x'\\''; rm -rf /; '\\''"));
+}


### PR DESCRIPTION
Closes #9.

## What

`src/platform/strings.{h,cpp}` — the first `platform/` layer file, and the base of the sequential Phase 0 chain (`#9 -> #8 -> #7 -> #6`). `paths.cpp` calls `str::Trim`, `files.cpp` calls `str::ToUtf8`, and `json` needs `str::FromUtf8`, so nothing downstream can start before this.

- `QuoteArg` — the security-relevant part. Windows has no argv: `CreateProcess` takes one flat string and the child pulls arguments back out with `CommandLineToArgvW`, so a folder name containing a quote is not a display bug, it is an injected argument.
- `FromUtf8` / `ToUtf8` — strict conversion returning `core::Status`.
- `Trim` — ASCII-only, for config values and paths.
- `EscapePowerShellSingleQuoted` / `EscapePosixSingleQuoted` — grouped with `QuoteArg` in the plan's port table as one security unit.

## Divergences from the old implementation

**Conversions return `core::Status` with an out-param, not a bare `std::wstring`.** The old code returned `{}` on failure, so one bad byte in a config file parsed as an empty document and the UI came up blank with nothing to explain it. `MB_ERR_INVALID_CHARS` / `WC_ERR_INVALID_CHARS` are what make it strict — without them an invalid byte silently becomes U+FFFD and the caller cannot distinguish corruption from a legitimate replacement character. #6 needs a real error to report a line and column.

**`QuoteArg` documents that it is not valid for `argv[0]`.** The program-name token is parsed by different rules: backslashes are never escapes there and quotes merely toggle. Using it for the executable path would corrupt any path with a backslash before a quote.

**`\r` added to the quote-triggering set.** `CommandLineToArgvW` only splits on space and tab, but a caller routing through `cmd.exe` would see more. Quoting costs two characters.

**Dropped for lack of call sites:** `SplitLines`, `IEquals`, `StartsWith`, `IContains`. They come back with the code that needs them.

## Testing

26 tests pass in both Debug and Release.

The `QuoteArg` tests round-trip through the **real `CommandLineToArgvW`** rather than comparing against hand-computed expected strings — a hand-written expectation encodes the same misunderstanding twice, so it would pass while being wrong. Coverage includes the hostile table from the issue (`C:\path with space\`, `a"b`, `a\\`, `""`, `a\"b\\`), plus embedded tab, the empty string, UNC paths, astral-plane characters, argument-boundary preservation across five arguments, and a concrete injection attempt (`dir" --elevate --exec=calc.exe "`) confirming the child sees two arguments and not four.

One test pins that a BOM survives `FromUtf8` as U+FEFF rather than being stripped. Stripping is the file layer's job in #7, and pinning it here keeps both layers from doing it twice.

## Not done

The issue's "used by every call site that builds a command line" and "autostart registry value and terminal launch both go through it" cannot be verified yet — there are no call sites. Those land with the process launcher and autostart in later phases; the round-trip guarantee is what makes them safe when they arrive.