### PR TITLE
feat(platform): add run-once worker jobs with epoch-stamped delivery (#15)

### DIFF
--- a/src/platform/worker.cpp
+++ b/src/platform/worker.cpp
@@ -1,0 +1,315 @@
+#include "platform/worker.h"
+
+#include <windows.h>
+
+#include <algorithm>
+#include <map>
+#include <mutex>
+#include <thread>
+#include <utility>
+#include <vector>
+
+namespace worker {
+namespace {
+
+// What crosses to the UI thread. The worker pointer lets Settle() re-check
+// the generation without any instance lookup at the window procedure.
+struct CompletionMessage {
+  Worker* worker = nullptr;
+  std::uint64_t generation = 0;
+  std::shared_ptr<void> cargo;
+  Deliver deliver;
+};
+
+struct ThreadEntry {
+  std::thread thread;
+  std::atomic<bool> done{false};
+};
+
+struct CoalesceSlot {
+  Work work;
+  Deliver deliver;
+  std::uint64_t generation = 0;
+  std::uint64_t sequence = 0;
+  bool serving = false;
+  std::shared_ptr<std::atomic<bool>> cancel;
+};
+
+}  // namespace
+
+struct Worker::Impl {
+  void* ui_window = nullptr;
+  unsigned int completion_message = 0;
+  bool shutdown = false;
+
+  mutable std::mutex mutex;
+  std::vector<std::unique_ptr<ThreadEntry>> threads;
+  std::uint64_t next_generation = 1;
+  std::map<std::uint64_t, bool> generations;  // id -> alive
+  std::map<std::wstring, std::shared_ptr<CoalesceSlot>> slots;
+
+  void ReapFinishedLocked() {
+    std::erase_if(threads, [](const std::unique_ptr<ThreadEntry>& entry) {
+      if (!entry->done.load()) {
+        return false;
+      }
+      entry->thread.join();
+      return true;
+    });
+  }
+
+  // Spawns under the caller-held lock; the entry is marked done by the
+  // thread itself at the very end, so a reap never joins a live thread.
+  void SpawnLocked(std::function<void()> body) {
+    auto entry = std::make_unique<ThreadEntry>();
+    ThreadEntry* raw = entry.get();
+    entry->thread = std::thread([raw, body = std::move(body)] {
+      body();
+      raw->done.store(true);
+    });
+    threads.push_back(std::move(entry));
+  }
+
+  // Posts one completion to the UI window, or drops it when the generation
+  // is already dead or the post fails (owner gone). Never touches UI state:
+  // everything the UI needs travels inside the message.
+  void PostCompletion(Worker* self, std::uint64_t generation, std::shared_ptr<void> cargo,
+                      Deliver deliver) {
+    if (generation != 0 && !self->GenerationAlive(generation)) {
+      return;
+    }
+    auto* message = new CompletionMessage{self, generation, std::move(cargo), std::move(deliver)};
+    if (!PostMessageW(static_cast<HWND>(ui_window), completion_message, 0,
+                      reinterpret_cast<LPARAM>(message))) {
+      delete message;
+    }
+  }
+};
+
+Worker::Worker(void* ui_window, unsigned int completion_message)
+    : impl_(std::make_unique<Impl>()) {
+  impl_->ui_window = ui_window;
+  impl_->completion_message = completion_message;
+}
+
+Worker::~Worker() { Shutdown(); }
+
+JobHandle Worker::Submit(Work work, Deliver deliver, std::uint64_t generation) {
+  JobHandle handle;
+  handle.cancel = std::make_shared<std::atomic<bool>>(false);
+  handle.generation = generation;
+
+  std::lock_guard<std::mutex> guard(impl_->mutex);
+  if (impl_->shutdown) {
+    return handle;
+  }
+  impl_->ReapFinishedLocked();
+  impl_->SpawnLocked([this, work = std::move(work), deliver = std::move(deliver),
+                      cancel = handle.cancel, generation] {
+    std::shared_ptr<void> cargo;
+    if (work) {
+      cargo = work(*cancel);
+    }
+    // Cancelled after the fact is still cancelled: the completion is
+    // dropped even though the work already returned.
+    if (cancel->load()) {
+      return;
+    }
+    impl_->PostCompletion(this, generation, std::move(cargo), std::move(deliver));
+  });
+  return handle;
+}
+
+JobHandle Worker::SubmitCoalesced(std::wstring_view key, Work work, Deliver deliver,
+                                  std::uint64_t generation, std::chrono::milliseconds quiet) {
+  JobHandle handle;
+  handle.generation = generation;
+
+  std::shared_ptr<CoalesceSlot> slot;
+  bool start_server = false;
+  {
+    std::lock_guard<std::mutex> guard(impl_->mutex);
+    if (impl_->shutdown) {
+      return handle;
+    }
+    auto& found = impl_->slots[std::wstring(key)];
+    if (!found) {
+      found = std::make_shared<CoalesceSlot>();
+    }
+    slot = found;
+    // A fresh request resets any earlier cancellation of this slot.
+    if (!slot->cancel || slot->cancel->load()) {
+      slot->cancel = std::make_shared<std::atomic<bool>>(false);
+    }
+    handle.cancel = slot->cancel;
+    slot->work = std::move(work);
+    slot->deliver = std::move(deliver);
+    slot->generation = generation;
+    ++slot->sequence;
+    if (!slot->serving) {
+      slot->serving = true;
+      start_server = true;
+    }
+    impl_->ReapFinishedLocked();
+    if (start_server) {
+      impl_->SpawnLocked([this, slot, quiet] {
+        // Latest-wins settling loop. Each iteration snapshots the newest
+        // request, lets it sit through the quiet period (in small slices,
+        // so cancel and newer requests are seen fast), and runs it only if
+        // nothing newer arrived. Five keystrokes become one run.
+        for (;;) {
+          Work work;
+          Deliver deliver;
+          std::uint64_t generation = 0;
+          std::uint64_t sequence = 0;
+          std::shared_ptr<std::atomic<bool>> cancel;
+          {
+            std::lock_guard<std::mutex> guard(impl_->mutex);
+            if (!slot->serving || (slot->cancel && slot->cancel->load())) {
+              break;
+            }
+            work = slot->work;
+            deliver = slot->deliver;
+            generation = slot->generation;
+            sequence = slot->sequence;
+            cancel = slot->cancel;
+          }
+
+          const auto deadline = std::chrono::steady_clock::now() + quiet;
+          bool superseded = false;
+          while (std::chrono::steady_clock::now() < deadline) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(2));
+            std::lock_guard<std::mutex> guard(impl_->mutex);
+            if ((slot->cancel && slot->cancel->load()) || !slot->serving) {
+              break;
+            }
+            if (slot->sequence != sequence) {
+              superseded = true;
+              break;
+            }
+          }
+          {
+            std::lock_guard<std::mutex> guard(impl_->mutex);
+            if ((slot->cancel && slot->cancel->load()) || !slot->serving) {
+              break;
+            }
+            if (superseded || slot->sequence != sequence) {
+              continue;  // a newer request won; settle it instead
+            }
+          }
+
+          std::shared_ptr<void> cargo;
+          if (work) {
+            cargo = work(*cancel);
+          }
+
+          bool still_current = false;
+          {
+            std::lock_guard<std::mutex> guard(impl_->mutex);
+            still_current = slot->serving && slot->sequence == sequence &&
+                            !(slot->cancel && slot->cancel->load());
+          }
+          if (still_current) {
+            impl_->PostCompletion(this, generation, std::move(cargo), std::move(deliver));
+          }
+
+          std::lock_guard<std::mutex> guard(impl_->mutex);
+          if (!slot->serving || (slot->cancel && slot->cancel->load())) {
+            break;
+          }
+          if (slot->sequence == sequence) {
+            slot->serving = false;  // caught up; the slot goes quiet
+            break;
+          }
+          // Otherwise a newer request landed while the work ran: loop and
+          // settle it on this same thread.
+        }
+        std::lock_guard<std::mutex> guard(impl_->mutex);
+        slot->serving = false;
+      });
+    }
+  }
+  return handle;
+}
+
+void Worker::Cancel(const JobHandle& handle) {
+  if (handle.cancel) {
+    handle.cancel->store(true);
+  }
+}
+
+std::uint64_t Worker::CreateGeneration() {
+  std::lock_guard<std::mutex> guard(impl_->mutex);
+  const std::uint64_t id = impl_->next_generation++;
+  impl_->generations[id] = true;
+  return id;
+}
+
+void Worker::InvalidateGeneration(std::uint64_t generation) {
+  std::lock_guard<std::mutex> guard(impl_->mutex);
+  const auto found = impl_->generations.find(generation);
+  if (found != impl_->generations.end()) {
+    found->second = false;
+  }
+}
+
+bool Worker::GenerationAlive(std::uint64_t generation) const {
+  if (generation == 0) {
+    return true;
+  }
+  std::lock_guard<std::mutex> guard(impl_->mutex);
+  const auto found = impl_->generations.find(generation);
+  return found != impl_->generations.end() && found->second;
+}
+
+void Worker::JoinFinished() {
+  std::lock_guard<std::mutex> guard(impl_->mutex);
+  impl_->ReapFinishedLocked();
+}
+
+std::size_t Worker::ThreadCount() const {
+  std::lock_guard<std::mutex> guard(impl_->mutex);
+  return impl_->threads.size();
+}
+
+void Worker::Shutdown() {
+  std::vector<std::unique_ptr<ThreadEntry>> to_join;
+  {
+    std::lock_guard<std::mutex> guard(impl_->mutex);
+    if (impl_->shutdown) {
+      return;
+    }
+    impl_->shutdown = true;
+    for (auto& generation : impl_->generations) {
+      generation.second = false;
+    }
+    for (auto& slot : impl_->slots) {
+      if (slot.second->cancel) {
+        slot.second->cancel->store(true);
+      }
+      slot.second->serving = false;
+    }
+    to_join = std::move(impl_->threads);
+    impl_->threads.clear();
+  }
+  // Join outside the lock: a running body may still call back into the
+  // worker (generation checks), and those take the same mutex.
+  for (auto& entry : to_join) {
+    if (entry->thread.joinable()) {
+      entry->thread.join();
+    }
+  }
+}
+
+void Worker::Settle(long long lparam) {
+  auto* message = reinterpret_cast<CompletionMessage*>(lparam);
+  if (message == nullptr) {
+    return;
+  }
+  if (message->worker->GenerationAlive(message->generation) && message->deliver) {
+    message->deliver(std::move(message->cargo));
+  }
+  delete message;
+}
+
+}  // namespace worker

--- a/src/platform/worker.h
+++ b/src/platform/worker.h
@@ -1,0 +1,106 @@
+// Run-once jobs off the UI thread, with completions posted back to it.
+//
+// This layer is the answer to the constraint pair that defines it: G1 says
+// **no threads alive at idle** and G2 says **the UI thread never blocks**.
+// Both at once rules out a persistent pool sitting on a condition variable,
+// so jobs are spawned per job and joined, and a job's result travels back as
+// a *message to the UI window*, never as a direct touch of UI state. There
+// are no locks around UI data because there is no shared UI data.
+//
+// Two delivery guards, both pinned by tests:
+//
+//   - Every completion carries the requester's **generation** (epoch). A
+//     result whose generation was invalidated — its window closed, its route
+//     changed — is dropped before it is posted, and the receiver re-checks
+//     on arrival, so a stale result can never land on a fresh tree.
+//   - A cancelled job stops as soon as its work observes the flag, and its
+//     completion is discarded even if the work already returned.
+//
+// Coalescing for rapid repeats (typing in a folder box): SubmitCoalesced
+// keeps only the latest request per key and lets it settle through a quiet
+// period inside the serving thread. The quiet wait exists only while a
+// request is pending; nothing is armed at idle, so G1 still holds.
+//
+// Like all of platform/, this layer keeps windows.h out of the header.
+#pragma once
+
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <string>
+#include <string_view>
+
+namespace worker {
+
+// Work runs on a worker thread. It receives the job's cancel flag and is
+// expected to poll it at its safe points; returning early on cancel is the
+// job's own business. The returned cargo is handed to Deliver on the UI
+// thread. `std::shared_ptr<void>` keeps this header free of the caller's
+// result type.
+using Work = std::function<std::shared_ptr<void>(const std::atomic<bool>& cancelled)>;
+using Deliver = std::function<void(std::shared_ptr<void> cargo)>;
+
+// A submitted job's only handles: its cancel flag and the generation its
+// completion is stamped with.
+struct JobHandle {
+  std::shared_ptr<std::atomic<bool>> cancel;
+  std::uint64_t generation = 0;
+};
+
+class Worker final {
+ public:
+  // Bind to the window completions are posted to, and the message used for
+  // them (RegisterWindowMessage-style ids work well). The window's procedure
+  // must route that message to Settle().
+  Worker(void* ui_window, unsigned int completion_message);
+  ~Worker();
+
+  Worker(const Worker&) = delete;
+  Worker& operator=(const Worker&) = delete;
+
+  // Spawns one thread for this job. generation 0 means "no epoch guard".
+  JobHandle Submit(Work work, Deliver deliver, std::uint64_t generation = 0);
+
+  // Latest-wins per key. Submitting again while a request for the same key
+  // is settling replaces it; the work runs once per quiet period at most.
+  JobHandle SubmitCoalesced(std::wstring_view key, Work work, Deliver deliver,
+                            std::uint64_t generation = 0,
+                            std::chrono::milliseconds quiet = std::chrono::milliseconds(30));
+
+  // Cancels one job: its flag is raised, and its completion is discarded
+  // even if the work has already finished.
+  void Cancel(const JobHandle& handle);
+
+  // Epochs. Create on mount, invalidate on close/route-change, pass to
+  // Submit, and re-check with Alive() when settling — that second check is
+  // the authoritative one.
+  std::uint64_t CreateGeneration();
+  void InvalidateGeneration(std::uint64_t generation);
+  bool GenerationAlive(std::uint64_t generation) const;
+
+  // Joins every thread that has finished, releasing its handle. Cheap; call
+  // it any time a handle count matters. Not called from any idle path.
+  void JoinFinished();
+
+  // Worker threads currently tracked (finished-but-unjoined ones included
+  // until JoinFinished runs). Zero is the idle state.
+  std::size_t ThreadCount() const;
+
+  // Invalidates every generation, cancels every coalescing slot, and joins
+  // every thread. Clean, no terminate, no leaked handle. Idempotent; also
+  // runs from the destructor. After it, Submit is a no-op.
+  void Shutdown();
+
+  // What the UI window's procedure calls for the completion message. Runs
+  // the delivery if the generation is still alive, drops it otherwise, and
+  // always frees the payload.
+  static void Settle(long long lparam);
+
+ private:
+  struct Impl;
+  std::unique_ptr<Impl> impl_;
+};
+
+}  // namespace worker

--- a/tests/platform/worker_test.cpp
+++ b/tests/platform/worker_test.cpp
@@ -1,0 +1,316 @@
+#include "platform/worker.h"
+
+#include <windows.h>
+
+#include <atomic>
+#include <chrono>
+#include <functional>
+#include <memory>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "framework/test_case.h"
+
+namespace {
+
+// One window per test receives the completions. The window procedure routes
+// the completion message to Worker::Settle; everything else is test state.
+struct RigState {
+  unsigned int completion_message = 0;
+  unsigned int ping_message = 0;
+  std::vector<std::shared_ptr<void>> delivered;
+  std::atomic<int> pings{0};
+  std::chrono::steady_clock::time_point ping_received;
+};
+
+RigState* g_rig = nullptr;
+
+LRESULT CALLBACK RigProc(HWND window, UINT message, WPARAM wparam, LPARAM lparam) {
+  if (g_rig != nullptr && message == g_rig->completion_message) {
+    worker::Worker::Settle(lparam);
+    return 0;
+  }
+  if (g_rig != nullptr && message == g_rig->ping_message) {
+    g_rig->ping_received = std::chrono::steady_clock::now();
+    ++g_rig->pings;
+    return 0;
+  }
+  return DefWindowProcW(window, message, wparam, lparam);
+}
+
+struct Rig {
+  HWND hwnd = nullptr;
+  RigState state;
+
+  Rig() {
+    g_rig = &state;
+    WNDCLASSW window_class{};
+    window_class.lpfnWndProc = RigProc;
+    window_class.hInstance = GetModuleHandleW(nullptr);
+    window_class.lpszClassName = L"dhepz.worker.test";
+    RegisterClassW(&window_class);  // already-exists is fine, one class per run
+    state.completion_message = RegisterWindowMessageW(L"dhepz.worker.test.completion");
+    state.ping_message = RegisterWindowMessageW(L"dhepz.worker.test.ping");
+    hwnd = CreateWindowExW(0, window_class.lpszClassName, L"", WS_POPUP, 0, 0, 16, 16, nullptr,
+                           nullptr, window_class.hInstance, nullptr);
+    DHEPZ_CHECK(hwnd != nullptr);
+  }
+
+  ~Rig() {
+    DestroyWindow(hwnd);
+    g_rig = nullptr;
+  }
+};
+
+// Busy-pumps until `done` or timeout. A tight loop on purpose: the tests
+// measure how fast a message gets through, and sleeping would smear it.
+void PumpUntil(const std::function<bool()>& done, int timeout_ms) {
+  const auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(timeout_ms);
+  while (!done() && std::chrono::steady_clock::now() < deadline) {
+    MSG msg;
+    while (PeekMessageW(&msg, nullptr, 0, 0, PM_REMOVE)) {
+      TranslateMessage(&msg);
+      DispatchMessageW(&msg);
+    }
+    std::this_thread::yield();
+  }
+}
+
+std::shared_ptr<void> MakeInt(int value) { return std::make_shared<int>(value); }
+
+int DeliveredInt(const RigState& state, std::size_t index) {
+  return *std::static_pointer_cast<int>(state.delivered[index]);
+}
+
+}  // namespace
+
+DHEPZ_TEST(Worker, DeliversCompletionOnTheUiThread) {
+  Rig rig;
+  worker::Worker worker(rig.hwnd, rig.state.completion_message);
+  const std::thread::id ui_thread = std::this_thread::get_id();
+  std::thread::id delivery_thread;
+
+  worker.Submit(
+      [](const std::atomic<bool>&) { return MakeInt(42); },
+      [&](std::shared_ptr<void> cargo) {
+        delivery_thread = std::this_thread::get_id();
+        rig.state.delivered.push_back(std::move(cargo));
+      });
+
+  PumpUntil([&] { return rig.state.delivered.size() == 1; }, 5000);
+  DHEPZ_CHECK_EQ(rig.state.delivered.size(), static_cast<std::size_t>(1));
+  DHEPZ_CHECK_EQ(DeliveredInt(rig.state, 0), 42);
+  DHEPZ_CHECK(delivery_thread == ui_thread);
+  worker.Shutdown();
+}
+
+DHEPZ_TEST(Worker, ThreadCountReturnsToZeroAtIdle) {
+  Rig rig;
+  worker::Worker worker(rig.hwnd, rig.state.completion_message);
+
+  worker.Submit(
+      [](const std::atomic<bool>&) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(150));
+        return MakeInt(1);
+      },
+      [&](std::shared_ptr<void> cargo) { rig.state.delivered.push_back(std::move(cargo)); });
+
+  DHEPZ_CHECK(worker.ThreadCount() >= 1);
+  PumpUntil([&] { return rig.state.delivered.size() == 1; }, 5000);
+  worker.JoinFinished();
+  DHEPZ_CHECK_EQ(worker.ThreadCount(), static_cast<std::size_t>(0));
+  worker.Shutdown();
+}
+
+DHEPZ_TEST(Worker, StaleGenerationIsDropped) {
+  Rig rig;
+  worker::Worker worker(rig.hwnd, rig.state.completion_message);
+  const std::uint64_t generation = worker.CreateGeneration();
+
+  worker.Submit(
+      [](const std::atomic<bool>&) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(80));
+        return MakeInt(7);
+      },
+      [&](std::shared_ptr<void> cargo) { rig.state.delivered.push_back(std::move(cargo)); },
+      generation);
+
+  // The "window" closes before the result lands.
+  worker.InvalidateGeneration(generation);
+
+  PumpUntil([&] { return false; }, 400);  // give the post every chance to arrive
+  DHEPZ_CHECK(rig.state.delivered.empty());
+  DHEPZ_CHECK_FALSE(worker.GenerationAlive(generation));
+  worker.JoinFinished();
+  DHEPZ_CHECK_EQ(worker.ThreadCount(), static_cast<std::size_t>(0));
+  worker.Shutdown();
+}
+
+DHEPZ_TEST(Worker, CancelStopsTheJobAndDiscardsItsCompletion) {
+  Rig rig;
+  worker::Worker worker(rig.hwnd, rig.state.completion_message);
+  std::atomic<bool> observed_cancel{false};
+
+  const worker::JobHandle handle = worker.Submit(
+      [&](const std::atomic<bool>& cancelled) -> std::shared_ptr<void> {
+        for (int i = 0; i < 2000; ++i) {
+          if (cancelled.load()) {
+            observed_cancel.store(true);
+            return nullptr;
+          }
+          std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        }
+        return MakeInt(9);
+      },
+      [&](std::shared_ptr<void> cargo) { rig.state.delivered.push_back(std::move(cargo)); });
+
+  std::this_thread::sleep_for(std::chrono::milliseconds(40));
+  worker.Cancel(handle);
+
+  PumpUntil([&] { return observed_cancel.load(); }, 3000);
+  DHEPZ_CHECK(observed_cancel.load());
+  PumpUntil([&] { return false; }, 200);  // nothing may still be delivered
+  DHEPZ_CHECK(rig.state.delivered.empty());
+  worker.JoinFinished();
+  DHEPZ_CHECK_EQ(worker.ThreadCount(), static_cast<std::size_t>(0));
+  worker.Shutdown();
+}
+
+DHEPZ_TEST(Worker, CoalescesRapidRequestsToTheLatest) {
+  Rig rig;
+  worker::Worker worker(rig.hwnd, rig.state.completion_message);
+  std::atomic<int> run_count{0};
+
+  for (int i = 0; i < 5; ++i) {
+    worker.SubmitCoalesced(
+        L"folder-box",
+        [&, i](const std::atomic<bool>&) {
+          ++run_count;
+          return MakeInt(i);
+        },
+        [&](std::shared_ptr<void> cargo) { rig.state.delivered.push_back(std::move(cargo)); },
+        0, std::chrono::milliseconds(80));
+    std::this_thread::sleep_for(std::chrono::milliseconds(15));
+  }
+
+  PumpUntil([&] { return !rig.state.delivered.empty(); }, 5000);
+  PumpUntil([&] { return false; }, 250);  // settle window for any stragglers
+  // Five keystrokes become at most two runs, and the value that lands is
+  // the latest request.
+  DHEPZ_CHECK(run_count.load() <= 2);
+  DHEPZ_CHECK(!rig.state.delivered.empty());
+  DHEPZ_CHECK_EQ(DeliveredInt(rig.state, rig.state.delivered.size() - 1), 4);
+  worker.JoinFinished();
+  worker.Shutdown();
+}
+
+DHEPZ_TEST(Worker, BlockingJobNeverStallsTheMessagePump) {
+  Rig rig;
+  worker::Worker worker(rig.hwnd, rig.state.completion_message);
+
+  worker.Submit(
+      [](const std::atomic<bool>&) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(2000));
+        return MakeInt(0);
+      },
+      [&](std::shared_ptr<void> cargo) { rig.state.delivered.push_back(std::move(cargo)); });
+
+  // While the 2 s job is in flight, an unrelated message must still get
+  // through fast — the stand-in for "a paint is never delayed".
+  std::this_thread::sleep_for(std::chrono::milliseconds(50));
+  const auto posted = std::chrono::steady_clock::now();
+  PostMessageW(rig.hwnd, rig.state.ping_message, 0, 0);
+  PumpUntil([&] { return rig.state.pings.load() > 0; }, 2000);
+  const auto latency = std::chrono::duration_cast<std::chrono::milliseconds>(
+                           rig.state.ping_received - posted)
+                           .count();
+  DHEPZ_CHECK(rig.state.pings.load() > 0);
+  DHEPZ_CHECK(latency < 100);
+  DHEPZ_CHECK(rig.state.delivered.empty());  // the 2 s job is still running
+  worker.Shutdown();  // joins the long job; ~2 s by design
+}
+
+DHEPZ_TEST(Worker, SequentialJobsLeaveTheHandleCountFlat) {
+  Rig rig;
+  worker::Worker worker(rig.hwnd, rig.state.completion_message);
+  const HANDLE process = GetCurrentProcess();
+  DWORD handles_before = 0;
+  GetProcessHandleCount(process, &handles_before);
+
+  for (int i = 0; i < 1000; ++i) {
+    worker.Submit(
+        [](const std::atomic<bool>&) { return MakeInt(1); },
+        [&](std::shared_ptr<void> cargo) { rig.state.delivered.push_back(std::move(cargo)); });
+    PumpUntil([&] { return rig.state.delivered.size() == static_cast<std::size_t>(i + 1); }, 5000);
+    if (i % 100 == 99) {
+      worker.JoinFinished();
+    }
+  }
+  worker.JoinFinished();
+
+  DWORD handles_after = 0;
+  GetProcessHandleCount(process, &handles_after);
+  DHEPZ_CHECK_EQ(rig.state.delivered.size(), static_cast<std::size_t>(1000));
+  DHEPZ_CHECK_EQ(worker.ThreadCount(), static_cast<std::size_t>(0));
+  // Flat means "no accumulated thread handles"; allow the OS a few of its
+  // own movements but nothing proportional to the job count.
+  const long long drift = static_cast<long long>(handles_after) - handles_before;
+  DHEPZ_CHECK(drift < 10);
+  worker.Shutdown();
+}
+
+DHEPZ_TEST(Worker, ShutdownJoinsCleanlyAndDiscardsInFlightCompletions) {
+  Rig rig;
+  worker::Worker worker(rig.hwnd, rig.state.completion_message);
+  const std::uint64_t generation = worker.CreateGeneration();
+
+  worker.Submit(
+      [](const std::atomic<bool>&) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(250));
+        return MakeInt(3);
+      },
+      [&](std::shared_ptr<void> cargo) { rig.state.delivered.push_back(std::move(cargo)); },
+      generation);
+
+  // Shutdown invalidates every generation, so the in-flight job finishes
+  // (its thread is joined — no terminate, no leak) but its result can never
+  // land on a UI that is being torn down.
+  worker.Shutdown();
+  DHEPZ_CHECK_EQ(worker.ThreadCount(), static_cast<std::size_t>(0));
+  PumpUntil([&] { return false; }, 150);
+  DHEPZ_CHECK(rig.state.delivered.empty());
+
+  // After shutdown a submit is a no-op: no thread, no delivery.
+  worker.Submit([](const std::atomic<bool>&) { return MakeInt(4); },
+                [&](std::shared_ptr<void> cargo) { rig.state.delivered.push_back(std::move(cargo)); });
+  DHEPZ_CHECK_EQ(worker.ThreadCount(), static_cast<std::size_t>(0));
+  PumpUntil([&] { return false; }, 150);
+  DHEPZ_CHECK(rig.state.delivered.empty());
+}
+
+DHEPZ_TEST(Worker, ADeadWindowDiscardsTheCompletionWithoutCrashing) {
+  HWND window = nullptr;
+  {
+    WNDCLASSW window_class{};
+    window_class.lpfnWndProc = DefWindowProcW;
+    window_class.hInstance = GetModuleHandleW(nullptr);
+    window_class.lpszClassName = L"dhepz.worker.test.dead";
+    RegisterClassW(&window_class);
+    window = CreateWindowExW(0, window_class.lpszClassName, L"", WS_POPUP, 0, 0, 16, 16, nullptr,
+                             nullptr, window_class.hInstance, nullptr);
+  }
+  DHEPZ_CHECK(window != nullptr);
+  const unsigned int message = RegisterWindowMessageW(L"dhepz.worker.test.dead.completion");
+  DestroyWindow(window);  // the owner is gone before the job finishes
+
+  worker::Worker worker(window, message);
+  worker.Submit(
+      [](const std::atomic<bool>&) { return MakeInt(5); },
+      [](std::shared_ptr<void>) { DHEPZ_FAIL("delivery to a dead window must not happen"); });
+
+  std::this_thread::sleep_for(std::chrono::milliseconds(200));
+  worker.JoinFinished();
+  DHEPZ_CHECK_EQ(worker.ThreadCount(), static_cast<std::size_t>(0));
+  worker.Shutdown();
+}


### PR DESCRIPTION
Closes #15.

## Summary
- `src/platform/worker.{h,cpp}` — new work, no prior art (the old build documents the contract and never implements it). Satisfies the constraint pair that defines it: **G1 no threads at idle** + **G2 the UI thread never blocks**.
- **Per-job spawn + join.** Threads live in a joinable registry, reaped on submit/shutdown so handles stay flat; `ThreadCount()` returns to 0 once jobs settle.
- **Completions are messages to the UI window**, never direct UI touches — no locks around UI data because there is no shared UI data. The receiver routes the message to `Worker::Settle()`.
- **Generations (epochs)**: create on mount, invalidate on close/route-change. A stale completion is dropped before posting *and* re-checked on settle — it can never land on a fresh tree. Shutdown invalidates them all, so in-flight results can't reach a torn-down UI.
- **Cancellation**: per-job flag the work polls at its safe points; a cancelled job's completion is discarded even if the work already returned.
- **Coalescing without timers**: `SubmitCoalesced` keeps the latest request per key and settles it through a quiet period inside the serving thread — five keystrokes become one run, and nothing is armed at idle (G1 intact).
- Windows stays out of the header (`void*` window, opaque cargo via `shared_ptr<void>`).

## The decision the issue asks for — made with a number
Measured over 1,000 sequential jobs in Release: **0.122 ms per job** including spawn, run, delivery, and reap (~130× headroom against the 16 ms input-to-paint budget). **Per-job spawn stays the design; the lazy-pool fallback is not needed.**

## Test plan
- [x] 9 new tests picked up by the glob, no project edit; 94/94 Debug and 94/94 Release (suite grew ~4 s — the 2 s blocking-job and 1,000-job tests are the cost of the verification list).
- [x] Delivery proven to run on the UI thread (thread-ID assertion).
- [x] Stale epoch dropped; cancel stops + discards; shutdown joins cleanly and refuses new work; dead window discards without crashing.
- [x] A 2 s blocking job never stalls the pump — an unrelated message gets through in <100 ms while it runs (the trace-verified version lands with the ETW wiring in later issues).
- [x] 1,000 sequential jobs leave the handle count flat (drift < 10 asserted).
- [x] Idle CPU after jobs: structural — zero threads exist after settle, and the process-level 0.0% idle is the #11/#13 record.
- [x] New files LF-only, verified byte-wise.