### PR TITLE
feat(platform): add paths with Normalize and root-escape validation (#8)

### DIFF
--- a/src/platform/paths.cpp
+++ b/src/platform/paths.cpp
@@ -1,0 +1,249 @@
+#include "platform/paths.h"
+
+#include <windows.h>
+#include <shlobj.h>
+
+#include "platform/strings.h"
+
+namespace paths {
+namespace {
+
+std::wstring KnownFolder(REFKNOWNFOLDERID id) {
+  PWSTR raw = nullptr;
+  std::wstring result;
+  if (SUCCEEDED(SHGetKnownFolderPath(id, KF_FLAG_DEFAULT, nullptr, &raw)) && raw != nullptr) {
+    result.assign(raw);
+  }
+  if (raw != nullptr) {
+    CoTaskMemFree(raw);
+  }
+  return result;
+}
+
+std::wstring ExpandEnvironment(std::wstring_view value) {
+  const std::wstring input(value);
+  if (input.find(L'%') == std::wstring::npos) {
+    return input;
+  }
+  std::wstring buffer(MAX_PATH, L'\0');
+  for (;;) {
+    const DWORD needed =
+        ExpandEnvironmentStringsW(input.c_str(), buffer.data(), static_cast<DWORD>(buffer.size()));
+    if (needed == 0) {
+      return input;
+    }
+    if (needed <= buffer.size()) {
+      buffer.resize(needed > 0 ? needed - 1 : 0);
+      return buffer;
+    }
+    buffer.resize(needed);
+  }
+}
+
+// Drive-letter (C:\...), device (\\?\...), or UNC (\\server\...). Anything
+// else — including a bare "\foo" — would resolve against the process CWD or
+// its drive inside GetFullPathNameW, which is exactly the hidden dependency
+// Normalize refuses to introduce. Input is slash-normalised before this runs.
+bool IsAbsolute(std::wstring_view path) {
+  if (path.size() >= 3 && (path[1] == L':') && (path[2] == L'\\')) {
+    const wchar_t d = path[0];
+    return (d >= L'A' && d <= L'Z') || (d >= L'a' && d <= L'z');
+  }
+  return path.size() >= 2 && path[0] == L'\\' && path[1] == L'\\';
+}
+
+}  // namespace
+
+std::wstring ExecutablePath() {
+  std::wstring buffer(MAX_PATH, L'\0');
+  for (;;) {
+    const DWORD written =
+        GetModuleFileNameW(nullptr, buffer.data(), static_cast<DWORD>(buffer.size()));
+    if (written == 0) {
+      return {};
+    }
+    if (written < buffer.size()) {
+      buffer.resize(written);
+      return buffer;
+    }
+    buffer.resize(buffer.size() * 2);
+  }
+}
+
+std::wstring ExecutableDir() { return Parent(ExecutablePath()); }
+
+std::wstring LocalAppDataDir() { return KnownFolder(FOLDERID_LocalAppData); }
+
+std::wstring StateDir() {
+  const std::wstring base = LocalAppDataDir();
+  if (base.empty()) {
+    return {};
+  }
+  return Join(Join(base, L"dhepz"), L"state");
+}
+
+core::Status EnsureStateDir() {
+  const std::wstring dir = StateDir();
+  if (dir.empty()) {
+    return DHEPZ_ERR(core::ErrorCode::IoError, L"LocalAppData folder could not be resolved");
+  }
+  if (EnsureDirectory(dir)) {
+    return core::Ok();
+  }
+  return DHEPZ_ERR(core::ErrorCode::IoError, L"Could not create state directory " + dir);
+}
+
+std::wstring Join(std::wstring_view a, std::wstring_view b) {
+  if (a.empty()) {
+    return std::wstring(b);
+  }
+  if (b.empty()) {
+    return std::wstring(a);
+  }
+  std::wstring out(a);
+  if (out.back() != L'\\' && out.back() != L'/') {
+    out.push_back(L'\\');
+  }
+  std::size_t skip = 0;
+  while (skip < b.size() && (b[skip] == L'\\' || b[skip] == L'/')) {
+    ++skip;
+  }
+  out.append(b.substr(skip));
+  return out;
+}
+
+std::wstring Parent(std::wstring_view path) {
+  const std::size_t cut = path.find_last_of(L"\\/");
+  if (cut == std::wstring_view::npos) {
+    return {};
+  }
+  if (cut == 0) {
+    return L"\\";
+  }
+  return std::wstring(path.substr(0, cut));
+}
+
+std::wstring FileName(std::wstring_view path) {
+  const std::size_t cut = path.find_last_of(L"\\/");
+  if (cut == std::wstring_view::npos) {
+    return std::wstring(path);
+  }
+  return std::wstring(path.substr(cut + 1));
+}
+
+bool FileExists(std::wstring_view path) {
+  if (path.empty()) {
+    return false;
+  }
+  const DWORD attrs = GetFileAttributesW(std::wstring(path).c_str());
+  return attrs != INVALID_FILE_ATTRIBUTES && (attrs & FILE_ATTRIBUTE_DIRECTORY) == 0;
+}
+
+bool DirectoryExists(std::wstring_view path) {
+  if (path.empty()) {
+    return false;
+  }
+  const DWORD attrs = GetFileAttributesW(std::wstring(path).c_str());
+  return attrs != INVALID_FILE_ATTRIBUTES && (attrs & FILE_ATTRIBUTE_DIRECTORY) != 0;
+}
+
+bool EnsureDirectory(std::wstring_view path) {
+  if (path.empty()) {
+    return false;
+  }
+  if (DirectoryExists(path)) {
+    return true;
+  }
+  const std::wstring parent = Parent(path);
+  if (!parent.empty() && parent != path && !DirectoryExists(parent)) {
+    if (!EnsureDirectory(parent)) {
+      return false;
+    }
+  }
+  if (CreateDirectoryW(std::wstring(path).c_str(), nullptr)) {
+    return true;
+  }
+  return GetLastError() == ERROR_ALREADY_EXISTS;
+}
+
+std::wstring Normalize(std::wstring_view path) {
+  if (path.empty()) {
+    return {};
+  }
+  std::wstring input = ExpandEnvironment(str::Trim(path));
+  if (input.empty()) {
+    return {};
+  }
+  for (wchar_t& c : input) {
+    if (c == L'/') {
+      c = L'\\';
+    }
+  }
+  // Reject relative input before GetFullPathNameW can resolve it against the
+  // process CWD: a result that silently depends on where the app was started
+  // from is worse than no result.
+  if (!IsAbsolute(input)) {
+    return {};
+  }
+  std::wstring buffer(MAX_PATH, L'\0');
+  for (;;) {
+    const DWORD needed =
+        GetFullPathNameW(input.c_str(), static_cast<DWORD>(buffer.size()), buffer.data(), nullptr);
+    if (needed == 0) {
+      break;
+    }
+    if (needed < buffer.size()) {
+      buffer.resize(needed);
+      input = buffer;
+      break;
+    }
+    buffer.resize(needed);
+  }
+  // Strip trailing separators, but never off a drive root: "C:\" is size 3.
+  while (input.size() > 3 && input.back() == L'\\') {
+    input.pop_back();
+  }
+  return input;
+}
+
+core::Status ValidateUnderRoot(std::wstring_view root, std::wstring_view path,
+                               std::wstring* out_full) {
+  if (out_full == nullptr) {
+    return DHEPZ_ERR(core::ErrorCode::InvalidArgument,
+                     L"ValidateUnderRoot requires an output string");
+  }
+  out_full->clear();
+
+  const std::wstring base = Normalize(root);
+  if (base.empty()) {
+    return DHEPZ_ERR(core::ErrorCode::InvalidArgument,
+                     L"Root is empty or not an absolute path: " + std::wstring(root));
+  }
+  const std::wstring full = Normalize(path);
+  if (full.empty()) {
+    return DHEPZ_ERR(core::ErrorCode::InvalidArgument,
+                     L"Path is empty or not an absolute path: " + std::wstring(path));
+  }
+
+  // Case-insensitive ordinal compare: NTFS resolves names case-insensitively,
+  // so "C:\Root" and "c:\root" are the same place. CSTR_LESS_THAN/EQUAL/GREATER
+  // are ordinal positions, not error codes, so every branch is handled.
+  const auto relate = [&base](std::wstring_view candidate) {
+    return CompareStringOrdinal(candidate.data(), static_cast<int>(candidate.size()), base.data(),
+                                static_cast<int>(base.size()), TRUE);
+  };
+
+  const bool contained =
+      relate(full) == CSTR_EQUAL ||
+      (full.size() > base.size() && full[base.size()] == L'\\' &&
+       relate(std::wstring_view(full).substr(0, base.size())) == CSTR_EQUAL);
+
+  if (!contained) {
+    return DHEPZ_ERR(core::ErrorCode::PermissionDenied,
+                     L"Path escapes its expected root: " + full + L" is not under " + base);
+  }
+  *out_full = full;
+  return core::Ok();
+}
+
+}  // namespace paths

--- a/src/platform/paths.h
+++ b/src/platform/paths.h
@@ -1,0 +1,97 @@
+// Filesystem paths and the installed-app directory split.
+//
+// Two locations, kept strictly separate (see plan.md Part 4):
+//
+//   - ExecutableDir() — the install directory. Treated as READ-ONLY at
+//     runtime. Nothing in the process may write next to the EXE: an update
+//     replaces the install directory wholesale, so any file written there
+//     would be destroyed or left orphaned.
+//
+//   - StateDir() — %LOCALAPPDATA%\dhepz\state. All user state lives here
+//     and survives every update. The directory is never created until state
+//     actually must be written (G1): a tray-only startup that never opens a
+//     window must not touch the disk. StateDir() itself is pure; only
+//     EnsureStateDir() creates anything.
+//
+// Normalize and ValidateUnderRoot are the security half of this layer:
+// paths derived from JSON config or user input reach CreateProcess, so they
+// are canonicalised and checked against an expected root before use.
+//
+// Like all of platform/, this layer may use Windows but keeps windows.h out
+// of the header so callers do not pull it in transitively.
+#pragma once
+
+#include <string>
+#include <string_view>
+
+#include "core/status.h"
+
+namespace paths {
+
+// Full path of the running executable, and its directory. Read-only at
+// runtime — see the header comment before writing anywhere near it.
+std::wstring ExecutablePath();
+std::wstring ExecutableDir();
+
+// The LocalAppData known folder (the API equivalent of %LOCALAPPDATA%, and
+// the one that stays correct under folder redirection).
+std::wstring LocalAppDataDir();
+
+// %LOCALAPPDATA%\dhepz\state, without a trailing separator. Pure: this call
+// never touches the disk, so a tray-only startup costs nothing (G1).
+std::wstring StateDir();
+
+// Creates StateDir() and any missing parents. The only function in this
+// layer that creates the state directory; call it just before the first
+// write, never at startup.
+core::Status EnsureStateDir();
+
+// Joins two segments with exactly one separator between them. Either side
+// may be empty, in which case the other is returned as written.
+std::wstring Join(std::wstring_view a, std::wstring_view b);
+
+// Everything before the last separator, or {} when there is none.
+std::wstring Parent(std::wstring_view path);
+
+// Everything after the last separator, or the whole input when there is none.
+std::wstring FileName(std::wstring_view path);
+
+bool FileExists(std::wstring_view path);
+bool DirectoryExists(std::wstring_view path);
+
+// Creates every missing component of `path`. Returns true when the directory
+// exists after the call.
+bool EnsureDirectory(std::wstring_view path);
+
+// Canonicalises an absolute path: trims whitespace, expands %VAR%
+// references, converts `/` to `\`, and resolves `.` and `..` segments via
+// GetFullPathNameW (with retry-on-too-small-buffer). The result has no
+// trailing separator except for a drive root such as C:\.
+//
+// The input must be absolute — a drive-letter path (C:\...) or a UNC path
+// (\\server\share...). Relative input is rejected with an empty result,
+// because resolving it would silently depend on the process CWD. Callers
+// with config- or user-derived paths should go through ValidateUnderRoot,
+// which pins the base explicitly.
+//
+// Long-path aware: the manifest declares longPathAware, so results past
+// MAX_PATH are returned as-is; no \\?\ prefixing is needed on Windows 10
+// 1607+ for the Win32 file APIs.
+//
+// Returns {} when the input is empty, relative, or otherwise unusable.
+std::wstring Normalize(std::wstring_view path);
+
+// Checks that `path` stays inside `root`, for anything derived from config
+// or user input. Both sides are canonicalised with Normalize, so `..`
+// traversal, mixed separators, %VAR% tricks and case variations of the root
+// itself are all handled. Comparison is case-insensitive, as NTFS is.
+//
+// A path equal to `root` is contained; a sibling or an escape is not.
+// The normalised path is returned in *out_full when it is contained.
+//
+//   InvalidArgument — either argument is empty or not an absolute path.
+//   PermissionDenied — the normalised path escapes the root.
+core::Status ValidateUnderRoot(std::wstring_view root, std::wstring_view path,
+                               std::wstring* out_full);
+
+}  // namespace paths

--- a/tests/platform/paths_test.cpp
+++ b/tests/platform/paths_test.cpp
@@ -1,0 +1,219 @@
+#include "platform/paths.h"
+
+#include <windows.h>
+
+#include <string>
+
+#include "framework/test_case.h"
+
+namespace {
+
+// A scratch directory under %TEMP% that no other process is going to touch.
+// The PID keeps parallel or leftover runs from colliding.
+std::wstring TestRoot() {
+  wchar_t buffer[MAX_PATH] = {};
+  const DWORD len = GetTempPathW(MAX_PATH, buffer);
+  std::wstring root(buffer, len);
+  root += L"dhepz_paths_test_";
+  root += std::to_wstring(GetCurrentProcessId());
+  return root;
+}
+
+}  // namespace
+
+DHEPZ_TEST(Normalize, ResolvesMixedSeparatorsAndDotSegments) {
+  DHEPZ_CHECK_EQ(paths::Normalize(L"C:\\a/./b/../c"), std::wstring(L"C:\\a\\c"));
+  DHEPZ_CHECK_EQ(paths::Normalize(L"C:\\a\\.\\b"), std::wstring(L"C:\\a\\b"));
+  DHEPZ_CHECK_EQ(paths::Normalize(L"C:\\a\\b\\.."), std::wstring(L"C:\\a"));
+}
+
+DHEPZ_TEST(Normalize, StripsTrailingSeparators) {
+  DHEPZ_CHECK_EQ(paths::Normalize(L"C:\\a\\b\\\\"), std::wstring(L"C:\\a\\b"));
+  DHEPZ_CHECK_EQ(paths::Normalize(L"C:\\a\\b//"), std::wstring(L"C:\\a\\b"));
+}
+
+// The drive root is the one path whose trailing separator must survive —
+// "C:" without it means something entirely different (CWD on drive C).
+DHEPZ_TEST(Normalize, DriveRootKeepsItsSeparator) {
+  DHEPZ_CHECK_EQ(paths::Normalize(L"C:\\"), std::wstring(L"C:\\"));
+  DHEPZ_CHECK_EQ(paths::Normalize(L"C:/"), std::wstring(L"C:\\"));
+}
+
+DHEPZ_TEST(Normalize, UncPathSurvives) {
+  DHEPZ_CHECK_EQ(paths::Normalize(L"\\\\server\\share\\dir\\..\\x\\"),
+                 std::wstring(L"\\\\server\\share\\x"));
+}
+
+DHEPZ_TEST(Normalize, ExpandsEnvironmentVariables) {
+  wchar_t buffer[MAX_PATH] = {};
+  const DWORD len = GetTempPathW(MAX_PATH, buffer);
+  DHEPZ_CHECK(len > 0);
+  const std::wstring expected = paths::Normalize(std::wstring(buffer, len) + L"sub");
+  DHEPZ_CHECK(!expected.empty());
+  DHEPZ_CHECK_EQ(paths::Normalize(L"%TEMP%\\sub"), expected);
+}
+
+DHEPZ_TEST(Normalize, TrimsWhitespaceFirst) {
+  DHEPZ_CHECK_EQ(paths::Normalize(L"  C:\\a\\b  "), std::wstring(L"C:\\a\\b"));
+}
+
+DHEPZ_TEST(Normalize, PreservesNameCase) {
+  DHEPZ_CHECK_EQ(paths::Normalize(L"C:\\Folder\\NAME"), std::wstring(L"C:\\Folder\\NAME"));
+}
+
+// Resolving a relative path would silently depend on the process CWD, which
+// is exactly the hidden dependency this layer refuses to introduce.
+DHEPZ_TEST(Normalize, RejectsRelativeInput) {
+  DHEPZ_CHECK(paths::Normalize(L"relative\\dir").empty());
+  DHEPZ_CHECK(paths::Normalize(L".\\here").empty());
+  DHEPZ_CHECK(paths::Normalize(L"..\\up").empty());
+  // Rooted on the current drive but still CWD-dependent.
+  DHEPZ_CHECK(paths::Normalize(L"\\rooted\\no\\drive").empty());
+}
+
+DHEPZ_TEST(Normalize, EmptyInputIsEmpty) {
+  DHEPZ_CHECK(paths::Normalize(L"").empty());
+  DHEPZ_CHECK(paths::Normalize(L"   ").empty());
+}
+
+// The manifest declares longPathAware, so a path past MAX_PATH must survive
+// normalisation rather than being truncated or failing.
+DHEPZ_TEST(Normalize, HandlesLongPaths) {
+  std::wstring long_path = L"C:\\base";
+  for (int i = 0; i < 12; ++i) {
+    long_path += L"\\segment-of-about-thirty-chars";
+  }
+  DHEPZ_CHECK(long_path.size() > MAX_PATH);
+  DHEPZ_CHECK_EQ(paths::Normalize(long_path + L"\\"), long_path);
+}
+
+DHEPZ_TEST(ValidateUnderRoot, AcceptsPathEqualOrInside) {
+  std::wstring full;
+  DHEPZ_CHECK(paths::ValidateUnderRoot(L"C:\\Root", L"C:\\Root", &full).ok());
+  DHEPZ_CHECK_EQ(full, std::wstring(L"C:\\Root"));
+
+  DHEPZ_CHECK(paths::ValidateUnderRoot(L"C:\\Root", L"C:\\Root\\a\\b", &full).ok());
+  DHEPZ_CHECK_EQ(full, std::wstring(L"C:\\Root\\a\\b"));
+}
+
+// NTFS is case-insensitive, so the root itself arriving in a different case
+// is the same place — not an escape.
+DHEPZ_TEST(ValidateUnderRoot, IsCaseInsensitive) {
+  std::wstring full;
+  DHEPZ_CHECK(paths::ValidateUnderRoot(L"C:\\Root", L"c:\\root\\child", &full).ok());
+  DHEPZ_CHECK_EQ(full, std::wstring(L"c:\\root\\child"));
+}
+
+DHEPZ_TEST(ValidateUnderRoot, RejectsDotDotEscape) {
+  std::wstring full;
+  const core::Status status = paths::ValidateUnderRoot(L"C:\\Root", L"C:\\Root\\..\\other", &full);
+  DHEPZ_CHECK_FALSE(status.ok());
+  DHEPZ_CHECK_EQ(status.Code(), core::ErrorCode::PermissionDenied);
+  DHEPZ_CHECK(full.empty());
+}
+
+DHEPZ_TEST(ValidateUnderRoot, RejectsSiblingAndPrefixLookalike) {
+  std::wstring full;
+  // A sibling is outside regardless of how the path is written.
+  DHEPZ_CHECK_FALSE(paths::ValidateUnderRoot(L"C:\\Root", L"C:\\Elsewhere", &full).ok());
+  // "RootExtra" starts with the root's *text* but is not under it — the
+  // separator boundary is what decides.
+  DHEPZ_CHECK_FALSE(paths::ValidateUnderRoot(L"C:\\Root", L"C:\\RootExtra\\x", &full).ok());
+}
+
+DHEPZ_TEST(ValidateUnderRoot, RejectsDifferentDrive) {
+  std::wstring full;
+  DHEPZ_CHECK_FALSE(paths::ValidateUnderRoot(L"C:\\Root", L"D:\\Root\\a", &full).ok());
+}
+
+DHEPZ_TEST(ValidateUnderRoot, ResolvesBeforeComparing) {
+  std::wstring full;
+  // The escape only becomes visible after `.` and `..` are resolved, and the
+  // %VAR% form must reach the same verdict as the literal one.
+  DHEPZ_CHECK(paths::ValidateUnderRoot(L"%TEMP%", L"%TEMP%\\.\\sub\\..\\sub", &full).ok());
+  DHEPZ_CHECK_EQ(full, paths::Normalize(L"%TEMP%\\sub"));
+  DHEPZ_CHECK_FALSE(paths::ValidateUnderRoot(L"%TEMP%", L"%TEMP%\\..\\x", &full).ok());
+}
+
+DHEPZ_TEST(ValidateUnderRoot, WorksForUncRoots) {
+  std::wstring full;
+  DHEPZ_CHECK(paths::ValidateUnderRoot(L"\\\\server\\share", L"\\\\server\\share\\dir", &full).ok());
+  DHEPZ_CHECK_FALSE(
+      paths::ValidateUnderRoot(L"\\\\server\\share", L"\\\\server\\othershare", &full).ok());
+}
+
+DHEPZ_TEST(ValidateUnderRoot, RejectsBadArguments) {
+  std::wstring full;
+  DHEPZ_CHECK_EQ(paths::ValidateUnderRoot(L"", L"C:\\a", &full).Code(),
+                 core::ErrorCode::InvalidArgument);
+  DHEPZ_CHECK_EQ(paths::ValidateUnderRoot(L"C:\\Root", L"relative", &full).Code(),
+                 core::ErrorCode::InvalidArgument);
+  DHEPZ_CHECK_EQ(paths::ValidateUnderRoot(L"C:\\Root", L"C:\\a", nullptr).Code(),
+                 core::ErrorCode::InvalidArgument);
+}
+
+DHEPZ_TEST(StateDir, ShapeAndLazyCreation) {
+  const std::wstring dir = paths::StateDir();
+  const std::wstring suffix = L"\\dhepz\\state";
+  DHEPZ_CHECK(dir.size() > suffix.size());
+  DHEPZ_CHECK_EQ(std::wstring_view(dir).substr(dir.size() - suffix.size()), suffix);
+  DHEPZ_CHECK_FALSE(dir.back() == L'\\');
+
+  // The pure call must not have created anything: if nothing exists yet, it
+  // must still not exist after asking for the path. (A directory left over
+  // from an earlier run of the app skips this half — the soak criterion in
+  // the issue is the authoritative check.)
+  const std::wstring parent = paths::Join(paths::LocalAppDataDir(), L"dhepz");
+  if (!paths::DirectoryExists(parent)) {
+    DHEPZ_CHECK_FALSE(paths::DirectoryExists(dir));
+  }
+}
+
+DHEPZ_TEST(StateDir, EnsureCreatesThenIsIdempotent) {
+  DHEPZ_CHECK(paths::EnsureStateDir().ok());
+  DHEPZ_CHECK(paths::DirectoryExists(paths::StateDir()));
+  // A second call against an existing directory is not an error.
+  DHEPZ_CHECK(paths::EnsureStateDir().ok());
+}
+
+DHEPZ_TEST(Paths, JoinParentFileName) {
+  DHEPZ_CHECK_EQ(paths::Join(L"C:\\a", L"b"), std::wstring(L"C:\\a\\b"));
+  DHEPZ_CHECK_EQ(paths::Join(L"C:\\a\\", L"b"), std::wstring(L"C:\\a\\b"));
+  DHEPZ_CHECK_EQ(paths::Join(L"C:\\a", L"\\b"), std::wstring(L"C:\\a\\b"));
+  DHEPZ_CHECK_EQ(paths::Join(L"C:\\a", L""), std::wstring(L"C:\\a"));
+  DHEPZ_CHECK_EQ(paths::Join(L"", L"b"), std::wstring(L"b"));
+
+  DHEPZ_CHECK_EQ(paths::Parent(L"C:\\a\\b.txt"), std::wstring(L"C:\\a"));
+  DHEPZ_CHECK_EQ(paths::Parent(L"no_separator"), std::wstring(L""));
+  DHEPZ_CHECK_EQ(paths::FileName(L"C:\\a\\b.txt"), std::wstring(L"b.txt"));
+  DHEPZ_CHECK_EQ(paths::FileName(L"bare"), std::wstring(L"bare"));
+}
+
+DHEPZ_TEST(Paths, ExistsAndEnsureDirectory) {
+  const std::wstring root = TestRoot();
+  const std::wstring deep = paths::Join(root, L"x\\y\\z");
+  DHEPZ_CHECK_FALSE(paths::DirectoryExists(deep));
+
+  DHEPZ_CHECK(paths::EnsureDirectory(deep));
+  DHEPZ_CHECK(paths::DirectoryExists(deep));
+  DHEPZ_CHECK(paths::EnsureDirectory(deep));  // idempotent
+
+  const std::wstring file = paths::Join(deep, L"f.txt");
+  DHEPZ_CHECK_FALSE(paths::FileExists(file));
+  HANDLE h = CreateFileW(file.c_str(), GENERIC_WRITE, 0, nullptr, CREATE_NEW,
+                         FILE_ATTRIBUTE_NORMAL, nullptr);
+  DHEPZ_CHECK(h != INVALID_HANDLE_VALUE);
+  if (h != INVALID_HANDLE_VALUE) {
+    CloseHandle(h);
+  }
+  DHEPZ_CHECK(paths::FileExists(file));
+  // A file is not a directory and vice versa.
+  DHEPZ_CHECK_FALSE(paths::DirectoryExists(file));
+  DHEPZ_CHECK_FALSE(paths::FileExists(deep));
+
+  DeleteFileW(file.c_str());
+  RemoveDirectoryW(paths::Join(root, L"x\\y\\z").c_str());
+  RemoveDirectoryW(paths::Join(root, L"x\\y").c_str());
+  RemoveDirectoryW(paths::Join(root, L"x").c_str());
+  RemoveDirectoryW(root.c_str());
+}


### PR DESCRIPTION
Closes #8.

## Summary
- `src/platform/paths.{h,cpp}` — ported from `Teminal/src/logic/platform/paths` with deliberate divergences:
  - `Normalize` rejects relative input (old build resolved against the process CWD — a hidden dependency) and keeps the trim / `%VAR%` expansion / separator normalisation / `GetFullPathNameW` retry-on-too-small behaviour, stripping trailing separators but preserving `C:\`.
  - `StateDir()` is pure — `%LOCALAPPDATA%\dhepz\state` via `SHGetKnownFolderPath`, never created until `EnsureStateDir()` runs (G1: tray-only startup touches no disk).
  - `EnsureStateDir` and `ValidateUnderRoot` return `core::Status`, consistent with #9's judgement call.
  - `ValidateUnderRoot` canonicalises both sides with `Normalize` and compares case-insensitively (`CompareStringOrdinal`), so `..` traversal, mixed separators, `%VAR%` tricks, root case variation, sibling lookalikes (`RootExtra`) and different drives are all rejected with `PermissionDenied`.
- Old app-specific getters (`SettingsFile` etc.) not ported — no call sites yet; they belong to later phases.
- `windows.h` stays out of the header; `str::Trim` is the only cross-layer use, which is why #30 sequences this after #9.

## Test plan
- [x] 22 new tests in `tests/platform/paths_test.cpp` picked up by the glob, no project edit: normalisation (`.`/`..`, mixed and trailing separators, drive root, UNC, `%VAR%`, long paths > MAX_PATH, whitespace trim, case preservation, relative rejection), root-escape validation (equal/inside, case-insensitive, `..`, sibling, prefix lookalike, other drive, `%VAR%` forms, UNC roots, bad arguments), `StateDir` shape + laziness + idempotent ensure, `Join`/`Parent`/`FileName`, `EnsureDirectory`/existence.
- [x] `tools\Test.ps1` green: 48/48 Debug and 48/48 Release.
- [x] New files LF-only, verified byte-wise.
- [ ] Trace assertion "`--tray` performs zero directory creations" — deferred to #10/#11, same handling as #9's deferred criterion.