### PR TITLE
feat(platform): add ETW trace with named milestones and ResourceSnapshot (#10)

### DIFF
--- a/src/platform/performance_trace.cpp
+++ b/src/platform/performance_trace.cpp
@@ -1,0 +1,213 @@
+#include "platform/performance_trace.h"
+
+#include <windows.h>
+#include <psapi.h>
+#include <TraceLoggingProvider.h>
+
+// A fresh GUID, not the old Terminal's: two providers registered with the
+// same ID would collide if both binaries ever ran side by side.
+TRACELOGGING_DEFINE_PROVIDER(
+    g_dhepz_performance_provider, "Yuzha.Dhepz.Performance",
+    (0x8f2c41d6, 0x9b7a, 0x4e53, 0xa1, 0xc8, 0x3d, 0x6e, 0xf5, 0x2b, 0x9a, 0x04));
+
+namespace trace {
+namespace {
+
+bool g_registered = false;
+
+struct WindowCounter {
+  DWORD process_id = 0;
+  std::uint32_t count = 0;
+};
+
+BOOL CALLBACK CountChildWindow(HWND, LPARAM value) noexcept {
+  auto* counter = reinterpret_cast<WindowCounter*>(value);
+  ++counter->count;
+  return TRUE;
+}
+
+BOOL CALLBACK CountTopLevelWindow(HWND window, LPARAM value) noexcept {
+  auto* counter = reinterpret_cast<WindowCounter*>(value);
+  DWORD process_id = 0;
+  GetWindowThreadProcessId(window, &process_id);
+  if (process_id != counter->process_id) {
+    return TRUE;
+  }
+  ++counter->count;
+  EnumChildWindows(window, CountChildWindow, value);
+  return TRUE;
+}
+
+const wchar_t* CacheName(const ResourceSnapshot& snapshot, std::size_t index) {
+  return index < snapshot.cache_count ? snapshot.caches[index].name : L"";
+}
+
+std::uint64_t CacheSize(const ResourceSnapshot& snapshot, std::size_t index) {
+  return index < snapshot.cache_count ? snapshot.caches[index].size : 0;
+}
+
+}  // namespace
+
+PerformanceTraceSession::PerformanceTraceSession(std::int64_t process_entry_qpc) noexcept {
+  registered_ = TraceLoggingRegister(g_dhepz_performance_provider) == ERROR_SUCCESS;
+  g_registered = registered_;
+  if (!registered_) {
+    return;
+  }
+  TraceLoggingWrite(g_dhepz_performance_provider, "ProcessEntry",
+                    TraceLoggingInt64(process_entry_qpc, "Qpc"));
+}
+
+PerformanceTraceSession::~PerformanceTraceSession() {
+  if (registered_) {
+    g_registered = false;
+    TraceLoggingUnregister(g_dhepz_performance_provider);
+  }
+}
+
+bool TraceActive() noexcept { return g_registered; }
+
+std::int64_t CurrentQpc() noexcept {
+  LARGE_INTEGER counter{};
+  return QueryPerformanceCounter(&counter) ? counter.QuadPart : 0;
+}
+
+void TraceConfigResolved() noexcept {
+  if (g_registered) {
+    TraceLoggingWrite(g_dhepz_performance_provider, "ConfigResolved",
+                      TraceLoggingInt64(CurrentQpc(), "Qpc"));
+  }
+}
+
+void TraceRenderBufferReady() noexcept {
+  if (g_registered) {
+    TraceLoggingWrite(g_dhepz_performance_provider, "RenderBufferReady",
+                      TraceLoggingInt64(CurrentQpc(), "Qpc"));
+  }
+}
+
+void TraceFirstLayoutComplete() noexcept {
+  if (g_registered) {
+    TraceLoggingWrite(g_dhepz_performance_provider, "FirstLayoutComplete",
+                      TraceLoggingInt64(CurrentQpc(), "Qpc"));
+  }
+}
+
+void TraceFirstPresentComplete() noexcept {
+  if (g_registered) {
+    TraceLoggingWrite(g_dhepz_performance_provider, "FirstPresentComplete",
+                      TraceLoggingInt64(CurrentQpc(), "Qpc"));
+  }
+}
+
+void TraceFirstFrameVisible() noexcept {
+  if (g_registered) {
+    TraceLoggingWrite(g_dhepz_performance_provider, "FirstFrameVisible",
+                      TraceLoggingInt64(CurrentQpc(), "Qpc"));
+  }
+}
+
+void TraceInputReceived(std::uint64_t correlation_id) noexcept {
+  if (g_registered) {
+    TraceLoggingWrite(g_dhepz_performance_provider, "InputReceived",
+                      TraceLoggingInt64(CurrentQpc(), "Qpc"),
+                      TraceLoggingUInt64(correlation_id, "CorrelationId"));
+  }
+}
+
+void TraceInputVisualPresented(std::uint64_t correlation_id) noexcept {
+  if (g_registered) {
+    TraceLoggingWrite(g_dhepz_performance_provider, "InputVisualPresented",
+                      TraceLoggingInt64(CurrentQpc(), "Qpc"),
+                      TraceLoggingUInt64(correlation_id, "CorrelationId"));
+  }
+}
+
+void TraceNavigationRequested(std::uint64_t correlation_id) noexcept {
+  if (g_registered) {
+    TraceLoggingWrite(g_dhepz_performance_provider, "NavigationRequested",
+                      TraceLoggingInt64(CurrentQpc(), "Qpc"),
+                      TraceLoggingUInt64(correlation_id, "CorrelationId"));
+  }
+}
+
+void TraceNavigationPresented(std::uint64_t correlation_id) noexcept {
+  if (g_registered) {
+    TraceLoggingWrite(g_dhepz_performance_provider, "NavigationPresented",
+                      TraceLoggingInt64(CurrentQpc(), "Qpc"),
+                      TraceLoggingUInt64(correlation_id, "CorrelationId"));
+  }
+}
+
+void TraceResizeFramePresented(std::uint64_t correlation_id) noexcept {
+  if (g_registered) {
+    TraceLoggingWrite(g_dhepz_performance_provider, "ResizeFramePresented",
+                      TraceLoggingInt64(CurrentQpc(), "Qpc"),
+                      TraceLoggingUInt64(correlation_id, "CorrelationId"));
+  }
+}
+
+void TraceScenarioSettled(std::uint64_t correlation_id) noexcept {
+  if (g_registered) {
+    TraceLoggingWrite(g_dhepz_performance_provider, "ScenarioSettled",
+                      TraceLoggingInt64(CurrentQpc(), "Qpc"),
+                      TraceLoggingUInt64(correlation_id, "CorrelationId"));
+  }
+}
+
+ResourceSnapshot CaptureResourceSnapshot() noexcept {
+  ResourceSnapshot snapshot;
+
+  // K32-prefixed form: identical behaviour, exported by kernel32, so the
+  // layer adds no new import library to the project.
+  PROCESS_MEMORY_COUNTERS_EX memory{};
+  memory.cb = sizeof(memory);
+  if (K32GetProcessMemoryInfo(GetCurrentProcess(),
+                              reinterpret_cast<PROCESS_MEMORY_COUNTERS*>(&memory),
+                              sizeof(memory))) {
+    snapshot.private_bytes = memory.PrivateUsage;
+    snapshot.working_set_bytes = memory.WorkingSetSize;
+  }
+
+  const HANDLE process = GetCurrentProcess();
+  snapshot.gdi_objects = GetGuiResources(process, GR_GDIOBJECTS);
+  snapshot.user_objects = GetGuiResources(process, GR_USEROBJECTS);
+
+  WindowCounter windows{GetCurrentProcessId(), 0};
+  EnumWindows(CountTopLevelWindow, reinterpret_cast<LPARAM>(&windows));
+  snapshot.hwnd_count = windows.count;
+
+  return snapshot;
+}
+
+void TraceResourceSnapshot(const ResourceSnapshot& snapshot) noexcept {
+  if (!g_registered) {
+    return;
+  }
+  TraceLoggingWrite(
+      g_dhepz_performance_provider, "ResourceSnapshot",
+      TraceLoggingInt64(CurrentQpc(), "Qpc"),
+      TraceLoggingUInt64(snapshot.private_bytes, "PrivateUsageBytes"),
+      TraceLoggingUInt64(snapshot.working_set_bytes, "WorkingSetBytes"),
+      TraceLoggingUInt32(snapshot.gdi_objects, "GdiObjects"),
+      TraceLoggingUInt32(snapshot.user_objects, "UserObjects"),
+      TraceLoggingUInt32(snapshot.hwnd_count, "HwndCount"),
+      TraceLoggingWideString(CacheName(snapshot, 0), "CacheName0"),
+      TraceLoggingUInt64(CacheSize(snapshot, 0), "CacheSize0"),
+      TraceLoggingWideString(CacheName(snapshot, 1), "CacheName1"),
+      TraceLoggingUInt64(CacheSize(snapshot, 1), "CacheSize1"),
+      TraceLoggingWideString(CacheName(snapshot, 2), "CacheName2"),
+      TraceLoggingUInt64(CacheSize(snapshot, 2), "CacheSize2"),
+      TraceLoggingWideString(CacheName(snapshot, 3), "CacheName3"),
+      TraceLoggingUInt64(CacheSize(snapshot, 3), "CacheSize3"),
+      TraceLoggingWideString(CacheName(snapshot, 4), "CacheName4"),
+      TraceLoggingUInt64(CacheSize(snapshot, 4), "CacheSize4"),
+      TraceLoggingWideString(CacheName(snapshot, 5), "CacheName5"),
+      TraceLoggingUInt64(CacheSize(snapshot, 5), "CacheSize5"),
+      TraceLoggingWideString(CacheName(snapshot, 6), "CacheName6"),
+      TraceLoggingUInt64(CacheSize(snapshot, 6), "CacheSize6"),
+      TraceLoggingWideString(CacheName(snapshot, 7), "CacheName7"),
+      TraceLoggingUInt64(CacheSize(snapshot, 7), "CacheSize7"));
+}
+
+}  // namespace trace

--- a/src/platform/performance_trace.h
+++ b/src/platform/performance_trace.h
@@ -1,0 +1,96 @@
+// Measurement backbone: an ETW TraceLogging provider plus the resource
+// snapshot every leak test asserts on.
+//
+// Without this, every budget in Part 1 of the plan is unfalsifiable and
+// G1/G2 are vibes. The design constraint is G1 itself: the provider costs
+// **nothing when no session is listening** — no logging thread, no file IO,
+// no idle wakeup. Every event function checks one bool and returns; the
+// TraceLogging machinery only runs when a session is attached.
+//
+// Startup is measured as named milestones, ProcessEntry through
+// FirstFrameVisible, each carrying a QueryPerformanceCounter timestamp.
+// Contract for the caller of TraceFirstFrameVisible: call it only after
+// DwmFlush() has returned, so "visible" means actually composited rather
+// than merely submitted.
+//
+// Input-to-paint and route-switch latencies come from correlation-ID pairs:
+// the event that receives the input and the event that presents its visual
+// carry the same ID, so a trace consumer can match them.
+//
+// Like all of platform/, this layer keeps windows.h out of the header.
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+namespace trace {
+
+// Registers the provider and emits ProcessEntry. Exactly one session exists
+// per process, created at startup and destroyed at exit.
+class PerformanceTraceSession final {
+ public:
+  explicit PerformanceTraceSession(std::int64_t process_entry_qpc) noexcept;
+  ~PerformanceTraceSession();
+
+  PerformanceTraceSession(const PerformanceTraceSession&) = delete;
+  PerformanceTraceSession& operator=(const PerformanceTraceSession&) = delete;
+
+ private:
+  bool registered_ = false;
+};
+
+// True while a session holds a registered provider. The event functions use
+// this as their one-instruction gate.
+bool TraceActive() noexcept;
+
+// QueryPerformanceCounter value, for callers that capture a timestamp at an
+// event the trace itself does not own (e.g. the very first line of wWinMain).
+std::int64_t CurrentQpc() noexcept;
+
+// Startup milestones, in the order they fire.
+void TraceConfigResolved() noexcept;
+void TraceRenderBufferReady() noexcept;
+void TraceFirstLayoutComplete() noexcept;
+void TraceFirstPresentComplete() noexcept;
+// Call only after DwmFlush() has returned — see the header comment.
+void TraceFirstFrameVisible() noexcept;
+
+// Correlation-ID pairs: both halves of each pair carry the same ID.
+void TraceInputReceived(std::uint64_t correlation_id) noexcept;
+void TraceInputVisualPresented(std::uint64_t correlation_id) noexcept;
+void TraceNavigationRequested(std::uint64_t correlation_id) noexcept;
+void TraceNavigationPresented(std::uint64_t correlation_id) noexcept;
+void TraceResizeFramePresented(std::uint64_t correlation_id) noexcept;
+void TraceScenarioSettled(std::uint64_t correlation_id) noexcept;
+
+// One struct carries everything a leak test asserts on, so a soak can
+// compare snapshots instead of scraping counters from five APIs.
+struct ResourceSnapshot {
+  struct CacheCounter {
+    const wchar_t* name = L"";
+    std::uint64_t size = 0;
+  };
+  // Bounded by construction: an unbounded counter list would itself be drift.
+  static constexpr std::size_t kMaxCaches = 8;
+
+  std::uint64_t private_bytes = 0;
+  std::uint64_t working_set_bytes = 0;
+  std::uint32_t gdi_objects = 0;
+  std::uint32_t user_objects = 0;
+  std::uint32_t hwnd_count = 0;
+  CacheCounter caches[kMaxCaches];
+  std::size_t cache_count = 0;
+};
+
+// Fills the OS half of a snapshot for the current process: private bytes
+// and working set, GDI/USER object counts, and the number of windows owned
+// by this process (top-level plus children). The cache half is filled by
+// the caller that owns the caches. Pure measurement — emits nothing.
+ResourceSnapshot CaptureResourceSnapshot() noexcept;
+
+// Emits a snapshot as one ResourceSnapshot event. No-op unless a session is
+// active. Cache slots beyond cache_count are emitted as empty/zero so the
+// event shape is fixed and a consumer never parses a variable field list.
+void TraceResourceSnapshot(const ResourceSnapshot& snapshot) noexcept;
+
+}  // namespace trace

--- a/tests/platform/performance_trace_test.cpp
+++ b/tests/platform/performance_trace_test.cpp
@@ -1,0 +1,118 @@
+#include "platform/performance_trace.h"
+
+#include <windows.h>
+
+#include "framework/test_case.h"
+
+DHEPZ_TEST(Trace, SessionLifecycleGatesTheEvents) {
+  DHEPZ_CHECK_FALSE(trace::TraceActive());
+
+  {
+    trace::PerformanceTraceSession session(trace::CurrentQpc());
+    DHEPZ_CHECK(trace::TraceActive());
+
+    // Every event function must be safe with a live session...
+    trace::TraceConfigResolved();
+    trace::TraceRenderBufferReady();
+    trace::TraceFirstLayoutComplete();
+    trace::TraceFirstPresentComplete();
+    trace::TraceFirstFrameVisible();
+    trace::TraceInputReceived(1);
+    trace::TraceInputVisualPresented(1);
+    trace::TraceNavigationRequested(2);
+    trace::TraceNavigationPresented(2);
+    trace::TraceResizeFramePresented(3);
+    trace::TraceScenarioSettled(3);
+    trace::TraceResourceSnapshot(trace::CaptureResourceSnapshot());
+  }
+
+  // ...and after the session is gone the gate is closed again.
+  DHEPZ_CHECK_FALSE(trace::TraceActive());
+  trace::TraceConfigResolved();
+  trace::TraceInputReceived(9);
+  trace::TraceResourceSnapshot(trace::CaptureResourceSnapshot());
+}
+
+// The criterion: snapshot counters match a known-good manual reading of the
+// same APIs, taken back-to-back so nothing else can move between them.
+DHEPZ_TEST(Trace, SnapshotMatchesManualCounters) {
+  const trace::ResourceSnapshot snapshot = trace::CaptureResourceSnapshot();
+  const HANDLE process = GetCurrentProcess();
+
+  DHEPZ_CHECK_EQ(static_cast<unsigned long long>(snapshot.gdi_objects),
+                 static_cast<unsigned long long>(GetGuiResources(process, GR_GDIOBJECTS)));
+  DHEPZ_CHECK_EQ(static_cast<unsigned long long>(snapshot.user_objects),
+                 static_cast<unsigned long long>(GetGuiResources(process, GR_USEROBJECTS)));
+  DHEPZ_CHECK(snapshot.private_bytes > 0);
+  DHEPZ_CHECK(snapshot.working_set_bytes > 0);
+}
+
+DHEPZ_TEST(Trace, SnapshotSeesGdiObjectsComeAndGo) {
+  const trace::ResourceSnapshot before = trace::CaptureResourceSnapshot();
+
+  HFONT fonts[3] = {};
+  for (int i = 0; i < 3; ++i) {
+    fonts[i] = CreateFontW(12, 0, 0, 0, FW_NORMAL, FALSE, FALSE, FALSE, DEFAULT_CHARSET,
+                           OUT_DEFAULT_PRECIS, CLIP_DEFAULT_PRECIS, DEFAULT_QUALITY,
+                           DEFAULT_PITCH, L"dhepz trace test");
+    DHEPZ_CHECK(fonts[i] != nullptr);
+  }
+  const trace::ResourceSnapshot with_fonts = trace::CaptureResourceSnapshot();
+  DHEPZ_CHECK_EQ(static_cast<unsigned long long>(with_fonts.gdi_objects - before.gdi_objects),
+                 static_cast<unsigned long long>(3));
+
+  for (HFONT font : fonts) {
+    DeleteObject(font);
+  }
+  const trace::ResourceSnapshot after = trace::CaptureResourceSnapshot();
+  DHEPZ_CHECK_EQ(static_cast<unsigned long long>(after.gdi_objects),
+                 static_cast<unsigned long long>(before.gdi_objects));
+}
+
+DHEPZ_TEST(Trace, SnapshotCountsThisProcessWindowsOnly) {
+  const trace::ResourceSnapshot before = trace::CaptureResourceSnapshot();
+
+  WNDCLASSW window_class{};
+  window_class.lpfnWndProc = DefWindowProcW;
+  window_class.hInstance = GetModuleHandleW(nullptr);
+  window_class.lpszClassName = L"dhepz_trace_test_window";
+  DHEPZ_CHECK(RegisterClassW(&window_class) != 0);
+  HWND window = CreateWindowExW(0, window_class.lpszClassName, L"", WS_POPUP, 0, 0, 16, 16,
+                                nullptr, nullptr, window_class.hInstance, nullptr);
+  DHEPZ_CHECK(window != nullptr);
+
+  const trace::ResourceSnapshot with_window = trace::CaptureResourceSnapshot();
+  // At least the window just created. Windows may add an auxiliary window of
+  // its own (input method machinery) on a process's first window, so the
+  // delta is "grew" rather than "exactly one" — what matters is that only
+  // this process's windows are counted and that they all go away again.
+  DHEPZ_CHECK(with_window.hwnd_count > before.hwnd_count);
+
+  DestroyWindow(window);
+  UnregisterClassW(window_class.lpszClassName, window_class.hInstance);
+  const trace::ResourceSnapshot after = trace::CaptureResourceSnapshot();
+  DHEPZ_CHECK_EQ(static_cast<unsigned long long>(after.hwnd_count),
+                 static_cast<unsigned long long>(before.hwnd_count));
+}
+
+DHEPZ_TEST(Trace, SnapshotCarriesBoundedCacheCounters) {
+  trace::ResourceSnapshot snapshot = trace::CaptureResourceSnapshot();
+  snapshot.caches[0] = {L"fonts", 12};
+  snapshot.caches[1] = {L"brushes", 3};
+  snapshot.cache_count = 2;
+
+  // Emitting a populated snapshot must be safe with or without a session.
+  trace::TraceResourceSnapshot(snapshot);
+  {
+    trace::PerformanceTraceSession session(trace::CurrentQpc());
+    trace::TraceResourceSnapshot(snapshot);
+  }
+  DHEPZ_CHECK_EQ(trace::ResourceSnapshot::kMaxCaches, static_cast<std::size_t>(8));
+}
+
+DHEPZ_TEST(Trace, QpcIsMonotonic) {
+  const std::int64_t first = trace::CurrentQpc();
+  const std::int64_t second = trace::CurrentQpc();
+  DHEPZ_CHECK(first > 0);
+  DHEPZ_CHECK(second >= first);
+}


### PR DESCRIPTION
Closes #10.

## Summary
- `src/platform/performance_trace.{h,cpp}` — ported from `Teminal/src/instrumentation/performance_trace` with a **fresh provider GUID and name** (`Yuzha.Dhepz.Performance`; the old GUID would collide if both binaries ever ran side by side).
- **Zero cost when no session listens** (G1): every event function checks one bool and returns; the layer creates no thread, no file IO, no wakeup. `TraceLoggingWrite` only runs while a session is attached.
- **Named startup milestones** with QPC timestamps: `ProcessEntry` → `ConfigResolved` → `RenderBufferReady` → `FirstLayoutComplete` → `FirstPresentComplete` → `FirstFrameVisible`. Header pins the contract that `TraceFirstFrameVisible` is called only **after `DwmFlush()` returns**, so "visible" means composited — #11's main supplies that call.
- **Correlation-ID pairs**: `InputReceived`/`InputVisualPresented`, `NavigationRequested`/`NavigationPresented`, `ResizeFramePresented`, `ScenarioSettled` — each pair carries the same ID so a trace consumer can match cause to present.
- **`ResourceSnapshot`** as a capturable struct (private bytes, working set, GDI/USER via `GetGuiResources`, per-process HWND count, bounded cache slots) with `CaptureResourceSnapshot()` separated from emission, so leak tests assert on the struct directly. Cache counters emit as 8 fixed slots because a TraceLogging event shape cannot vary at runtime — fixed shape means consumers never parse a variable field list.
- `Measure-Performance.ps1` criterion **amended on the issue and deferred to #13**: the consumer launches the app, which does not exist until #11 — same reasoning as #12's release.yml deferral.

## Judgement calls
- `VelopackHooksComplete` milestone dropped — no updater exists yet; it returns with the #28 port.
- `K32GetProcessMemoryInfo` instead of the psapi.lib form: identical behaviour, kernel32-exported, so no project-file change was needed.

## Test plan
- [x] 6 new tests picked up by the glob, no project edit: session lifecycle gates every event function; snapshot counters **match manual `GetGuiResources` readings** (the mandated verification) and track a ±3-font delta exactly; HWND counting sees a created window come and go (robust to the auxiliary window Windows adds to a process's first HWND); populated snapshots emit safely with and without a session; QPC monotonic.
- [x] `tools\Test.ps1` green: 83/83 Debug and 83/83 Release.
- [x] New files LF-only, verified byte-wise.
- [ ] "Idle CPU 0.0% with no listener" — structural half is in (no thread/IO exists in the layer); the measured half lands with the #11 tray process soak.