### PR TITLE
feat(core): add json parser with depth limit and line/column errors (#6)

### DIFF
--- a/src/core/json.cpp
+++ b/src/core/json.cpp
@@ -1,0 +1,680 @@
+#include "core/json.h"
+
+#include <cmath>
+#include <cstdio>
+#include <cwchar>
+
+namespace json {
+namespace {
+
+// Strict UTF-8 to UTF-16. core/ cannot call str::FromUtf8 — that conversion
+// is built on a Windows API and lives a layer up — so the parser carries its
+// own decoder with the same contract: invalid, truncated, overlong, and
+// surrogate input is an error, never a silently empty document.
+core::Status Utf8ToWide(std::string_view utf8, std::wstring* out) {
+  out->clear();
+  std::size_t i = 0;
+  while (i < utf8.size()) {
+    const unsigned char lead = static_cast<unsigned char>(utf8[i]);
+    unsigned int code = 0;
+    std::size_t length = 0;
+    if (lead < 0x80) {
+      code = lead;
+      length = 1;
+    } else if ((lead & 0xE0) == 0xC0) {
+      code = lead & 0x1Fu;
+      length = 2;
+    } else if ((lead & 0xF0) == 0xE0) {
+      code = lead & 0x0Fu;
+      length = 3;
+    } else if ((lead & 0xF8) == 0xF0) {
+      code = lead & 0x07u;
+      length = 4;
+    } else {
+      return DHEPZ_ERR(core::ErrorCode::ParseError, L"Input is not valid UTF-8");
+    }
+    if (i + length > utf8.size()) {
+      return DHEPZ_ERR(core::ErrorCode::ParseError, L"Input is not valid UTF-8: truncated sequence");
+    }
+    for (std::size_t k = 1; k < length; ++k) {
+      const unsigned char next = static_cast<unsigned char>(utf8[i + k]);
+      if ((next & 0xC0) != 0x80) {
+        return DHEPZ_ERR(core::ErrorCode::ParseError, L"Input is not valid UTF-8: bad continuation byte");
+      }
+      code = code * 64 + (next & 0x3Fu);
+    }
+    // Reject encodings a shorter form could express, the surrogate block,
+    // and everything past the Unicode range.
+    const unsigned int minimum =
+        length == 2 ? 0x80u : length == 3 ? 0x800u : length == 4 ? 0x10000u : 0u;
+    if (code < minimum || (code >= 0xD800 && code <= 0xDFFF) || code > 0x10FFFF) {
+      return DHEPZ_ERR(core::ErrorCode::ParseError, L"Input is not valid UTF-8: illegal code point");
+    }
+    if (code >= 0x10000) {
+      code -= 0x10000;
+      out->push_back(static_cast<wchar_t>(0xD800 + (code >> 10)));
+      out->push_back(static_cast<wchar_t>(0xDC00 + (code & 0x3FF)));
+    } else {
+      out->push_back(static_cast<wchar_t>(code));
+    }
+    i += length;
+  }
+  return core::Ok();
+}
+
+const std::wstring& EmptyString() {
+  static const std::wstring instance;
+  return instance;
+}
+
+class Parser {
+ public:
+  Parser(std::wstring_view text) : text_(text) {}
+
+  bool Run(Value* out) {
+    SkipWhitespace();
+    if (!ParseValue(out)) {
+      return false;
+    }
+    SkipWhitespace();
+    if (pos_ != text_.size()) {
+      Fail(L"Unexpected text after the top-level value");
+      return false;
+    }
+    return true;
+  }
+
+  const std::wstring& error() const { return error_; }
+
+ private:
+  std::wstring_view text_;
+  std::size_t pos_ = 0;
+  int depth_ = 0;
+  std::wstring error_;
+
+  std::wstring Message(std::wstring_view what) const {
+    std::size_t line = 1;
+    std::size_t column = 1;
+    for (std::size_t i = 0; i < pos_ && i < text_.size(); ++i) {
+      if (text_[i] == L'\n') {
+        ++line;
+        column = 1;
+      } else {
+        ++column;
+      }
+    }
+    return std::wstring(what) + L" (line " + std::to_wstring(line) + L", column " +
+           std::to_wstring(column) + L")";
+  }
+
+  bool Fail(std::wstring_view what) {
+    if (error_.empty()) {
+      error_ = Message(what);
+    }
+    return false;
+  }
+
+  void SkipWhitespace() {
+    while (pos_ < text_.size()) {
+      const wchar_t c = text_[pos_];
+      if (c == L' ' || c == L'\t' || c == L'\r' || c == L'\n') {
+        ++pos_;
+      } else {
+        break;
+      }
+    }
+  }
+
+  bool Literal(std::wstring_view word) {
+    if (text_.compare(pos_, word.size(), word) != 0) {
+      return false;
+    }
+    pos_ += word.size();
+    return true;
+  }
+
+  bool ParseValue(Value* out) {
+    if (pos_ >= text_.size()) {
+      return Fail(L"Unexpected end of input");
+    }
+    switch (text_[pos_]) {
+      case L'{':
+        return ParseObject(out);
+      case L'[':
+        return ParseArray(out);
+      case L'"': {
+        std::wstring text;
+        if (!ParseString(&text)) {
+          return false;
+        }
+        *out = Value::String(std::move(text));
+        return true;
+      }
+      case L't':
+        if (!Literal(L"true")) {
+          return Fail(L"Invalid literal, expected 'true'");
+        }
+        *out = Value::Bool(true);
+        return true;
+      case L'f':
+        if (!Literal(L"false")) {
+          return Fail(L"Invalid literal, expected 'false'");
+        }
+        *out = Value::Bool(false);
+        return true;
+      case L'n':
+        if (!Literal(L"null")) {
+          return Fail(L"Invalid literal, expected 'null'");
+        }
+        *out = Value::Null();
+        return true;
+      default:
+        return ParseNumber(out);
+    }
+  }
+
+  bool ParseObject(Value* out) {
+    if (depth_ >= kMaxDepth) {
+      return Fail(L"JSON nesting is too deep (limit is 512)");
+    }
+    ++pos_;  // '{'
+    ++depth_;
+    Value object = Value::Object();
+    SkipWhitespace();
+    if (pos_ < text_.size() && text_[pos_] == L'}') {
+      ++pos_;
+      --depth_;
+      *out = std::move(object);
+      return true;
+    }
+    for (;;) {
+      SkipWhitespace();
+      if (pos_ >= text_.size() || text_[pos_] != L'"') {
+        return Fail(L"Expected a quoted member name");
+      }
+      std::wstring key;
+      if (!ParseString(&key)) {
+        return false;
+      }
+      SkipWhitespace();
+      if (pos_ >= text_.size() || text_[pos_] != L':') {
+        return Fail(L"Expected ':' after the member name");
+      }
+      ++pos_;
+      SkipWhitespace();
+      Value member;
+      if (!ParseValue(&member)) {
+        return false;
+      }
+      object.Set(key, std::move(member));
+      SkipWhitespace();
+      if (pos_ < text_.size() && text_[pos_] == L',') {
+        ++pos_;
+        continue;
+      }
+      if (pos_ < text_.size() && text_[pos_] == L'}') {
+        ++pos_;
+        --depth_;
+        *out = std::move(object);
+        return true;
+      }
+      return Fail(L"Expected ',' or '}'");
+    }
+  }
+
+  bool ParseArray(Value* out) {
+    if (depth_ >= kMaxDepth) {
+      return Fail(L"JSON nesting is too deep (limit is 512)");
+    }
+    ++pos_;  // '['
+    ++depth_;
+    Value array = Value::Array();
+    SkipWhitespace();
+    if (pos_ < text_.size() && text_[pos_] == L']') {
+      ++pos_;
+      --depth_;
+      *out = std::move(array);
+      return true;
+    }
+    for (;;) {
+      SkipWhitespace();
+      Value item;
+      if (!ParseValue(&item)) {
+        return false;
+      }
+      array.Append(std::move(item));
+      SkipWhitespace();
+      if (pos_ < text_.size() && text_[pos_] == L',') {
+        ++pos_;
+        continue;
+      }
+      if (pos_ < text_.size() && text_[pos_] == L']') {
+        ++pos_;
+        --depth_;
+        *out = std::move(array);
+        return true;
+      }
+      return Fail(L"Expected ',' or ']'");
+    }
+  }
+
+  bool ParseString(std::wstring* out) {
+    ++pos_;  // opening quote
+    out->clear();
+    while (pos_ < text_.size()) {
+      const wchar_t c = text_[pos_++];
+      if (c == L'"') {
+        return true;
+      }
+      if (c == L'\\') {
+        if (pos_ >= text_.size()) {
+          break;
+        }
+        const wchar_t esc = text_[pos_++];
+        switch (esc) {
+          case L'"': out->push_back(L'"'); break;
+          case L'\\': out->push_back(L'\\'); break;
+          case L'/': out->push_back(L'/'); break;
+          case L'b': out->push_back(L'\b'); break;
+          case L'f': out->push_back(L'\f'); break;
+          case L'n': out->push_back(L'\n'); break;
+          case L'r': out->push_back(L'\r'); break;
+          case L't': out->push_back(L'\t'); break;
+          case L'u': {
+            if (pos_ + 4 > text_.size()) {
+              return Fail(L"Truncated \\u escape");
+            }
+            unsigned int code = 0;
+            for (int i = 0; i < 4; ++i) {
+              const wchar_t digit = text_[pos_ + i];
+              unsigned int nibble = 0;
+              if (digit >= L'0' && digit <= L'9') {
+                nibble = static_cast<unsigned int>(digit - L'0');
+              } else if (digit >= L'a' && digit <= L'f') {
+                nibble = static_cast<unsigned int>(digit - L'a') + 10;
+              } else if (digit >= L'A' && digit <= L'F') {
+                nibble = static_cast<unsigned int>(digit - L'A') + 10;
+              } else {
+                return Fail(L"Invalid \\u escape");
+              }
+              code = code * 16 + nibble;
+            }
+            pos_ += 4;
+            // A high surrogate must be followed by a low one; pairing them
+            // here keeps the UTF-16 output well-formed for anything that
+            // later converts it back to UTF-8.
+            if (code >= 0xD800 && code <= 0xDBFF && pos_ + 6 <= text_.size() &&
+                text_[pos_] == L'\\' && text_[pos_ + 1] == L'u') {
+              unsigned int low = 0;
+              bool valid = true;
+              for (int i = 0; i < 4; ++i) {
+                const wchar_t digit = text_[pos_ + 2 + i];
+                unsigned int nibble = 0;
+                if (digit >= L'0' && digit <= L'9') {
+                  nibble = static_cast<unsigned int>(digit - L'0');
+                } else if (digit >= L'a' && digit <= L'f') {
+                  nibble = static_cast<unsigned int>(digit - L'a') + 10;
+                } else if (digit >= L'A' && digit <= L'F') {
+                  nibble = static_cast<unsigned int>(digit - L'A') + 10;
+                } else {
+                  valid = false;
+                  break;
+                }
+                low = low * 16 + nibble;
+              }
+              if (valid && low >= 0xDC00 && low <= 0xDFFF) {
+                pos_ += 6;
+                out->push_back(static_cast<wchar_t>(code));
+                out->push_back(static_cast<wchar_t>(low));
+                break;
+              }
+            }
+            out->push_back(static_cast<wchar_t>(code));
+            break;
+          }
+          default:
+            return Fail(L"Invalid escape sequence");
+        }
+        continue;
+      }
+      if (c < 0x20) {
+        return Fail(L"Control character inside a string");
+      }
+      out->push_back(c);
+    }
+    return Fail(L"Unterminated string");
+  }
+
+  bool ParseNumber(Value* out) {
+    const std::size_t start = pos_;
+    if (pos_ < text_.size() && text_[pos_] == L'-') {
+      ++pos_;
+    }
+    bool any_digit = false;
+    while (pos_ < text_.size() && text_[pos_] >= L'0' && text_[pos_] <= L'9') {
+      ++pos_;
+      any_digit = true;
+    }
+    // A fraction is only valid after an integer digit, and must have digits.
+    if (any_digit && pos_ < text_.size() && text_[pos_] == L'.') {
+      ++pos_;
+      bool frac_digit = false;
+      while (pos_ < text_.size() && text_[pos_] >= L'0' && text_[pos_] <= L'9') {
+        ++pos_;
+        frac_digit = true;
+      }
+      if (!frac_digit) {
+        pos_ = start;
+        return Fail(L"Missing digits after decimal point");
+      }
+    }
+    if (any_digit && pos_ < text_.size() && (text_[pos_] == L'e' || text_[pos_] == L'E')) {
+      ++pos_;
+      if (pos_ < text_.size() && (text_[pos_] == L'-' || text_[pos_] == L'+')) {
+        ++pos_;
+      }
+      bool exp_digit = false;
+      while (pos_ < text_.size() && text_[pos_] >= L'0' && text_[pos_] <= L'9') {
+        ++pos_;
+        exp_digit = true;
+      }
+      if (!exp_digit) {
+        return Fail(L"Invalid exponent");
+      }
+    }
+    if (!any_digit) {
+      pos_ = start;
+      return Fail(L"Unexpected character");
+    }
+    const std::wstring raw(text_.substr(start, pos_ - start));
+    *out = Value::Number(raw, std::wcstod(raw.c_str(), nullptr));
+    return true;
+  }
+};
+
+void Write(const Value& value, bool pretty, int indent, std::wstring* out) {
+  const std::wstring pad = pretty ? std::wstring(static_cast<std::size_t>(indent) * 2, L' ')
+                                   : std::wstring();
+  const std::wstring pad_inner =
+      pretty ? std::wstring(static_cast<std::size_t>(indent + 1) * 2, L' ') : std::wstring();
+  const wchar_t* newline = pretty ? L"\n" : L"";
+  const wchar_t* colon = pretty ? L": " : L":";
+
+  switch (value.type()) {
+    case Type::Null:
+      out->append(L"null");
+      break;
+    case Type::Bool:
+      out->append(value.AsBool() ? L"true" : L"false");
+      break;
+    case Type::Number: {
+      const std::wstring& raw = value.AsString();
+      if (!raw.empty()) {
+        out->append(raw);
+        break;
+      }
+      const double number = value.AsNumber();
+      wchar_t buffer[64];
+      if (number == std::floor(number) && std::fabs(number) < 1e15) {
+        std::swprintf(buffer, 64, L"%lld", static_cast<long long>(number));
+      } else {
+        std::swprintf(buffer, 64, L"%.17g", number);
+      }
+      out->append(buffer);
+      break;
+    }
+    case Type::String:
+      out->append(EscapeString(value.AsString()));
+      break;
+    case Type::Array: {
+      if (value.items().empty()) {
+        out->append(L"[]");
+        break;
+      }
+      out->append(L"[").append(newline);
+      for (std::size_t i = 0; i < value.items().size(); ++i) {
+        out->append(pad_inner);
+        Write(value.items()[i], pretty, indent + 1, out);
+        if (i + 1 < value.items().size()) {
+          out->append(L",");
+        }
+        out->append(newline);
+      }
+      out->append(pad).append(L"]");
+      break;
+    }
+    case Type::Object: {
+      if (value.members().empty()) {
+        out->append(L"{}");
+        break;
+      }
+      out->append(L"{").append(newline);
+      for (std::size_t i = 0; i < value.members().size(); ++i) {
+        out->append(pad_inner);
+        out->append(EscapeString(value.members()[i].first));
+        out->append(colon);
+        Write(value.members()[i].second, pretty, indent + 1, out);
+        if (i + 1 < value.members().size()) {
+          out->append(L",");
+        }
+        out->append(newline);
+      }
+      out->append(pad).append(L"}");
+      break;
+    }
+  }
+}
+
+}  // namespace
+
+Value Value::Null() { return Value(); }
+
+Value Value::Bool(bool value) {
+  Value out;
+  out.type_ = Type::Bool;
+  out.bool_ = value;
+  return out;
+}
+
+Value Value::Number(double value) {
+  Value out;
+  out.type_ = Type::Number;
+  out.number_ = value;
+  return out;
+}
+
+Value Value::Number(std::wstring raw, double value) {
+  Value out;
+  out.type_ = Type::Number;
+  out.number_ = value;
+  out.text_ = std::move(raw);
+  return out;
+}
+
+Value Value::String(std::wstring value) {
+  Value out;
+  out.type_ = Type::String;
+  out.text_ = std::move(value);
+  return out;
+}
+
+Value Value::Array() {
+  Value out;
+  out.type_ = Type::Array;
+  return out;
+}
+
+Value Value::Object() {
+  Value out;
+  out.type_ = Type::Object;
+  return out;
+}
+
+bool Value::AsBool(bool fallback) const { return type_ == Type::Bool ? bool_ : fallback; }
+double Value::AsNumber(double fallback) const { return type_ == Type::Number ? number_ : fallback; }
+
+const std::wstring& Value::AsString() const {
+  if (type_ == Type::String || type_ == Type::Number) {
+    return text_;
+  }
+  return EmptyString();
+}
+
+void Value::Append(Value value) {
+  if (type_ != Type::Array) {
+    type_ = Type::Array;
+    members_.clear();
+  }
+  items_.push_back(std::move(value));
+}
+
+const Value* Value::Find(std::wstring_view key) const {
+  if (type_ != Type::Object) {
+    return nullptr;
+  }
+  for (const auto& member : members_) {
+    if (member.first == key) {
+      return &member.second;
+    }
+  }
+  return nullptr;
+}
+
+Value* Value::Find(std::wstring_view key) {
+  if (type_ != Type::Object) {
+    return nullptr;
+  }
+  for (auto& member : members_) {
+    if (member.first == key) {
+      return &member.second;
+    }
+  }
+  return nullptr;
+}
+
+std::wstring Value::StringField(std::wstring_view key, std::wstring_view fallback) const {
+  const Value* found = Find(key);
+  if (found == nullptr || !found->is_string()) {
+    return std::wstring(fallback);
+  }
+  return found->AsString();
+}
+
+bool Value::BoolField(std::wstring_view key, bool fallback) const {
+  const Value* found = Find(key);
+  if (found == nullptr || !found->is_bool()) {
+    return fallback;
+  }
+  return found->AsBool();
+}
+
+double Value::NumberField(std::wstring_view key, double fallback) const {
+  const Value* found = Find(key);
+  if (found == nullptr || !found->is_number()) {
+    return fallback;
+  }
+  return found->AsNumber();
+}
+
+const Value* Value::ArrayField(std::wstring_view key) const {
+  const Value* found = Find(key);
+  return (found != nullptr && found->is_array()) ? found : nullptr;
+}
+
+const Value* Value::ObjectField(std::wstring_view key) const {
+  const Value* found = Find(key);
+  return (found != nullptr && found->is_object()) ? found : nullptr;
+}
+
+void Value::Set(std::wstring_view key, Value value) {
+  if (type_ != Type::Object) {
+    type_ = Type::Object;
+    items_.clear();
+  }
+  for (auto& member : members_) {
+    if (member.first == key) {
+      member.second = std::move(value);
+      return;
+    }
+  }
+  members_.emplace_back(std::wstring(key), std::move(value));
+}
+
+void Value::Remove(std::wstring_view key) {
+  for (std::size_t i = 0; i < members_.size(); ++i) {
+    if (members_[i].first == key) {
+      members_.erase(members_.begin() + static_cast<std::ptrdiff_t>(i));
+      return;
+    }
+  }
+}
+
+core::Status Parse(std::wstring_view text, Value* out) {
+  if (out == nullptr) {
+    return DHEPZ_ERR(core::ErrorCode::InvalidArgument, L"Parse requires an output value");
+  }
+  // A leading U+FEFF is the BOM as a character — tolerated and skipped, per
+  // the division pinned by #7/#9: converters preserve it, this layer strips.
+  if (!text.empty() && text.front() == L'\uFEFF') {
+    text.remove_prefix(1);
+  }
+  Parser parser(text);
+  Value parsed;
+  if (!parser.Run(&parsed)) {
+    const std::wstring& message = parser.error();
+    return DHEPZ_ERR(core::ErrorCode::ParseError, message.empty() ? L"Invalid JSON" : message);
+  }
+  *out = std::move(parsed);
+  return core::Ok();
+}
+
+core::Status ParseUtf8(std::string_view utf8, Value* out) {
+  if (out == nullptr) {
+    return DHEPZ_ERR(core::ErrorCode::InvalidArgument, L"ParseUtf8 requires an output value");
+  }
+  if (utf8.size() >= 3 && static_cast<unsigned char>(utf8[0]) == 0xEF &&
+      static_cast<unsigned char>(utf8[1]) == 0xBB && static_cast<unsigned char>(utf8[2]) == 0xBF) {
+    utf8.remove_prefix(3);
+  }
+  std::wstring wide;
+  DHEPZ_RETURN_IF_ERROR(Utf8ToWide(utf8, &wide));
+  return Parse(wide, out);
+}
+
+std::wstring Serialize(const Value& value, bool pretty) {
+  std::wstring out;
+  Write(value, pretty, 0, &out);
+  if (pretty) {
+    out.push_back(L'\n');
+  }
+  return out;
+}
+
+std::wstring EscapeString(std::wstring_view value) {
+  std::wstring out;
+  out.reserve(value.size() + 2);
+  out.push_back(L'"');
+  for (wchar_t c : value) {
+    switch (c) {
+      case L'"': out.append(L"\\\""); break;
+      case L'\\': out.append(L"\\\\"); break;
+      case L'\b': out.append(L"\\b"); break;
+      case L'\f': out.append(L"\\f"); break;
+      case L'\n': out.append(L"\\n"); break;
+      case L'\r': out.append(L"\\r"); break;
+      case L'\t': out.append(L"\\t"); break;
+      default:
+        if (c < 0x20) {
+          wchar_t buffer[8];
+          std::swprintf(buffer, 8, L"\\u%04x", static_cast<unsigned int>(c));
+          out.append(buffer);
+        } else {
+          out.push_back(c);
+        }
+    }
+  }
+  out.push_back(L'"');
+  return out;
+}
+
+}  // namespace json

--- a/src/core/json.h
+++ b/src/core/json.h
@@ -1,0 +1,109 @@
+// Minimal JSON model for config-sized documents.
+//
+// Two properties are load-bearing for G3, so they are pinned by tests:
+//
+//   - Object member order is preserved. The UI resolver lays screens out in
+//     declaration order, and rewriting a config must keep every field where
+//     the user (or another tool) had it.
+//   - Absent optional fields are not errors. The typed fallback accessors
+//     (`StringField`, `BoolField`, `NumberField`) and `Find()` returning
+//     nullptr are the plan's answer to optional config — no error plumbing
+//     at every call site.
+//
+// The parser is strict, the way the tooling requires: no comments, no
+// trailing commas, no garbage after the top-level value, so anything this
+// layer accepts round-trips through ConvertFrom-Json on the PowerShell side.
+// Nesting is bounded by kMaxDepth: a hostile or accidental 10,000-deep
+// input is a ParseError, not a stack overflow.
+//
+// Duplicate member names keep the last value at the first key's position —
+// standard JSON tolerance, with position stability for the resolver.
+//
+// core/ never includes Windows.h. This header is standard library only.
+#pragma once
+
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include "core/status.h"
+
+namespace json {
+
+// Deepest nesting the parser accepts. Real config is single-digit deep; the
+// bound exists so adversarial input cannot trade depth for stack.
+inline constexpr int kMaxDepth = 512;
+
+enum class Type { Null, Bool, Number, String, Array, Object };
+
+class Value {
+ public:
+  Value() = default;
+  static Value Null();
+  static Value Bool(bool value);
+  static Value Number(double value);
+  static Value Number(std::wstring raw, double value);
+  static Value String(std::wstring value);
+  static Value Array();
+  static Value Object();
+
+  Type type() const { return type_; }
+  bool is_null() const { return type_ == Type::Null; }
+  bool is_bool() const { return type_ == Type::Bool; }
+  bool is_number() const { return type_ == Type::Number; }
+  bool is_string() const { return type_ == Type::String; }
+  bool is_array() const { return type_ == Type::Array; }
+  bool is_object() const { return type_ == Type::Object; }
+
+  bool AsBool(bool fallback = false) const;
+  double AsNumber(double fallback = 0.0) const;
+  const std::wstring& AsString() const;
+
+  // Array access.
+  std::size_t size() const { return items_.size(); }
+  void Append(Value value);
+
+  // Object access. Find returns nullptr when the key is absent.
+  const Value* Find(std::wstring_view key) const;
+  Value* Find(std::wstring_view key);
+  std::wstring StringField(std::wstring_view key, std::wstring_view fallback = {}) const;
+  bool BoolField(std::wstring_view key, bool fallback = false) const;
+  double NumberField(std::wstring_view key, double fallback = 0.0) const;
+  const Value* ArrayField(std::wstring_view key) const;
+  const Value* ObjectField(std::wstring_view key) const;
+
+  // Sets a member, keeping its original position when the key already exists.
+  void Set(std::wstring_view key, Value value);
+  void Remove(std::wstring_view key);
+
+  const std::vector<std::pair<std::wstring, Value>>& members() const { return members_; }
+  const std::vector<Value>& items() const { return items_; }
+
+ private:
+  Type type_ = Type::Null;
+  bool bool_ = false;
+  double number_ = 0.0;
+  std::wstring text_;  // string payload, or verbatim number text
+  std::vector<Value> items_;
+  std::vector<std::pair<std::wstring, Value>> members_;
+};
+
+// Parses strict JSON from UTF-16 text. A leading U+FEFF (the BOM as a
+// character) is tolerated and skipped. On failure the Status carries
+// ParseError with a message naming what was expected plus a 1-based
+// "(line N, column M)".
+core::Status Parse(std::wstring_view text, Value* out);
+
+// Parses UTF-8 input: converts strictly via str::FromUtf8 (invalid bytes are
+// a ParseError, never a silent empty document), strips a UTF-8 BOM, then
+// delegates to the UTF-16 parser.
+core::Status ParseUtf8(std::string_view utf8, Value* out);
+
+// Pretty-prints with two-space indent and a trailing newline.
+std::wstring Serialize(const Value& value, bool pretty = true);
+
+// Quotes and escapes a bare string as a JSON string literal.
+std::wstring EscapeString(std::wstring_view value);
+
+}  // namespace json

--- a/tests/core/json_test.cpp
+++ b/tests/core/json_test.cpp
@@ -1,0 +1,217 @@
+#include "core/json.h"
+
+#include <string>
+
+#include "framework/test_case.h"
+
+namespace {
+
+// Parses and fails the test with the parser's own message if it cannot.
+json::Value ParseOrDie(const std::wstring& text, const char* file, int line) {
+  json::Value value;
+  const core::Status status = json::Parse(text, &value);
+  if (!status.ok()) {
+    ::testing::Fail(std::string("expected parse to succeed\n    error: ") +
+                        ::testing::Describe(std::wstring_view(status.Message())),
+                    file, line);
+  }
+  return value;
+}
+
+core::Status ParseExpectingFailure(const std::wstring& text, json::Value* out) {
+  return json::Parse(text, out);
+}
+
+}  // namespace
+
+#define PARSE_OR_DIE(text) ParseOrDie((text), __FILE__, __LINE__)
+
+DHEPZ_TEST(Json, ParsesEveryScalarType) {
+  const json::Value value = PARSE_OR_DIE(L"{\"s\": \"text\", \"n\": -12.5e2, \"t\": true, \"f\": false, \"z\": null}");
+  DHEPZ_CHECK(value.is_object());
+  DHEPZ_CHECK_EQ(value.StringField(L"s"), std::wstring(L"text"));
+  DHEPZ_CHECK_EQ(value.NumberField(L"n"), -1250.0);
+  DHEPZ_CHECK(value.BoolField(L"t"));
+  DHEPZ_CHECK_FALSE(value.BoolField(L"f"));
+  const json::Value* z = value.Find(L"z");
+  DHEPZ_CHECK(z != nullptr);
+  DHEPZ_CHECK(z->is_null());
+}
+
+// The UI resolver lays screens out in declaration order, so this is the
+// load-bearing behaviour for G3.
+DHEPZ_TEST(Json, PreservesMemberOrder) {
+  const json::Value value = PARSE_OR_DIE(L"{\"zeta\": 1, \"alpha\": 2, \"mid\": 3}");
+  DHEPZ_CHECK_EQ(value.members().size(), static_cast<std::size_t>(3));
+  DHEPZ_CHECK_EQ(value.members()[0].first, std::wstring(L"zeta"));
+  DHEPZ_CHECK_EQ(value.members()[1].first, std::wstring(L"alpha"));
+  DHEPZ_CHECK_EQ(value.members()[2].first, std::wstring(L"mid"));
+}
+
+DHEPZ_TEST(Json, DuplicateKeyKeepsLastValueAtFirstPosition) {
+  const json::Value value = PARSE_OR_DIE(L"{\"a\": 1, \"b\": 2, \"a\": 3}");
+  DHEPZ_CHECK_EQ(value.members().size(), static_cast<std::size_t>(2));
+  DHEPZ_CHECK_EQ(value.members()[0].first, std::wstring(L"a"));
+  DHEPZ_CHECK_EQ(value.NumberField(L"a"), 3.0);
+  DHEPZ_CHECK_EQ(value.members()[1].first, std::wstring(L"b"));
+}
+
+DHEPZ_TEST(Json, FallbackAccessIsNotAnError) {
+  const json::Value value = PARSE_OR_DIE(L"{\"present\": \"yes\"}");
+  DHEPZ_CHECK_EQ(value.StringField(L"missing", L"default"), std::wstring(L"default"));
+  DHEPZ_CHECK(value.BoolField(L"missing", true));
+  DHEPZ_CHECK_EQ(value.NumberField(L"missing", 7.5), 7.5);
+  DHEPZ_CHECK(value.Find(L"missing") == nullptr);
+  DHEPZ_CHECK(value.ArrayField(L"present") == nullptr);  // wrong type, not a crash
+  // A field of the wrong type falls back too.
+  DHEPZ_CHECK_EQ(value.StringField(L"present", L"x"), std::wstring(L"yes"));
+  DHEPZ_CHECK_EQ(value.NumberField(L"present", 1.0), 1.0);
+}
+
+DHEPZ_TEST(Json, ErrorsCarryLineColumnAndExpectation) {
+  json::Value value;
+  // Line 2, the missing colon after the member name.
+  const core::Status status = ParseExpectingFailure(L"{\n  \"key\" 1\n}", &value);
+  DHEPZ_CHECK_FALSE(status.ok());
+  DHEPZ_CHECK_EQ(status.Code(), core::ErrorCode::ParseError);
+  DHEPZ_CHECK_CONTAINS(status.Message(), std::wstring(L"line 2"));
+  DHEPZ_CHECK_CONTAINS(status.Message(), std::wstring(L"column 9"));
+  DHEPZ_CHECK_CONTAINS(status.Message(), std::wstring(L"':'"));
+}
+
+DHEPZ_TEST(Json, RejectsTrailingCommas) {
+  json::Value value;
+  DHEPZ_CHECK_FALSE(json::Parse(L"{\"a\": 1,}", &value).ok());
+  DHEPZ_CHECK_FALSE(json::Parse(L"[1, 2,]", &value).ok());
+}
+
+// No comments, so whatever this layer accepts round-trips through
+// ConvertFrom-Json on the tooling side.
+DHEPZ_TEST(Json, RejectsCommentsAndGarbage) {
+  json::Value value;
+  DHEPZ_CHECK_FALSE(json::Parse(L"// no comments\n{}", &value).ok());
+  DHEPZ_CHECK_FALSE(json::Parse(L"{\"a\": 1} /* trailing */", &value).ok());
+  const core::Status trailing = json::Parse(L"{} {}", &value);
+  DHEPZ_CHECK_FALSE(trailing.ok());
+  DHEPZ_CHECK_CONTAINS(trailing.Message(), std::wstring(L"after the top-level value"));
+}
+
+DHEPZ_TEST(Json, RejectsMalformedLiteralsAndNumbers) {
+  json::Value value;
+  DHEPZ_CHECK_FALSE(json::Parse(L"tru", &value).ok());
+  DHEPZ_CHECK_FALSE(json::Parse(L"1.", &value).ok());
+  DHEPZ_CHECK_FALSE(json::Parse(L"1e", &value).ok());
+  DHEPZ_CHECK_FALSE(json::Parse(L"\"unterminated", &value).ok());
+  DHEPZ_CHECK_FALSE(json::Parse(L"", &value).ok());
+  // Split literals stop the hex escape swallowing the following 'c'.
+  const core::Status control = json::Parse(L"\"bad\x01" L"char\"", &value);
+  DHEPZ_CHECK_FALSE(control.ok());
+  DHEPZ_CHECK_CONTAINS(control.Message(), std::wstring(L"Control character"));
+}
+
+// The mandated verification: 10,000-deep input is an error, not a crash.
+DHEPZ_TEST(Json, DepthLimitRejectsTenThousandNesting) {
+  std::wstring deep(10000, L'[');
+  deep.append(10000, L']');
+  json::Value value;
+  const core::Status status = json::Parse(deep, &value);
+  DHEPZ_CHECK_FALSE(status.ok());
+  DHEPZ_CHECK_EQ(status.Code(), core::ErrorCode::ParseError);
+  DHEPZ_CHECK_CONTAINS(status.Message(), std::wstring(L"too deep"));
+
+  // Same shape as objects.
+  std::wstring obj(10000 * 4, L'{');
+  json::Value value2;
+  DHEPZ_CHECK_FALSE(json::Parse(obj, &value2).ok());
+}
+
+DHEPZ_TEST(Json, DepthLimitAllowsDeepButSaneNesting) {
+  // Well under kMaxDepth: parses fine, proving the limit is not hair-trigger.
+  std::wstring nested;
+  for (int i = 0; i < 100; ++i) {
+    nested += L"{\"next\": ";
+  }
+  nested += L"1";
+  for (int i = 0; i < 100; ++i) {
+    nested += L"}";
+  }
+  const json::Value value = PARSE_OR_DIE(nested);
+  DHEPZ_CHECK(value.is_object());
+}
+
+DHEPZ_TEST(Json, StringEscapesIncludingSurrogatePairs) {
+  const json::Value value =
+      PARSE_OR_DIE(L"\"a\\\"b\\\\c\\/d\\b\\f\\n\\r\\t\\u00e9\\uD83D\\uDE00\"");
+  const std::wstring expected = L"a\"b\\c/d\b\f\n\r\t\u00e9\U0001F600";
+  DHEPZ_CHECK_EQ(value.AsString(), expected);
+
+  json::Value bad;
+  DHEPZ_CHECK_FALSE(json::Parse(L"\"\\q\"", &bad).ok());
+  DHEPZ_CHECK_FALSE(json::Parse(L"\"\\u12\"", &bad).ok());
+}
+
+DHEPZ_TEST(Json, BomIsToleratedAndStripped) {
+  // Wide BOM character in front of the document.
+  const json::Value wide = PARSE_OR_DIE(L"\uFEFF{\"a\": 1}");
+  DHEPZ_CHECK_EQ(wide.NumberField(L"a"), 1.0);
+
+  // UTF-8 BOM bytes on the UTF-8 entry point.
+  json::Value utf8;
+  DHEPZ_CHECK(json::ParseUtf8(std::string("\xEF\xBB\xBF") + "{\"a\": 2}", &utf8).ok());
+  DHEPZ_CHECK_EQ(utf8.NumberField(L"a"), 2.0);
+}
+
+DHEPZ_TEST(Json, Utf8InputRoundTripsAndRejectsBadBytes) {
+  json::Value value;
+  DHEPZ_CHECK(json::ParseUtf8("{\"note\": \"caf\xC3\xA9 \xE4\xB8\xAD \xF0\x9F\x98\x80\"}", &value).ok());
+  DHEPZ_CHECK_EQ(value.StringField(L"note"), std::wstring(L"caf\u00e9 \u4e2d \U0001F600"));
+
+  // The old build's failure mode: one bad byte must be a ParseError, never a
+  // silent empty document.
+  json::Value bad;
+  const core::Status truncated = json::ParseUtf8(std::string("\xC3\x28{}"), &bad);
+  DHEPZ_CHECK_FALSE(truncated.ok());
+  DHEPZ_CHECK_EQ(truncated.Code(), core::ErrorCode::ParseError);
+
+  json::Value overlong;
+  DHEPZ_CHECK_FALSE(json::ParseUtf8(std::string("\xC0\xAF{}"), &overlong).ok());
+}
+
+DHEPZ_TEST(Json, SerializeRoundTripsAndKeepsOrder) {
+  const json::Value value = PARSE_OR_DIE(L"{\"z\": [1, 2.5, \"x\"], \"a\": {\"b\": null}}");
+  const std::wstring pretty = json::Serialize(value);
+  DHEPZ_CHECK(pretty.back() == L'\n');
+  const json::Value reparsed = PARSE_OR_DIE(pretty);
+  DHEPZ_CHECK_EQ(reparsed.members()[0].first, std::wstring(L"z"));
+  DHEPZ_CHECK_EQ(reparsed.members()[1].first, std::wstring(L"a"));
+  DHEPZ_CHECK_EQ(reparsed.ObjectField(L"a")->Find(L"b")->is_null(), true);
+
+  // Compact form is one line and parses back to the same shape.
+  const std::wstring compact = json::Serialize(value, false);
+  DHEPZ_CHECK(compact.find(L'\n') == std::wstring::npos);
+  const json::Value compact_reparsed = PARSE_OR_DIE(compact);
+  DHEPZ_CHECK_EQ(compact_reparsed.ArrayField(L"z")->size(), static_cast<std::size_t>(3));
+}
+
+DHEPZ_TEST(Json, NumbersKeepTheirVerbatimText) {
+  const json::Value value = PARSE_OR_DIE(L"{\"n\": 1.500}");
+  const json::Value* n = value.Find(L"n");
+  DHEPZ_CHECK(n != nullptr);
+  DHEPZ_CHECK_EQ(n->AsNumber(), 1.5);
+  DHEPZ_CHECK_EQ(n->AsString(), std::wstring(L"1.500"));
+  // Serialize writes the verbatim form back, so a rewrite does not reformat
+  // numbers the user typed.
+  DHEPZ_CHECK_CONTAINS(json::Serialize(value, false), std::wstring(L"1.500"));
+}
+
+DHEPZ_TEST(Json, MutatorsKeepPositionSemantics) {
+  json::Value object = json::Value::Object();
+  object.Set(L"b", json::Value::Number(1.0));
+  object.Set(L"a", json::Value::Number(2.0));
+  object.Set(L"b", json::Value::Number(3.0));  // replace in place, no move
+  DHEPZ_CHECK_EQ(object.members()[0].first, std::wstring(L"b"));
+  DHEPZ_CHECK_EQ(object.NumberField(L"b"), 3.0);
+  object.Remove(L"b");
+  DHEPZ_CHECK_EQ(object.members().size(), static_cast<std::size_t>(1));
+  DHEPZ_CHECK(object.Find(L"b") == nullptr);
+}


### PR DESCRIPTION
Closes #6.

## Summary
- `src/core/json.{h,cpp}` — ported from `Teminal/src/logic/storage/json` with `core::Status` returns (continuing the standing judgement call):
  - **Ordered members** preserved end-to-end (parse and serialize) — the UI resolver lays screens out in declaration order (G3).
  - **Hard depth limit** (`kMaxDepth = 512`): adversarial or accidental deep nesting is a `ParseError`, not a stack overflow.
  - **Errors name what was expected plus 1-based line and column**: `Expected ':' after the member name (line 2, column 9)`.
  - **Fallback typed access** — `StringField`/`BoolField`/`NumberField(key, default)`, `Find()` → nullptr; absent or wrong-typed optional fields are defaults, not errors.
  - **UTF-8 in / UTF-16 out** via `ParseUtf8`: BOM bytes stripped, strict decode — invalid bytes are a `ParseError`, never a silent empty document (the old blank-UI failure mode).
  - **Strict format**: trailing commas and comments rejected, no garbage after the top-level value — accepted input round-trips through `ConvertFrom-Json`.
  - Duplicate keys keep the last value at the first key's position; numbers keep verbatim text so rewrites do not reformat user-typed values; `\uD83D\uDE00` surrogate pairs are kept well-formed.
- **Layering call:** `ParseUtf8` carries its own strict UTF-8 decoder (truncation, bad continuation, overlong, surrogate range all rejected). `core/` cannot call `str::FromUtf8` — it is Win32-based and `platform/` is a layer up — so "core knows nothing about Windows" stays absolute. Both decoders are pinned by their own tests.
- `core/` stays standard-library-only; no `windows.h` anywhere in the folder.

## Test plan
- [x] 16 new tests picked up by the glob, no project edit, covering every mandated verification: order preservation, depth-limit rejection (**10,000-deep arrays and objects error, no crash**; 100-deep still parses), error line/column accuracy, BOM handling on both entry points, duplicate keys.
- [x] Plus: fallback access, trailing-comma/comment/garbage rejection, malformed literals and numbers, control-character rejection, escape handling incl. surrogate pairs, serialize round-trips (pretty + compact), verbatim numbers, `Set`/`Remove` position semantics.
- [x] `tools\Test.ps1` green: 77/77 Debug and 77/77 Release.
- [x] New files LF-only, verified byte-wise.