### PR TITLE
feat(render): define the RenderBackend interface, the Direct2D seam (#16)

### DIFF
--- a/src/render/render_backend.h
+++ b/src/render/render_backend.h
@@ -1,0 +1,174 @@
+// The rendering seam: the full drawing surface the UI is allowed to use,
+// declared before any implementation exists behind it.
+//
+// HYRUM'S LAW NOTE — read before changing anything in this header.
+// Fourteen components, the window frame, and the theme layer will be written
+// against this surface. Every signature, enum value, and documented behaviour
+// here becomes a contract the moment the second consumer exists. A change
+// after that point touches all of them. If this interface must change, the
+// reason goes in the PR, and the Phase 1 gate (#23) is where such a decision
+// is still cheap. Direct2D is the planned escape hatch — it is only taken if
+// GDI misses the responsiveness targets, and this header is what keeps that
+// swap a contained change instead of a rewrite.
+//
+// THE CONTRACT
+//
+// Ownership and lifetime
+//   - The backend owns every resource it hands out. Callers hold handles,
+//     never the resources. Image handles must be released with ReleaseImage;
+//     everything else (fonts, brushes, pens, buffers) is backend-internal
+//     and bounded by the cache layer.
+//   - Fonts are not handles at all: callers describe text with a TextStyle
+//     value, and the backend resolves it to a cached font internally. This
+//     keeps the hot path allocation-free of resource bookkeeping and lets
+//     the cache key fonts by (style, dpi, epoch).
+//
+// Paint scope
+//   - Drawing calls (Fill*, Stroke*, Draw*, Push*/Pop*) are valid only
+//     between BeginFrame and EndFrame. Outside that scope they are errors.
+//   - MeasureText, LoadImage, ReleaseImage, Resize, and SetDpi are valid at
+//     any time. Measurement in particular MUST work without a live paint
+//     scope: layout runs before paint, often several times per frame.
+//
+// Frames and presentation
+//   - The shell calls Resize whenever the window size or DPI changes, then
+//     BeginFrame(dirty) to open a frame clipped to the dirty region, draws,
+//     EndFrame, and Present(window) to put the buffer on screen. Nothing is
+//     presented that was not drawn this frame into the back buffer.
+//
+// DPI
+//   - SetDpi changes the scale all metrics and drawing are expressed in.
+//     A DPI change implies a resource-epoch bump: cached fonts and tiles
+//     from the old DPI are invalid and are rebuilt lazily. Callers do not
+//     scale coordinates themselves; they draw in logical pixels at the
+//     current DPI.
+//
+// This header is standard library only. If a Win32 type ever appears here,
+// the seam no longer exists — the check is a grep, and it is part of the
+// acceptance criteria.
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <string_view>
+
+namespace render {
+
+// --- Value types -----------------------------------------------------------
+
+struct Color {
+  std::uint8_t r = 0;
+  std::uint8_t g = 0;
+  std::uint8_t b = 0;
+  std::uint8_t a = 255;
+};
+
+struct Point {
+  float x = 0.0f;
+  float y = 0.0f;
+};
+
+struct Size {
+  float width = 0.0f;
+  float height = 0.0f;
+};
+
+struct Rect {
+  float x = 0.0f;
+  float y = 0.0f;
+  float width = 0.0f;
+  float height = 0.0f;
+
+  float right() const { return x + width; }
+  float bottom() const { return y + height; }
+  bool empty() const { return width <= 0.0f || height <= 0.0f; }
+  bool contains(Point p) const {
+    return p.x >= x && p.x < right() && p.y >= y && p.y < bottom();
+  }
+};
+
+// Per-corner radii so a card can round two corners and not the others.
+struct CornerRadius {
+  float top_left = 0.0f;
+  float top_right = 0.0f;
+  float bottom_right = 0.0f;
+  float bottom_left = 0.0f;
+
+  static CornerRadius Uniform(float radius) {
+    return CornerRadius{radius, radius, radius, radius};
+  }
+};
+
+enum class FontWeight { Normal, Medium, Semibold, Bold };
+
+enum class TextAlign {
+  Left,
+  Center,
+  Right,
+};
+
+enum class VerticalAlign {
+  Top,
+  Middle,
+  Bottom,
+};
+
+// A font description, not a font. The backend resolves it to a cached
+// resource keyed by (family, size, weight, italic, dpi, epoch).
+struct TextStyle {
+  std::wstring family = L"Segoe UI";
+  float size_px = 14.0f;
+  FontWeight weight = FontWeight::Normal;
+  bool italic = false;
+};
+
+// Opaque, backend-owned. Zero is never a valid handle.
+enum class ImageHandle : std::uint64_t { Invalid = 0 };
+
+// --- The interface ----------------------------------------------------------
+
+class RenderBackend {
+ public:
+  virtual ~RenderBackend() = default;
+
+  // Surface management. Valid at any time.
+  virtual void Resize(Size logical_size) = 0;
+  virtual void SetDpi(float dpi) = 0;
+  virtual float dpi() const = 0;
+  virtual Size surface_size() const = 0;
+
+  // Frame scope. Drawing is only valid between BeginFrame and EndFrame.
+  virtual void BeginFrame(const Rect& dirty) = 0;
+  virtual void EndFrame() = 0;
+  // Puts the back buffer on the window. The window handle is opaque here;
+  // the shell knows what it really is.
+  virtual void Present(void* window_handle) = 0;
+
+  // Resources. Valid at any time; the backend owns what it returns.
+  virtual ImageHandle LoadImage(std::wstring_view path) = 0;
+  virtual void ReleaseImage(ImageHandle image) = 0;
+
+  // Measurement. Valid OUTSIDE a paint scope — layout depends on it.
+  // max_width 0 means unbounded. Returns the size the text would occupy.
+  virtual Size MeasureText(std::wstring_view text, const TextStyle& style,
+                           float max_width) = 0;
+
+  // Drawing. Valid only inside a paint scope.
+  virtual void FillRect(const Rect& rect, Color color) = 0;
+  virtual void StrokeRect(const Rect& rect, Color color, float stroke_width) = 0;
+  virtual void FillRoundedRect(const Rect& rect, const CornerRadius& radius, Color color) = 0;
+  virtual void StrokeRoundedRect(const Rect& rect, const CornerRadius& radius, Color color,
+                                 float stroke_width) = 0;
+  virtual void DrawText(std::wstring_view text, const Rect& bounds, const TextStyle& style,
+                        Color color, TextAlign horizontal, VerticalAlign vertical) = 0;
+  virtual void DrawImage(ImageHandle image, const Rect& dest, float opacity) = 0;
+
+  // Clip and translation stacks. Every Push must be balanced by a Pop
+  // before EndFrame; a frame ends with an empty stack.
+  virtual void PushClip(const Rect& rect) = 0;
+  virtual void PopClip() = 0;
+  virtual void PushTranslation(Point offset) = 0;
+  virtual void PopTranslation() = 0;
+};
+
+}  // namespace render

--- a/tests/render/render_backend_test.cpp
+++ b/tests/render/render_backend_test.cpp
@@ -1,0 +1,171 @@
+// Proof that the render seam holds: this file includes render_backend.h
+// with no backend implementation anywhere in the build, implements the
+// interface with a recording stub, and exercises the contract. If a Win32
+// type ever leaks into the header, this translation unit stops compiling.
+
+#include "render/render_backend.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "framework/test_case.h"
+
+namespace {
+
+class StubBackend final : public render::RenderBackend {
+ public:
+  std::vector<std::string> calls;
+  float dpi_value = 96.0f;
+  render::Size size = {800.0f, 600.0f};
+  std::uint64_t next_image = 1;
+  int live_images = 0;
+
+  void Resize(render::Size logical_size) override {
+    size = logical_size;
+    calls.push_back("resize");
+  }
+  void SetDpi(float dpi) override {
+    dpi_value = dpi;
+    calls.push_back("set_dpi");
+  }
+  float dpi() const override { return dpi_value; }
+  render::Size surface_size() const override { return size; }
+
+  void BeginFrame(const render::Rect&) override { calls.push_back("begin"); }
+  void EndFrame() override { calls.push_back("end"); }
+  void Present(void*) override { calls.push_back("present"); }
+
+  render::ImageHandle LoadImage(std::wstring_view) override {
+    ++live_images;
+    calls.push_back("load_image");
+    return static_cast<render::ImageHandle>(next_image++);
+  }
+  void ReleaseImage(render::ImageHandle) override {
+    --live_images;
+    calls.push_back("release_image");
+  }
+
+  render::Size MeasureText(std::wstring_view text, const render::TextStyle&, float) override {
+    calls.push_back("measure");
+    // Deterministic fake: one advance per code unit. A real backend measures
+    // glyphs; the seam test only needs the call to work outside a frame.
+    return {static_cast<float>(text.size()) * 7.0f, 14.0f};
+  }
+
+  void FillRect(const render::Rect&, render::Color) override { calls.push_back("fill_rect"); }
+  void StrokeRect(const render::Rect&, render::Color, float) override {
+    calls.push_back("stroke_rect");
+  }
+  void FillRoundedRect(const render::Rect&, const render::CornerRadius&, render::Color) override {
+    calls.push_back("fill_rounded");
+  }
+  void StrokeRoundedRect(const render::Rect&, const render::CornerRadius&, render::Color,
+                         float) override {
+    calls.push_back("stroke_rounded");
+  }
+  void DrawText(std::wstring_view, const render::Rect&, const render::TextStyle&, render::Color,
+                render::TextAlign, render::VerticalAlign) override {
+    calls.push_back("draw_text");
+  }
+  void DrawImage(render::ImageHandle, const render::Rect&, float) override {
+    calls.push_back("draw_image");
+  }
+
+  void PushClip(const render::Rect&) override { calls.push_back("push_clip"); }
+  void PopClip() override { calls.push_back("pop_clip"); }
+  void PushTranslation(render::Point) override { calls.push_back("push_translation"); }
+  void PopTranslation() override { calls.push_back("pop_translation"); }
+};
+
+bool Contains(const std::vector<std::string>& calls, const std::string& name) {
+  for (const auto& call : calls) {
+    if (call == name) {
+      return true;
+    }
+  }
+  return false;
+}
+
+// MSVC constant-folds trivial accessors on known values into the check
+// macro's `if`, which is C4127 under /WX. A noinline boundary keeps the
+// assertion a runtime check, which is what it is meant to be.
+__declspec(noinline) bool RectEmptyAtRuntime(const render::Rect& rect) { return rect.empty(); }
+
+}  // namespace
+
+DHEPZ_TEST(RenderBackend, StubImplementsTheWholeSurfaceWithoutWin32) {
+  StubBackend backend;
+  render::RenderBackend& surface = backend;
+
+  surface.Resize({1024.0f, 768.0f});
+  surface.SetDpi(144.0f);
+  DHEPZ_CHECK_EQ(surface.dpi(), 144.0f);
+  DHEPZ_CHECK_EQ(surface.surface_size().width, 1024.0f);
+
+  // Measurement works with no frame open — the layout-before-paint contract.
+  const render::TextStyle style;
+  const render::Size measured = surface.MeasureText(L"hello", style, 0.0f);
+  DHEPZ_CHECK_EQ(measured.width, 5.0f * 7.0f);
+
+  const render::ImageHandle image = surface.LoadImage(L"icon.png");
+  DHEPZ_CHECK(image != render::ImageHandle::Invalid);
+
+  int window = 0;  // opaque to the interface
+  surface.BeginFrame({0.0f, 0.0f, 1024.0f, 768.0f});
+  surface.FillRect({0.0f, 0.0f, 100.0f, 100.0f}, {255, 0, 0, 255});
+  surface.StrokeRect({0.0f, 0.0f, 100.0f, 100.0f}, {0, 0, 0, 255}, 1.0f);
+  surface.FillRoundedRect({0.0f, 0.0f, 100.0f, 100.0f}, render::CornerRadius::Uniform(8.0f),
+                          {0, 120, 215, 255});
+  surface.StrokeRoundedRect({0.0f, 0.0f, 100.0f, 100.0f}, render::CornerRadius::Uniform(8.0f),
+                            {0, 0, 0, 255}, 1.0f);
+  surface.PushClip({10.0f, 10.0f, 80.0f, 80.0f});
+  surface.PushTranslation({5.0f, 5.0f});
+  surface.DrawText(L"tab", {0.0f, 0.0f, 80.0f, 20.0f}, style, {255, 255, 255, 255},
+                   render::TextAlign::Center, render::VerticalAlign::Middle);
+  surface.DrawImage(image, {0.0f, 0.0f, 16.0f, 16.0f}, 1.0f);
+  surface.PopTranslation();
+  surface.PopClip();
+  surface.EndFrame();
+  surface.Present(&window);
+
+  surface.ReleaseImage(image);
+  DHEPZ_CHECK_EQ(backend.live_images, 0);
+
+  // The frame order is the contract a compositor implements against.
+  DHEPZ_CHECK(Contains(backend.calls, "measure"));
+  DHEPZ_CHECK(Contains(backend.calls, "fill_rounded"));
+  const auto& calls = backend.calls;
+  const auto begin = std::find(calls.begin(), calls.end(), "begin");
+  const auto end = std::find(calls.begin(), calls.end(), "end");
+  const auto fill = std::find(calls.begin(), calls.end(), "fill_rect");
+  const auto present = std::find(calls.begin(), calls.end(), "present");
+  DHEPZ_CHECK(begin != calls.end());
+  DHEPZ_CHECK(end != calls.end());
+  DHEPZ_CHECK(fill > begin && fill < end);
+  DHEPZ_CHECK(present > end);
+}
+
+DHEPZ_TEST(RenderBackend, ValueTypesBehave) {
+  const render::Rect rect{10.0f, 20.0f, 30.0f, 40.0f};
+  DHEPZ_CHECK_EQ(rect.right(), 40.0f);
+  DHEPZ_CHECK_EQ(rect.bottom(), 60.0f);
+  // Extra parens: braces alone do not shield commas from the preprocessor,
+  // and an unparenthesised braced-init-list splits a macro argument.
+  DHEPZ_CHECK((rect.contains({10.0f, 20.0f})));
+  DHEPZ_CHECK_FALSE((rect.contains({40.0f, 60.0f})));  // right/bottom edges are exclusive
+  DHEPZ_CHECK(RectEmptyAtRuntime({0.0f, 0.0f, 0.0f, 5.0f}));
+
+  const render::CornerRadius uniform = render::CornerRadius::Uniform(6.0f);
+  DHEPZ_CHECK_EQ(uniform.top_left, 6.0f);
+  DHEPZ_CHECK_EQ(uniform.bottom_right, 6.0f);
+
+  // Zero is never a valid handle. Multiplying an opaque address by zero
+  // keeps the right-hand side from being a compile-time constant (C4127
+  // under /WX) while still evaluating to exactly 0 at runtime.
+  int opaque = 0;
+  const auto sentinel =
+      static_cast<render::ImageHandle>(reinterpret_cast<std::uintptr_t>(&opaque) * 0u);
+  DHEPZ_CHECK(render::ImageHandle::Invalid == sentinel);
+}


### PR DESCRIPTION
Closes #16.

## Summary
- `src/render/render_backend.h` — the full drawing surface, declared before any implementation: filled/stroked rects, per-corner rounded rects, text with alignment, images, clip and translation stacks, frame scoping (`Resize` / `BeginFrame` / `EndFrame` / `Present`).
- **Text measurement is a first-class operation valid outside a paint scope** — layout runs before paint, often several times per frame.
- **Standard-library-only header.** Grep for `HDC|HBRUSH|HFONT|HPEN|HBITMAP|HWND|HGDIOBJ|windows.h` finds no types — the only hit is the word "GDI" in the rule's own comment.
- **Opaque, backend-owned resources**: `ImageHandle` (zero never valid), and fonts as `TextStyle` *values* the backend resolves through its cache — keyed by (family, size, weight, dpi, epoch) when #19 lands.
- **The contract is written in the header**: ownership/lifetime, what is valid inside vs outside a paint scope, frame/present flow, and the DPI policy (SetDpi implies a resource-epoch bump; callers draw logical pixels). The Hyrum's-Law warning sits at the top: once components are written against this, changing it touches all 14, and the Phase 1 gate is where such a decision is still cheap.

## Verification
- [x] **Seam proof**: `tests/render/render_backend_test.cpp` implements the entire interface with a recording stub and no backend implementation anywhere in the build; the frame-order contract (measure before frame, draw inside, present after) is asserted. `ui/` re-proves this naturally in Phase 2.
- [x] Grep confirms no Win32 GDI type in the header.
- [x] 96/96 tests Debug and Release (2 new); new files LF-only verified byte-wise.

## Traps recorded
Braced-init-lists inside check macros split macro arguments (parens fix), and `C4127` constant-condition under `/WX` needed an opaque runtime boundary — both documented in the test file for the next person.