### PR TITLE
feat(platform): add files with atomic, create-new, and in-place writes (#7)

### DIFF
--- a/src/platform/files.cpp
+++ b/src/platform/files.cpp
@@ -1,0 +1,262 @@
+#include "platform/files.h"
+
+#include <windows.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <string>
+
+#include "platform/paths.h"
+#include "platform/strings.h"
+
+namespace files {
+namespace {
+
+constexpr std::int64_t kMaxReadableBytes = 64LL * 1024 * 1024;
+constexpr std::size_t kChunkBytes = 1u << 20;
+
+// System wording for a Win32 error, trimmed of the trailing CRLF that
+// FORMAT_MESSAGE appends. Falls back to the bare code — a message is never
+// worth failing for.
+std::wstring ErrorText(DWORD code) {
+  wchar_t* raw = nullptr;
+  const DWORD len = FormatMessageW(
+      FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+      nullptr, code, 0, reinterpret_cast<wchar_t*>(&raw), 0, nullptr);
+  std::wstring text;
+  if (len != 0 && raw != nullptr) {
+    text.assign(raw, len);
+    while (!text.empty() && (text.back() == L'\n' || text.back() == L'\r' || text.back() == L' ')) {
+      text.pop_back();
+    }
+    LocalFree(raw);
+  }
+  if (text.empty()) {
+    text = L"error " + std::to_wstring(code);
+  }
+  return text;
+}
+
+// Maps the codes callers actually branch on; everything else is IoError.
+core::Status StatusFromWin32(std::wstring_view what, DWORD code) {
+  std::wstring message = std::wstring(what) + L": " + ErrorText(code);
+  switch (code) {
+    case ERROR_FILE_NOT_FOUND:
+    case ERROR_PATH_NOT_FOUND:
+      return DHEPZ_ERR(core::ErrorCode::NotFound, std::move(message));
+    case ERROR_FILE_EXISTS:
+    case ERROR_ALREADY_EXISTS:
+      return DHEPZ_ERR(core::ErrorCode::AlreadyExists, std::move(message));
+    default:
+      return DHEPZ_ERR(core::ErrorCode::IoError, std::move(message));
+  }
+}
+
+core::Status EnsureParentExists(std::wstring_view target) {
+  const std::wstring parent = paths::Parent(target);
+  if (!parent.empty() && !paths::EnsureDirectory(parent)) {
+    return DHEPZ_ERR(core::ErrorCode::IoError, L"Cannot create folder: " + parent);
+  }
+  return core::Ok();
+}
+
+core::Status WriteAllBytes(HANDLE handle, std::string_view utf8, std::wstring_view what) {
+  std::size_t written_total = 0;
+  while (written_total < utf8.size()) {
+    DWORD written = 0;
+    const DWORD want =
+        static_cast<DWORD>((std::min)(utf8.size() - written_total, kChunkBytes));
+    if (!WriteFile(handle, utf8.data() + written_total, want, &written, nullptr)) {
+      return StatusFromWin32(what, GetLastError());
+    }
+    if (written == 0) {
+      return DHEPZ_ERR(core::ErrorCode::IoError, std::wstring(what) + L": no bytes were written");
+    }
+    written_total += written;
+  }
+  return core::Ok();
+}
+
+}  // namespace
+
+core::Status ReadText(std::wstring_view path, std::wstring* out) {
+  if (out == nullptr) {
+    return DHEPZ_ERR(core::ErrorCode::InvalidArgument, L"ReadText requires an output string");
+  }
+  out->clear();
+
+  const std::wstring file(path);
+  HANDLE handle = CreateFileW(file.c_str(), GENERIC_READ, FILE_SHARE_READ | FILE_SHARE_WRITE,
+                              nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
+  if (handle == INVALID_HANDLE_VALUE) {
+    return StatusFromWin32(L"Cannot open file", GetLastError());
+  }
+
+  core::Status status;
+  std::string raw;
+  LARGE_INTEGER size{};
+  if (!GetFileSizeEx(handle, &size)) {
+    status = StatusFromWin32(L"Cannot read file size", GetLastError());
+  } else if (size.QuadPart > kMaxReadableBytes) {
+    status = DHEPZ_ERR(core::ErrorCode::IoError, L"File is too large to open (over 64 MB)");
+  } else {
+    raw.resize(static_cast<std::size_t>(size.QuadPart), '\0');
+    std::size_t read_total = 0;
+    while (read_total < raw.size()) {
+      DWORD chunk = 0;
+      const DWORD want = static_cast<DWORD>((std::min)(raw.size() - read_total, kChunkBytes));
+      if (!ReadFile(handle, raw.data() + read_total, want, &chunk, nullptr)) {
+        status = StatusFromWin32(L"Cannot read file", GetLastError());
+        break;
+      }
+      if (chunk == 0) {
+        break;
+      }
+      read_total += chunk;
+    }
+    raw.resize(read_total);
+  }
+  CloseHandle(handle);
+  if (!status.ok()) {
+    return status;
+  }
+
+  std::string_view body(raw);
+  if (body.size() >= 3 && static_cast<unsigned char>(body[0]) == 0xEF &&
+      static_cast<unsigned char>(body[1]) == 0xBB && static_cast<unsigned char>(body[2]) == 0xBF) {
+    body.remove_prefix(3);
+  }
+  return str::FromUtf8(body, out);
+}
+
+core::Status WriteTextAtomic(std::wstring_view path, std::wstring_view text) {
+  const std::wstring target(path);
+  DHEPZ_RETURN_IF_ERROR(EnsureParentExists(target));
+
+  // Fixed temp name is safe under the single-owner-thread contract: only one
+  // thread writes app files, so two concurrent saves to the same target
+  // cannot race on <target>.tmp. Revisit (random suffix) if that changes.
+  const std::wstring temp = target + L".tmp";
+
+  std::string utf8;
+  DHEPZ_RETURN_IF_ERROR(str::ToUtf8(text, &utf8));
+
+  HANDLE handle =
+      CreateFileW(temp.c_str(), GENERIC_WRITE, 0, nullptr, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, nullptr);
+  if (handle == INVALID_HANDLE_VALUE) {
+    return StatusFromWin32(L"Cannot create temporary file", GetLastError());
+  }
+  core::Status status = WriteAllBytes(handle, utf8, L"Cannot write temporary file");
+  if (status.ok() && !FlushFileBuffers(handle)) {
+    status = StatusFromWin32(L"Cannot flush temporary file", GetLastError());
+  }
+  CloseHandle(handle);
+  if (!status.ok()) {
+    DeleteFileW(temp.c_str());
+    return status;
+  }
+
+  if (paths::FileExists(target)) {
+    if (!ReplaceFileW(target.c_str(), temp.c_str(), nullptr, REPLACEFILE_IGNORE_MERGE_ERRORS,
+                      nullptr, nullptr)) {
+      const DWORD code = GetLastError();
+      if (!MoveFileExW(temp.c_str(), target.c_str(),
+                       MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH)) {
+        DeleteFileW(temp.c_str());
+        return StatusFromWin32(L"Cannot replace file", code);
+      }
+    }
+  } else if (!MoveFileExW(temp.c_str(), target.c_str(), MOVEFILE_WRITE_THROUGH)) {
+    const DWORD code = GetLastError();
+    DeleteFileW(temp.c_str());
+    return StatusFromWin32(L"Cannot move file into place", code);
+  }
+  return core::Ok();
+}
+
+core::Status WriteTextNew(std::wstring_view path, std::wstring_view text) {
+  const std::wstring target(path);
+  DHEPZ_RETURN_IF_ERROR(EnsureParentExists(target));
+
+  std::string utf8;
+  DHEPZ_RETURN_IF_ERROR(str::ToUtf8(text, &utf8));
+
+  // CREATE_NEW means an existing target is never touched: no replace, no
+  // rename, no delete, so a file already open in an editor keeps its identity.
+  HANDLE handle =
+      CreateFileW(target.c_str(), GENERIC_WRITE, 0, nullptr, CREATE_NEW, FILE_ATTRIBUTE_NORMAL, nullptr);
+  if (handle == INVALID_HANDLE_VALUE) {
+    return StatusFromWin32(L"Cannot create file", GetLastError());
+  }
+
+  core::Status status = WriteAllBytes(handle, utf8, L"Cannot write file");
+  if (status.ok() && !FlushFileBuffers(handle)) {
+    status = StatusFromWin32(L"Cannot flush file", GetLastError());
+  }
+  CloseHandle(handle);
+  return status;
+}
+
+core::Status WriteTextInPlace(std::wstring_view path, std::wstring_view text) {
+  const std::wstring target(path);
+  DHEPZ_RETURN_IF_ERROR(EnsureParentExists(target));
+
+  std::string utf8;
+  DHEPZ_RETURN_IF_ERROR(str::ToUtf8(text, &utf8));
+
+  // OPEN_ALWAYS preserves an existing file object and creates the first file
+  // when there is none. FILE_SHARE_READ keeps an external editor able to
+  // read while this handle is open; no replace/rename/delete occurs.
+  HANDLE handle = CreateFileW(target.c_str(), GENERIC_WRITE, FILE_SHARE_READ, nullptr, OPEN_ALWAYS,
+                              FILE_ATTRIBUTE_NORMAL, nullptr);
+  if (handle == INVALID_HANDLE_VALUE) {
+    return StatusFromWin32(L"Cannot open file for writing", GetLastError());
+  }
+
+  LARGE_INTEGER start{};
+  core::Status status;
+  if (!SetFilePointerEx(handle, start, nullptr, FILE_BEGIN)) {
+    status = StatusFromWin32(L"Cannot seek file", GetLastError());
+  } else {
+    status = WriteAllBytes(handle, utf8, L"Cannot write file");
+  }
+  // The new content can be shorter than the old. Without this, stale
+  // trailing bytes remain and make the next parse fail despite a successful
+  // write — the bug this mode exists to prevent.
+  if (status.ok() && !SetEndOfFile(handle)) {
+    status = StatusFromWin32(L"Cannot truncate file", GetLastError());
+  }
+  if (status.ok() && !FlushFileBuffers(handle)) {
+    status = StatusFromWin32(L"Cannot flush file", GetLastError());
+  }
+  CloseHandle(handle);
+  return status;
+}
+
+std::wstring BackupPath(std::wstring_view path) { return std::wstring(path) + L".otn.bak"; }
+
+core::Status MakeBackup(std::wstring_view path) {
+  if (!paths::FileExists(path)) {
+    return core::Ok();
+  }
+  const std::wstring source(path);
+  const std::wstring backup = BackupPath(path);
+  if (!CopyFileW(source.c_str(), backup.c_str(), FALSE)) {
+    return StatusFromWin32(L"Cannot create backup", GetLastError());
+  }
+  return core::Ok();
+}
+
+bool HasBackup(std::wstring_view path) { return paths::FileExists(BackupPath(path)); }
+
+core::Status RestoreBackup(std::wstring_view path) {
+  const std::wstring backup = BackupPath(path);
+  if (!paths::FileExists(backup)) {
+    return DHEPZ_ERR(core::ErrorCode::NotFound, L"No backup exists yet for " + std::wstring(path));
+  }
+  std::wstring text;
+  DHEPZ_RETURN_IF_ERROR(ReadText(backup, &text));
+  return WriteTextAtomic(path, text);
+}
+
+}  // namespace files

--- a/src/platform/files.h
+++ b/src/platform/files.h
@@ -1,0 +1,76 @@
+// File IO with three deliberately different write modes.
+//
+// The modes exist because they have genuinely different failure semantics,
+// and collapsing them caused a real bug in the old build:
+//
+//   - WriteTextAtomic  — temp file + flush + replace. A crash mid-write can
+//     never leave a corrupt settings.json: the target either keeps its old
+//     bytes or gains the complete new ones.
+//   - WriteTextNew     — CREATE_NEW. Fails when the target exists, for cases
+//     where clobbering is itself the bug. Never replaces, renames, or
+//     deletes an existing file.
+//   - WriteTextInPlace — writes through the file's current object, then
+//     truncates with SetEndOfFile and flushes. The file identity (its
+//     directory entry and open handles) never changes, so an external
+//     editor watching the file keeps working. The truncation is the part
+//     the old build got wrong: shorter new content left stale trailing
+//     bytes behind, and the next parse read garbage.
+//
+// All writes are UTF-8 without BOM. Reads tolerate a UTF-8 BOM and strip
+// it — stripping belongs here, not in str::FromUtf8, which preserves it as
+// U+FEFF (pinned by #9's tests). Input that is not valid UTF-8 is a
+// ParseError, never a silent empty result: the old build returned {} on
+// failure, so one bad byte in a config file came up as a blank UI with
+// nothing to explain it.
+//
+// Like all of platform/, this layer may use Windows but keeps windows.h out
+// of the header.
+#pragma once
+
+#include <string>
+#include <string_view>
+
+#include "core/status.h"
+
+namespace files {
+
+// Reads a whole file as UTF-8 text. Files over 64 MiB are refused as
+// IoError — config-sized files only; anything bigger is a mistake or the
+// wrong API.
+//
+//   NotFound       — the file does not exist.
+//   IoError        — open, size, or read failure; file too large.
+//   ParseError     — the bytes are not valid UTF-8.
+core::Status ReadText(std::wstring_view path, std::wstring* out);
+
+// Writes `text` to "<path>.tmp", flushes it, then replaces the target in
+// one step (ReplaceFileW, falling back to MoveFileExW). Creates missing
+// parent directories. On any failure the target is untouched and the temp
+// file is removed.
+core::Status WriteTextAtomic(std::wstring_view path, std::wstring_view text);
+
+// Creates `path` and writes `text`. Fails without touching anything when
+// the file already exists.
+//
+//   AlreadyExists  — the target is present.
+core::Status WriteTextNew(std::wstring_view path, std::wstring_view text);
+
+// Overwrites the bytes of an existing file through its current file object,
+// truncates, and flushes. Never replaces, renames, or deletes the target;
+// creates it when it does not exist yet. FILE_SHARE_READ is kept so an
+// external editor can still read while the write is in flight.
+core::Status WriteTextInPlace(std::wstring_view path, std::wstring_view text);
+
+// Backup path used before destructive writes: "<path>.otn.bak".
+std::wstring BackupPath(std::wstring_view path);
+
+// Copies path -> BackupPath(path). A missing source is not an error — there
+// is simply nothing to back up yet.
+core::Status MakeBackup(std::wstring_view path);
+bool HasBackup(std::wstring_view path);
+
+// Replaces `path` with its backup, atomically. Fails with NotFound when no
+// backup exists.
+core::Status RestoreBackup(std::wstring_view path);
+
+}  // namespace files

--- a/tests/platform/files_test.cpp
+++ b/tests/platform/files_test.cpp
@@ -1,0 +1,271 @@
+#include "platform/files.h"
+
+#include <windows.h>
+
+#include <filesystem>
+#include <string>
+
+#include "framework/test_case.h"
+
+namespace {
+
+// A scratch directory under %TEMP% unique to this process. Every test gets
+// the directory created on demand and removes it at the end, so no state
+// leaks between tests.
+std::wstring TestRoot() {
+  wchar_t buffer[MAX_PATH] = {};
+  const DWORD len = GetTempPathW(MAX_PATH, buffer);
+  std::wstring root(buffer, len);
+  root += L"dhepz_files_test_";
+  root += std::to_wstring(GetCurrentProcessId());
+  return root;
+}
+
+std::wstring MakeTestDir() {
+  const std::wstring root = TestRoot();
+  std::filesystem::create_directories(root);
+  return root;
+}
+
+void RemoveTestDir() { std::filesystem::remove_all(TestRoot()); }
+
+// Raw byte helpers: the tests must be able to see exactly what is on disk
+// (BOM presence, line endings, trailing bytes), which the layer under test
+// would happily normalise away.
+std::string ReadRawBytes(const std::wstring& path) {
+  HANDLE handle =
+      CreateFileW(path.c_str(), GENERIC_READ, FILE_SHARE_READ, nullptr, OPEN_EXISTING,
+                  FILE_ATTRIBUTE_NORMAL, nullptr);
+  if (handle == INVALID_HANDLE_VALUE) {
+    return {};
+  }
+  std::string raw;
+  char chunk[4096];
+  DWORD got = 0;
+  while (ReadFile(handle, chunk, sizeof(chunk), &got, nullptr) && got > 0) {
+    raw.append(chunk, got);
+  }
+  CloseHandle(handle);
+  return raw;
+}
+
+bool WriteRawBytes(const std::wstring& path, const std::string& bytes) {
+  HANDLE handle =
+      CreateFileW(path.c_str(), GENERIC_WRITE, 0, nullptr, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, nullptr);
+  if (handle == INVALID_HANDLE_VALUE) {
+    return false;
+  }
+  DWORD written = 0;
+  const bool ok = WriteFile(handle, bytes.data(), static_cast<DWORD>(bytes.size()), &written, nullptr) &&
+                  written == bytes.size();
+  CloseHandle(handle);
+  return ok;
+}
+
+bool StartsWithBom(const std::string& raw) {
+  return raw.size() >= 3 && static_cast<unsigned char>(raw[0]) == 0xEF &&
+         static_cast<unsigned char>(raw[1]) == 0xBB && static_cast<unsigned char>(raw[2]) == 0xBF;
+}
+
+}  // namespace
+
+DHEPZ_TEST(Files, AtomicRoundTripAndNoBomNoCr) {
+  const std::wstring dir = MakeTestDir();
+  const std::wstring path = dir + L"\\settings.json";
+
+  const std::wstring text = L"{\n  \"theme\": \"dark\",\n  \"note\": \"caf\u00e9 \u4e2d\u6587\"\n}\n";
+  DHEPZ_CHECK(files::WriteTextAtomic(path, text).ok());
+
+  std::wstring back;
+  DHEPZ_CHECK(files::ReadText(path, &back).ok());
+  DHEPZ_CHECK_EQ(back, text);
+
+  // UTF-8 without BOM and LF untouched: no CR byte anywhere, no BOM prefix.
+  const std::string raw = ReadRawBytes(path);
+  DHEPZ_CHECK(!raw.empty());
+  DHEPZ_CHECK(!StartsWithBom(raw));
+  DHEPZ_CHECK(raw.find('\r') == std::string::npos);
+
+  // A second atomic write replaces cleanly and leaves no temp file behind.
+  DHEPZ_CHECK(files::WriteTextAtomic(path, L"second").ok());
+  DHEPZ_CHECK(files::ReadText(path, &back).ok());
+  DHEPZ_CHECK_EQ(back, std::wstring(L"second"));
+  DHEPZ_CHECK(!std::filesystem::exists(path + L".tmp"));
+
+  RemoveTestDir();
+}
+
+DHEPZ_TEST(Files, AtomicCreatesMissingParents) {
+  const std::wstring dir = MakeTestDir();
+  const std::wstring path = dir + L"\\a\\b\\c\\deep.txt";
+  DHEPZ_CHECK(files::WriteTextAtomic(path, L"deep").ok());
+  std::wstring back;
+  DHEPZ_CHECK(files::ReadText(path, &back).ok());
+  DHEPZ_CHECK_EQ(back, std::wstring(L"deep"));
+  RemoveTestDir();
+}
+
+// The criterion's second case: a temp file left behind by an earlier failed
+// run must not break the next write — it is simply overwritten on the way
+// to replacing the target.
+DHEPZ_TEST(Files, AtomicSurvivesStaleTempFile) {
+  const std::wstring dir = MakeTestDir();
+  const std::wstring path = dir + L"\\settings.json";
+  DHEPZ_CHECK(files::WriteTextAtomic(path, L"original").ok());
+  DHEPZ_CHECK(WriteRawBytes(path + L".tmp", "garbage from a crashed write"));
+
+  DHEPZ_CHECK(files::WriteTextAtomic(path, L"recovered").ok());
+  std::wstring back;
+  DHEPZ_CHECK(files::ReadText(path, &back).ok());
+  DHEPZ_CHECK_EQ(back, std::wstring(L"recovered"));
+  DHEPZ_CHECK(!std::filesystem::exists(path + L".tmp"));
+  RemoveTestDir();
+}
+
+// The criterion's first case, the other half: when the write itself fails,
+// the original file is untouched. Making the target's parent a *file* forces
+// EnsureDirectory to fail deterministically without any mocking.
+DHEPZ_TEST(Files, AtomicFailureLeavesOriginalIntact) {
+  const std::wstring dir = MakeTestDir();
+  const std::wstring blocker = dir + L"\\blocker";
+  DHEPZ_CHECK(WriteRawBytes(blocker, "i am a file, not a folder"));
+
+  const std::wstring target_under_blocker = blocker + L"\\settings.json";
+  const core::Status status = files::WriteTextAtomic(target_under_blocker, L"nope");
+  DHEPZ_CHECK_FALSE(status.ok());
+  DHEPZ_CHECK(!std::filesystem::exists(target_under_blocker));
+
+  // And a target that does exist survives a failed write elsewhere intact.
+  const std::wstring existing = dir + L"\\existing.json";
+  DHEPZ_CHECK(files::WriteTextAtomic(existing, L"keep me").ok());
+  DHEPZ_CHECK_FALSE(files::WriteTextAtomic(existing + L"\\child.txt", L"nope").ok());
+  std::wstring back;
+  DHEPZ_CHECK(files::ReadText(existing, &back).ok());
+  DHEPZ_CHECK_EQ(back, std::wstring(L"keep me"));
+  RemoveTestDir();
+}
+
+// The recorded bug in the old build: shorter new content left the tail of
+// the old content behind, and the next parse read garbage.
+DHEPZ_TEST(Files, InPlaceTruncatesShorterContent) {
+  const std::wstring dir = MakeTestDir();
+  const std::wstring path = dir + L"\\ui.json";
+
+  const std::wstring long_text(4096, L'x');
+  DHEPZ_CHECK(files::WriteTextInPlace(path, long_text).ok());
+
+  DHEPZ_CHECK(files::WriteTextInPlace(path, L"short").ok());
+  const std::string raw = ReadRawBytes(path);
+  DHEPZ_CHECK_EQ(raw.size(), static_cast<std::size_t>(5));
+  DHEPZ_CHECK_EQ(raw, std::string("short"));
+
+  std::wstring back;
+  DHEPZ_CHECK(files::ReadText(path, &back).ok());
+  DHEPZ_CHECK_EQ(back, std::wstring(L"short"));
+  RemoveTestDir();
+}
+
+DHEPZ_TEST(Files, InPlaceCreatesWhenMissingAndGrows) {
+  const std::wstring dir = MakeTestDir();
+  const std::wstring path = dir + L"\\fresh.json";
+  DHEPZ_CHECK(files::WriteTextInPlace(path, L"one").ok());
+  DHEPZ_CHECK(files::WriteTextInPlace(path, L"one but longer").ok());
+  std::wstring back;
+  DHEPZ_CHECK(files::ReadText(path, &back).ok());
+  DHEPZ_CHECK_EQ(back, std::wstring(L"one but longer"));
+  RemoveTestDir();
+}
+
+DHEPZ_TEST(Files, NewRefusesToClobber) {
+  const std::wstring dir = MakeTestDir();
+  const std::wstring path = dir + L"\\first.json";
+
+  DHEPZ_CHECK(files::WriteTextNew(path, L"original").ok());
+  const core::Status second = files::WriteTextNew(path, L"replacement");
+  DHEPZ_CHECK_FALSE(second.ok());
+  DHEPZ_CHECK_EQ(second.Code(), core::ErrorCode::AlreadyExists);
+
+  std::wstring back;
+  DHEPZ_CHECK(files::ReadText(path, &back).ok());
+  DHEPZ_CHECK_EQ(back, std::wstring(L"original"));
+  RemoveTestDir();
+}
+
+DHEPZ_TEST(Files, ReadStripsBom) {
+  const std::wstring dir = MakeTestDir();
+  const std::wstring path = dir + L"\\bom.txt";
+  DHEPZ_CHECK(WriteRawBytes(path, std::string("\xEF\xBB\xBF") + "bom content"));
+
+  std::wstring back;
+  DHEPZ_CHECK(files::ReadText(path, &back).ok());
+  DHEPZ_CHECK_EQ(back, std::wstring(L"bom content"));
+  RemoveTestDir();
+}
+
+// The old build returned an empty string here, indistinguishable from a
+// successful read of an empty file. Invalid bytes are a ParseError.
+DHEPZ_TEST(Files, ReadRejectsInvalidUtf8) {
+  const std::wstring dir = MakeTestDir();
+  const std::wstring path = dir + L"\\bad.txt";
+  DHEPZ_CHECK(WriteRawBytes(path, std::string("ok \xC3\x28 bad")));
+
+  std::wstring back = L"stale";
+  const core::Status status = files::ReadText(path, &back);
+  DHEPZ_CHECK_FALSE(status.ok());
+  DHEPZ_CHECK_EQ(status.Code(), core::ErrorCode::ParseError);
+  DHEPZ_CHECK(back.empty());
+  RemoveTestDir();
+}
+
+DHEPZ_TEST(Files, ReadMissingFileIsNotFound) {
+  const std::wstring dir = MakeTestDir();
+  std::wstring back;
+  const core::Status status = files::ReadText(dir + L"\\nope.txt", &back);
+  DHEPZ_CHECK_FALSE(status.ok());
+  DHEPZ_CHECK_EQ(status.Code(), core::ErrorCode::NotFound);
+  RemoveTestDir();
+}
+
+// An unpaired surrogate has no UTF-8 encoding and a std::wstring can hold
+// one, so a write path must reject it rather than write a mangled file.
+DHEPZ_TEST(Files, WriteRejectsUnpairedSurrogate) {
+  const std::wstring dir = MakeTestDir();
+  const std::wstring broken(1, static_cast<wchar_t>(0xD800));
+  const core::Status status = files::WriteTextAtomic(dir + L"\\x.txt", broken);
+  DHEPZ_CHECK_FALSE(status.ok());
+  DHEPZ_CHECK_EQ(status.Code(), core::ErrorCode::ParseError);
+  DHEPZ_CHECK(!std::filesystem::exists(dir + L"\\x.txt"));
+  DHEPZ_CHECK(!std::filesystem::exists(dir + L"\\x.txt.tmp"));
+  RemoveTestDir();
+}
+
+DHEPZ_TEST(Files, BackupAndRestoreRoundTrip) {
+  const std::wstring dir = MakeTestDir();
+  const std::wstring path = dir + L"\\ui.json";
+
+  // No file yet: backing up is a no-op, not an error.
+  DHEPZ_CHECK(files::MakeBackup(path).ok());
+  DHEPZ_CHECK_FALSE(files::HasBackup(path));
+
+  DHEPZ_CHECK(files::WriteTextAtomic(path, L"version one").ok());
+  DHEPZ_CHECK(files::MakeBackup(path).ok());
+  DHEPZ_CHECK(files::HasBackup(path));
+  DHEPZ_CHECK_EQ(files::BackupPath(path), path + L".otn.bak");
+
+  // A destructive change, then the restore brings the backup back.
+  DHEPZ_CHECK(files::WriteTextInPlace(path, L"version two, corrupted beyond repair").ok());
+  DHEPZ_CHECK(files::RestoreBackup(path).ok());
+  std::wstring back;
+  DHEPZ_CHECK(files::ReadText(path, &back).ok());
+  DHEPZ_CHECK_EQ(back, std::wstring(L"version one"));
+
+  RemoveTestDir();
+}
+
+DHEPZ_TEST(Files, RestoreWithoutBackupIsNotFound) {
+  const std::wstring dir = MakeTestDir();
+  const core::Status status = files::RestoreBackup(dir + L"\\never.txt");
+  DHEPZ_CHECK_FALSE(status.ok());
+  DHEPZ_CHECK_EQ(status.Code(), core::ErrorCode::NotFound);
+  RemoveTestDir();
+}


### PR DESCRIPTION
Closes #7.

## Summary
- `src/platform/files.{h,cpp}` — ported from `Teminal/src/logic/platform/files` with `core::Status` returns (continuing #9's judgement call) instead of bare bools + error out-param:
  - `WriteTextAtomic` — `<path>.tmp`, write, `FlushFileBuffers`, then `ReplaceFileW` with `MoveFileExW` fallback. Any failure deletes the temp and leaves the target untouched; missing parents are created.
  - `WriteTextNew` — `CREATE_NEW`; an existing target fails with `AlreadyExists` and is never touched.
  - `WriteTextInPlace` — `OPEN_ALWAYS` + `FILE_SHARE_READ`, seek, write, **`SetEndOfFile`**, flush. The truncation is the fix the old build lacked: shorter new content used to leave stale trailing bytes that parsed as garbage.
  - `ReadText` — 64 MiB cap, chunked read, strips a UTF-8 BOM, and rejects invalid UTF-8 as `ParseError` (the old build returned `{}` here, which is how a one-bad-byte config produced a blank UI).
  - Backup trio kept: `BackupPath` (`<path>.otn.bak`), `MakeBackup` (missing source is a no-op), `HasBackup`, `RestoreBackup` (via the atomic path).
- Error wording via `FormatMessageW` — `process::ErrorMessage` does not exist yet; it ports with `process.*`. Mapped codes: `NotFound`, `AlreadyExists`, `IoError`, `ParseError`. Flush failures are now reported rather than ignored.

## Test plan
- [x] 13 new tests picked up by the glob, no project edit, including both mandated verifications:
  - shorter in-place rewrite leaves exactly the new bytes on disk (raw read: 5 bytes, no tail);
  - a failed atomic write (parent is a file — deterministic, no mocks) leaves the original intact, and a stale `.tmp` from a crashed run is cleaned up by the next successful write.
  - Plus: no-BOM/no-CR raw-byte checks, BOM stripping on read, `AlreadyExists` refusal, invalid-UTF-8 and unpaired-surrogate rejection, missing-file `NotFound`, deep parent creation, backup/restore round trip.
- [x] `tools\Test.ps1` green: 61/61 Debug and 61/61 Release.
- [x] New files LF-only, verified byte-wise.