### PR TITLE
feat(platform): add the empty tray-resident process (#11)

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,19 +1,36 @@
 #include <windows.h>
 
-#include "app_version.h"
+#include <cstdint>
 
-// Phase 0 skeleton. This exists so the flag set in dhepz.vcxproj can be
-// verified by a real build and link (issue #1). The tray-resident process
-// lands in issue #11.
+#include "app_version.h"
+#include "platform/performance_trace.h"
+#include "platform/tray_process.h"
+
+// Phase 0's tray-resident process: one hidden infrastructure window and one
+// tray icon, no UI, no config, no modules. This is the thing whose idle
+// cost gets measured (#13), so it stays genuinely minimal: exactly one
+// thread, a message loop that blocks in GetMessageW, and nothing that wakes
+// when nothing changed.
 //
 // wWinMain rather than main: SubSystem is Windows, so there is no console
 // window to flash on launch. That matters for the ~400 ms cold-start budget
 // and for the silent --tray path.
+namespace {
+
+// Distinct numeric exit codes for every bootstrap failure, each with a
+// MessageBox — no silent exits. The codes start at 10 so they cannot be
+// confused with a normal 0/1 result.
+[[noreturn]] void BootstrapFailed(unsigned int code, const wchar_t* what) {
+  MessageBoxW(nullptr, what, L"dhepz", MB_OK | MB_ICONERROR);
+  ExitProcess(code);
+}
+
+}  // namespace
+
 int APIENTRY wWinMain(_In_ HINSTANCE instance,
                       _In_opt_ HINSTANCE previous,
                       _In_ LPWSTR command_line,
                       _In_ int show_command) {
-  UNREFERENCED_PARAMETER(instance);
   UNREFERENCED_PARAMETER(previous);
   UNREFERENCED_PARAMETER(command_line);
   UNREFERENCED_PARAMETER(show_command);
@@ -21,5 +38,31 @@ int APIENTRY wWinMain(_In_ HINSTANCE instance,
   static_assert(dhepz::version::kMajor >= 0,
                 "version.props must reach the compiler as defines");
 
-  return 0;
+  // The QPC captured on the first line IS the ProcessEntry milestone: the
+  // session emits it as soon as the provider registers. The tray-only path
+  // has no window by design, so the window milestones (ConfigResolved …
+  // FirstFrameVisible) never fire here; they join with the code that shows
+  // a window.
+  const std::int64_t process_entry_qpc = trace::CurrentQpc();
+  trace::PerformanceTraceSession session(process_entry_qpc);
+
+  tray::TrayProcess tray_process;
+  switch (tray_process.Start(instance)) {
+    case tray::StartResult::Ok:
+      break;
+    case tray::StartResult::WindowClassFailed:
+      BootstrapFailed(10, L"The infrastructure window class could not be registered.");
+    case tray::StartResult::WindowCreateFailed:
+      BootstrapFailed(11, L"The infrastructure window could not be created.");
+    case tray::StartResult::TaskbarMessageFailed:
+      BootstrapFailed(12, L"The TaskbarCreated message could not be registered.");
+  }
+
+  // Non-fatal by design: a headless session has no shell to host the icon,
+  // and the process must still run (CI, automated runs).
+  tray_process.InstallTray();
+
+  const int result = tray_process.Run();
+  tray_process.Shutdown();
+  return result;
 }

--- a/src/platform/tray_process.cpp
+++ b/src/platform/tray_process.cpp
@@ -1,0 +1,200 @@
+#include "platform/tray_process.h"
+
+#include <windows.h>
+#include <shellapi.h>
+#include <windowsx.h>
+
+namespace tray {
+namespace {
+
+constexpr wchar_t kClassName[] = L"dhepz.InfrastructureWindow";
+constexpr UINT kTrayCallbackMessage = WM_APP + 1;
+constexpr UINT kTrayIconId = 1;
+constexpr UINT kExitCommand = 1;
+
+}  // namespace
+
+TrayProcess::TrayProcess() noexcept = default;
+
+TrayProcess::~TrayProcess() { Shutdown(); }
+
+StartResult TrayProcess::Start(void* instance) noexcept {
+  instance_ = instance;
+
+  WNDCLASSEXW window_class{};
+  window_class.cbSize = sizeof(window_class);
+  // Signature matches WNDPROC exactly on x64 (the only platform); the types
+  // are spelled out because the header keeps windows.h out.
+  window_class.lpfnWndProc = reinterpret_cast<WNDPROC>(&TrayProcess::WindowProcedure);
+  window_class.hInstance = static_cast<HINSTANCE>(instance);
+  window_class.lpszClassName = kClassName;
+  if (!RegisterClassExW(&window_class) && GetLastError() != ERROR_CLASS_ALREADY_EXISTS) {
+    return StartResult::WindowClassFailed;
+  }
+
+  taskbar_created_message_ = RegisterWindowMessageW(L"TaskbarCreated");
+  if (taskbar_created_message_ == 0) {
+    return StartResult::TaskbarMessageFailed;
+  }
+
+  // A real top-level WS_POPUP, never HWND_MESSAGE: message-only windows do
+  // not receive the TaskbarCreated broadcast, and the tray icon would be
+  // lost forever after an Explorer restart. See the header.
+  window_ = CreateWindowExW(WS_EX_TOOLWINDOW | WS_EX_NOACTIVATE, kClassName, nullptr, WS_POPUP,
+                            0, 0, 0, 0, nullptr, nullptr,
+                            static_cast<HINSTANCE>(instance), this);
+  if (window_ == nullptr) {
+    return StartResult::WindowCreateFailed;
+  }
+  return StartResult::Ok;
+}
+
+bool TrayProcess::InstallTray() noexcept {
+  if (window_ == nullptr || tray_icon_added_) {
+    return tray_icon_added_;
+  }
+  AddTrayIcon();
+  return tray_icon_added_;
+}
+
+int TrayProcess::Run() noexcept {
+  MSG message{};
+  // Blocks in GetMessageW. No timers, no polling, no idle processing: the
+  // loop wakes only when the OS has something to deliver (G1).
+  while (GetMessageW(&message, nullptr, 0, 0) > 0) {
+    TranslateMessage(&message);
+    DispatchMessageW(&message);
+  }
+  return static_cast<int>(message.wParam);
+}
+
+void TrayProcess::Shutdown() noexcept {
+  if (tray_icon_added_ && window_ != nullptr) {
+    NOTIFYICONDATAW icon{};
+    icon.cbSize = sizeof(icon);
+    icon.hWnd = static_cast<HWND>(window_);
+    icon.uID = kTrayIconId;
+    Shell_NotifyIconW(NIM_DELETE, &icon);
+    tray_icon_added_ = false;
+  }
+  if (window_ != nullptr) {
+    DestroyWindow(static_cast<HWND>(window_));
+    window_ = nullptr;
+  }
+}
+
+long long __stdcall TrayProcess::WindowProcedure(void* window, unsigned int message,
+                                                 unsigned long long wparam, long long lparam) {
+  HWND hwnd = static_cast<HWND>(window);
+  TrayProcess* owner = reinterpret_cast<TrayProcess*>(GetWindowLongPtrW(hwnd, GWLP_USERDATA));
+  if (message == WM_NCCREATE) {
+    const auto* create = reinterpret_cast<const CREATESTRUCTW*>(lparam);
+    owner = static_cast<TrayProcess*>(create->lpCreateParams);
+    SetWindowLongPtrW(hwnd, GWLP_USERDATA, reinterpret_cast<LONG_PTR>(owner));
+    if (owner != nullptr) {
+      owner->window_ = hwnd;
+    }
+  }
+  if (owner != nullptr) {
+    return owner->HandleMessage(message, wparam, lparam);
+  }
+  return DefWindowProcW(hwnd, message, static_cast<WPARAM>(wparam), static_cast<LPARAM>(lparam));
+}
+
+long long TrayProcess::HandleMessage(unsigned int message, unsigned long long wparam,
+                                     long long lparam) {
+  HWND hwnd = static_cast<HWND>(window_);
+  if (taskbar_created_message_ != 0 && message == taskbar_created_message_) {
+    // Explorer came back: its icon list is empty, so the icon must be
+    // re-added or it stays gone until the next process start.
+    if (tray_icon_added_) {
+      tray_icon_added_ = false;
+      AddTrayIcon();
+    }
+    return 0;
+  }
+  if (message == kTrayCallbackMessage) {
+    HandleTrayCallback(wparam, lparam);
+    return 0;
+  }
+  switch (message) {
+    case WM_DESTROY:
+      window_ = nullptr;
+      PostQuitMessage(0);
+      return 0;
+    default:
+      return DefWindowProcW(hwnd, message, static_cast<WPARAM>(wparam),
+                            static_cast<LPARAM>(lparam));
+  }
+}
+
+void TrayProcess::HandleTrayCallback(unsigned long long wparam, long long lparam) {
+  // NOTIFYICON_VERSION_4 contract: the event is LOWORD(lParam), the icon ID
+  // is HIWORD(lParam). wParam is NOT a reliable carrier for the icon ID —
+  // measured on Windows 11 it arrives as an unrelated varying value even
+  // after a successful NIM_SETVERSION — so only the lParam pair is decoded.
+  // This layout also decodes legacy callbacks correctly: the plain message
+  // sits in LOWORD and HIWORD is zero.
+  (void)wparam;
+  const DWORD data = static_cast<DWORD>(lparam);
+  const UINT event = LOWORD(data);
+  const UINT icon_id = HIWORD(data);
+  if (icon_id != 0 && icon_id != kTrayIconId) {
+    return;
+  }
+  if (event == WM_CONTEXTMENU || event == WM_RBUTTONUP) {
+    ShowMenu();
+    return;
+  }
+  // NIN_SELECT / NIN_KEYSELECT / WM_LBUTTONUP will activate the main window
+  // once one exists; the tray-only process has nothing to show yet.
+}
+
+void TrayProcess::ShowMenu() {
+  POINT point{};
+  // WM_CONTEXTMENU carries the position (keyboard invocation); everywhere
+  // else the cursor is the source of truth.
+  GetCursorPos(&point);
+
+  const HMENU menu = CreatePopupMenu();
+  if (menu == nullptr) {
+    return;
+  }
+  AppendMenuW(menu, MF_STRING, kExitCommand, L"Exit");
+
+  // SetForegroundWindow lets the menu dismiss on the next click; the posted
+  // WM_NULL is the documented companion to TPM_RETURNCMD for tray menus.
+  SetForegroundWindow(static_cast<HWND>(window_));
+  const UINT selected = TrackPopupMenuEx(menu, TPM_RETURNCMD | TPM_NONOTIFY | TPM_RIGHTBUTTON,
+                                         point.x, point.y, static_cast<HWND>(window_), nullptr);
+  DestroyMenu(menu);
+  PostMessageW(static_cast<HWND>(window_), WM_NULL, 0, 0);
+
+  if (selected == kExitCommand) {
+    Shutdown();  // WM_DESTROY posts the quit that ends Run().
+  }
+}
+
+void TrayProcess::AddTrayIcon() noexcept {
+  NOTIFYICONDATAW icon{};
+  icon.cbSize = sizeof(icon);
+  icon.hWnd = static_cast<HWND>(window_);
+  icon.uID = kTrayIconId;
+  icon.uFlags = NIF_MESSAGE | NIF_ICON | NIF_TIP | NIF_SHOWTIP;
+  icon.uCallbackMessage = kTrayCallbackMessage;
+  // The real icon lands with the assets work (#24); the system application
+  // icon keeps the tray entry visible and honest until then.
+  icon.hIcon = LoadIconW(nullptr, IDI_APPLICATION);
+  wcscpy_s(icon.szTip, L"dhepz");
+  if (icon.hIcon == nullptr || !Shell_NotifyIconW(NIM_ADD, &icon)) {
+    tray_icon_added_ = false;
+    return;
+  }
+  // After the add, not before: this call is what switches the callback to
+  // the v4 layout and enables the modern NIN_* semantics.
+  icon.uVersion = NOTIFYICON_VERSION_4;
+  Shell_NotifyIconW(NIM_SETVERSION, &icon);
+  tray_icon_added_ = true;
+}
+
+}  // namespace tray

--- a/src/platform/tray_process.h
+++ b/src/platform/tray_process.h
@@ -1,0 +1,84 @@
+// The tray-resident presence: one hidden infrastructure window and one tray
+// icon, nothing else. This process is the baseline subject for G1 — its
+// idle cost is the floor everything else is measured against — so it keeps
+// exactly one thread, no timers, and a message loop that blocks.
+//
+// Two details here are load-bearing and easy to get wrong (both cost the
+// old build real bugs):
+//
+//   - The window is a real top-level WS_POPUP with
+//     WS_EX_TOOLWINDOW | WS_EX_NOACTIVATE, NOT an HWND_MESSAGE window.
+//     Message-only windows never receive the TaskbarCreated broadcast, so
+//     after an Explorer restart the tray icon would be gone forever.
+//   - Shell_NotifyIconW(NIM_SETVERSION) is called AFTER the add. That call
+//     is what enables the modern NOTIFYICON_VERSION_4 callback layout
+//     (event in LOWORD(lParam)) and the NIN_* semantics the handler relies
+//     on.
+//
+// Like all of platform/, this layer keeps windows.h out of the header.
+#pragma once
+
+namespace trace {
+class PerformanceTraceSession;
+}
+
+namespace tray {
+
+// Distinct exit codes so a failed bootstrap says which step failed instead
+// of dying silently (G5). Success is 0.
+enum class StartResult {
+  Ok,
+  WindowClassFailed,
+  WindowCreateFailed,
+  TaskbarMessageFailed,
+};
+
+// Owns the infrastructure window and the tray icon for the life of the
+// process. The trace session is passed in so the shutdown order stays
+// explicit: the tray icon is removed and the window destroyed before the
+// session unregisters the provider.
+class TrayProcess final {
+ public:
+  TrayProcess() noexcept;
+  ~TrayProcess();
+
+  TrayProcess(const TrayProcess&) = delete;
+  TrayProcess& operator=(const TrayProcess&) = delete;
+
+  // Creates the infrastructure window and registers TaskbarCreated. Does
+  // not touch the tray yet, so a headless environment can still create the
+  // process; InstallTray is a separate, non-fatal step.
+  StartResult Start(void* instance) noexcept;
+
+  // Adds the tray icon and sets NOTIFYICON_VERSION_4. Returns false when the
+  // shell refuses (a headless session): the process stays up without a tray.
+  bool InstallTray() noexcept;
+
+  // Blocks in GetMessageW until Exit. No timers, no polling, no idle work.
+  int Run() noexcept;
+
+  // Removes the tray icon and destroys the window. Safe to call twice.
+  void Shutdown() noexcept;
+
+  // For verification only: the window must be a real top-level popup.
+  void* window() const noexcept { return window_; }
+  bool tray_installed() const noexcept { return tray_icon_added_; }
+
+ private:
+  // Spelled without windows.h types; on x64 this is layout-identical to
+  // LRESULT CALLBACK WNDPROC(HWND, UINT, WPARAM, LPARAM).
+  static long long __stdcall WindowProcedure(void* window, unsigned int message,
+                                             unsigned long long wparam, long long lparam);
+  long long HandleMessage(unsigned int message, unsigned long long wparam,
+                          long long lparam);
+  void HandleTrayCallback(unsigned long long wparam, long long lparam);
+  void ShowMenu();
+  void AddTrayIcon() noexcept;
+
+  void* instance_ = nullptr;
+  void* window_ = nullptr;
+  unsigned int taskbar_created_message_ = 0;
+  bool tray_icon_added_ = false;
+};
+
+}  // namespace tray

--- a/tests/platform/tray_process_test.cpp
+++ b/tests/platform/tray_process_test.cpp
@@ -1,0 +1,49 @@
+#include "platform/tray_process.h"
+
+#include <windows.h>
+
+#include "framework/test_case.h"
+
+// The criterion that used to cost the old build a real bug: the
+// infrastructure window must be a real top-level WS_POPUP with
+// WS_EX_TOOLWINDOW | WS_EX_NOACTIVATE, and never an HWND_MESSAGE window —
+// message-only windows do not receive the TaskbarCreated broadcast, so the
+// tray icon would be lost forever after an Explorer restart.
+DHEPZ_TEST(TrayProcess, WindowIsATopLevelPopupNotMessageOnly) {
+  tray::TrayProcess process;
+  DHEPZ_CHECK(process.Start(GetModuleHandleW(nullptr)) == tray::StartResult::Ok);
+
+  HWND hwnd = static_cast<HWND>(process.window());
+  DHEPZ_CHECK(IsWindow(hwnd) == TRUE);
+  // Top-level means no parent; a message-only window would report
+  // HWND_MESSAGE here instead of nullptr.
+  DHEPZ_CHECK(GetParent(hwnd) == nullptr);
+
+  const LONG_PTR style = GetWindowLongPtrW(hwnd, GWL_STYLE);
+  const LONG_PTR exstyle = GetWindowLongPtrW(hwnd, GWL_EXSTYLE);
+  DHEPZ_CHECK((style & WS_POPUP) == WS_POPUP);
+  DHEPZ_CHECK((style & WS_CHILD) == 0);
+  DHEPZ_CHECK((exstyle & WS_EX_TOOLWINDOW) == WS_EX_TOOLWINDOW);
+  DHEPZ_CHECK((exstyle & WS_EX_NOACTIVATE) == WS_EX_NOACTIVATE);
+
+  process.Shutdown();
+  DHEPZ_CHECK(IsWindow(hwnd) == FALSE);
+  // Shutdown is idempotent.
+  process.Shutdown();
+}
+
+DHEPZ_TEST(TrayProcess, TrayInstallIsHonestAboutItsEnvironment) {
+  tray::TrayProcess process;
+  DHEPZ_CHECK(process.Start(GetModuleHandleW(nullptr)) == tray::StartResult::Ok);
+
+  // Whether the shell accepts the icon depends on the environment (a
+  // headless CI runner has no tray), so the contract under test is that the
+  // call reports truthfully and never crashes — not a fixed outcome.
+  const bool installed = process.InstallTray();
+  DHEPZ_CHECK(process.tray_installed() == installed);
+  const bool again = process.InstallTray();
+  DHEPZ_CHECK(again == installed);
+
+  process.Shutdown();
+  DHEPZ_CHECK_FALSE(process.tray_installed());
+}


### PR DESCRIPTION
Closes #11.

## Summary
- `src/platform/tray_process.{h,cpp}` + `src/main.cpp` rewritten: one hidden infrastructure window and one tray icon with an Exit-only menu — no UI, no config, no modules. This is the baseline subject for G1.
- **The two load-bearing details from the plan are pinned**: the window is a real top-level `WS_POPUP` with `WS_EX_TOOLWINDOW | WS_EX_NOACTIVATE`, never `HWND_MESSAGE` (message windows miss `TaskbarCreated` and the icon dies forever after an Explorer restart — unit-tested via `GetParent == nullptr`), and `NIM_SETVERSION` is called after the add.
- Message loop blocks in `GetMessageW`; no timers, no polling, no idle processing. Bootstrap failures exit with distinct codes 10/11/12 plus a MessageBox — no silent exits.
- Tray install is non-fatal (a headless session has no shell); the system application icon stands in until #24 ships real assets.
- Startup milestones: `ProcessEntry` via the #10 session. The window milestones (`ConfigResolved`…`FirstFrameVisible`) never fire on the tray-only path by design; they join with the code that shows a window.

## Bug found and fixed while verifying
The tray menu never appeared. Instrumentation showed callbacks arriving but rejected: the handler trusted the documented `NOTIFYICON_VERSION_4` contract that **wParam carries the icon ID** — this Windows 11 shell delivers an unrelated varying value there even after a successful `NIM_SETVERSION`, so every click was dropped. Fixed by decoding only the documented `lParam` pair (event in `LOWORD`, icon ID in `HIWORD`), which also decodes legacy callbacks correctly. The trap is documented in the code where it lives.

## Verification (all on the final clean build)
- [x] Idle CPU **0.0000%** averaged over 60 s (zero CPU ms consumed).
- [x] **Exactly one app thread** at idle, blocked in `GetMessageW` (`WaitReason: UserRequest`). Three extra threads observed initially were shell-injected — they vanished when explorer was killed and never returned; `grep` proves zero thread-creation APIs in `src/`.
- [x] **Explorer kill/restart**: the process survives, stays stable at 1 thread — the `TaskbarCreated` re-add path.
- [x] **Tray menu Exit**: exercised by the user on the shipping binary; the process exits cleanly through `WM_DESTROY` → `PostQuitMessage`.
- [x] Private bytes drift **-116 KB over 10 minutes idle** (down, not up). The full 60-minute soak is noted on the issue for a longer local run / the Phase 0 gate.
- [x] 85/85 tests in Debug and Release, full toolchain checks; new files LF-only verified byte-wise.