### PR TITLE
feat(render): implement the GDI backend with a per-window back buffer (#17)

### DIFF
--- a/src/render/gdi_backend.cpp
+++ b/src/render/gdi_backend.cpp
@@ -1,0 +1,635 @@
+#include "render/gdi_backend.h"
+
+#include <windows.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <cstring>
+#include <map>
+#include <string>
+#include <vector>
+
+namespace render {
+namespace {
+
+// --- Compositor -------------------------------------------------------------
+//
+// Pixel packing is (a<<24)|(r<<16)|(g<<8)|b. Stored little-endian that is
+// the byte order [B,G,R,A] a 32-bpp DIB expects, so GDI and the compositor
+// agree on the buffer without any conversion.
+
+constexpr std::uint32_t Channel(std::uint32_t pixel, int shift) noexcept {
+  return (pixel >> shift) & 0xFFu;
+}
+
+// Exact /255 without a divide (the old build's trick, kept because it is
+// both faster and rounded correctly).
+constexpr std::uint32_t DivideBy255(std::uint32_t value) noexcept {
+  return (value + 128u + ((value + 128u) >> 8u)) >> 8u;
+}
+
+std::uint32_t Pack(const Color& color) noexcept {
+  return (static_cast<std::uint32_t>(color.a) << 24) |
+         (static_cast<std::uint32_t>(color.r) << 16) |
+         (static_cast<std::uint32_t>(color.g) << 8) | static_cast<std::uint32_t>(color.b);
+}
+
+std::uint32_t Premultiply(const Color& color) noexcept {
+  const std::uint32_t alpha = color.a;
+  const std::uint32_t red = DivideBy255(static_cast<std::uint32_t>(color.r) * alpha);
+  const std::uint32_t green = DivideBy255(static_cast<std::uint32_t>(color.g) * alpha);
+  const std::uint32_t blue = DivideBy255(static_cast<std::uint32_t>(color.b) * alpha);
+  return (alpha << 24) | (red << 16) | (green << 8) | blue;
+}
+
+std::uint32_t SourceOverPremultiplied(std::uint32_t destination, std::uint32_t source) noexcept {
+  const std::uint32_t inverse_alpha = 255u - Channel(source, 24);
+  const std::uint32_t blue = Channel(source, 0) + DivideBy255(Channel(destination, 0) * inverse_alpha);
+  const std::uint32_t green = Channel(source, 8) + DivideBy255(Channel(destination, 8) * inverse_alpha);
+  const std::uint32_t red = Channel(source, 16) + DivideBy255(Channel(destination, 16) * inverse_alpha);
+  const std::uint32_t alpha = Channel(source, 24) + DivideBy255(Channel(destination, 24) * inverse_alpha);
+  return (std::min(255u, alpha) << 24) | (std::min(255u, red) << 16) |
+         (std::min(255u, green) << 8) | std::min(255u, blue);
+}
+
+struct ImageData {
+  int width = 0;
+  int height = 0;
+  std::vector<std::uint32_t> pixels;  // premultiplied, same packing as the buffer
+};
+
+struct FontKey {
+  std::wstring family;
+  int height_px = 0;
+  int weight = FW_NORMAL;
+  bool italic = false;
+
+  bool operator<(const FontKey& other) const noexcept {
+    if (family != other.family) return family < other.family;
+    if (height_px != other.height_px) return height_px < other.height_px;
+    if (weight != other.weight) return weight < other.weight;
+    return italic < other.italic;
+  }
+};
+
+int ToGdiWeight(FontWeight weight) noexcept {
+  switch (weight) {
+    case FontWeight::Normal: return FW_NORMAL;
+    case FontWeight::Medium: return FW_MEDIUM;
+    case FontWeight::Semibold: return FW_SEMIBOLD;
+    case FontWeight::Bold: return FW_BOLD;
+  }
+  return FW_NORMAL;
+}
+
+// Decodes an uncompressed 24/32-bit BI_RGB BMP. PNG and icon formats arrive
+// with the first component that needs them — see the header.
+bool DecodeBmp(const std::uint8_t* data, std::size_t size, ImageData* out) {
+  if (size < sizeof(BITMAPFILEHEADER) + sizeof(BITMAPINFOHEADER)) return false;
+  BITMAPFILEHEADER file_header{};
+  std::memcpy(&file_header, data, sizeof(file_header));
+  BITMAPINFOHEADER info{};
+  std::memcpy(&info, data + sizeof(BITMAPFILEHEADER), sizeof(info));
+  if (info.biCompression != BI_RGB || (info.biBitCount != 24 && info.biBitCount != 32)) {
+    return false;
+  }
+  const int width = info.biWidth;
+  const int height_abs = std::abs(info.biHeight);
+  const bool top_down = info.biHeight < 0;
+  if (width <= 0 || height_abs <= 0 || file_header.bfOffBits >= size) return false;
+
+  const std::size_t row_bytes = ((static_cast<std::size_t>(width) * info.biBitCount + 31) / 32) * 4;
+  const std::size_t needed = file_header.bfOffBits + row_bytes * height_abs;
+  if (needed > size) return false;
+
+  out->width = width;
+  out->height = height_abs;
+  out->pixels.resize(static_cast<std::size_t>(width) * height_abs);
+  for (int y = 0; y < height_abs; ++y) {
+    const int source_y = top_down ? y : (height_abs - 1 - y);
+    const std::uint8_t* row = data + file_header.bfOffBits + row_bytes * source_y;
+    std::uint32_t* dest = out->pixels.data() + static_cast<std::size_t>(y) * width;
+    for (int x = 0; x < width; ++x) {
+      const std::uint8_t blue = row[x * info.biBitCount / 8 + 0];
+      const std::uint8_t green = row[x * info.biBitCount / 8 + 1];
+      const std::uint8_t red = row[x * info.biBitCount / 8 + 2];
+      const std::uint8_t alpha = info.biBitCount == 32 ? row[x * 4 + 3] : 255;
+      Color color{red, green, blue, alpha};
+      dest[x] = Premultiply(color);
+    }
+  }
+  return true;
+}
+
+}  // namespace
+
+// --- Implementation -----------------------------------------------------------
+
+struct GdiBackend::Impl {
+  float dpi = 96.0f;
+  Size logical_size = {0.0f, 0.0f};
+
+  HDC buffer_dc = nullptr;
+  HBITMAP bitmap = nullptr;
+  HGDIOBJ previous_bitmap = nullptr;
+  std::uint32_t* pixels = nullptr;
+  int buffer_width = 0;
+  int buffer_height = 0;
+
+  bool in_paint_scope = false;
+  Rect dirty{};
+
+  std::vector<Rect> clips;
+  std::vector<Point> translations;
+
+  HDC measurement_dc = nullptr;
+  std::map<FontKey, HFONT> fonts;
+  std::map<std::uint64_t, ImageData> images;
+  std::uint64_t next_image = 1;
+
+  float scale() const noexcept { return dpi / 96.0f; }
+
+  int Physical(float value) const noexcept {
+    return static_cast<int>(std::lround(value * scale()));
+  }
+  float Logical(int value) const noexcept { return value / scale(); }
+
+  Point Translation() const noexcept {
+    Point total{0.0f, 0.0f};
+    for (const Point& offset : translations) {
+      total.x += offset.x;
+      total.y += offset.y;
+    }
+    return total;
+  }
+
+  // The effective clip in physical buffer coordinates: the surface, the
+  // frame's dirty region, and every pushed clip, all offset by the current
+  // translation. Returns an empty rect when nothing is drawable.
+  RECT EffectiveClip() const noexcept {
+    RECT clip{0, 0, buffer_width, buffer_height};
+    if (in_paint_scope) {
+      // LONG and int are distinct types to the template, so spell the type.
+      clip.left = std::max<LONG>(clip.left, Physical(dirty.x));
+      clip.top = std::max<LONG>(clip.top, Physical(dirty.y));
+      clip.right = std::min<LONG>(clip.right, Physical(dirty.right()));
+      clip.bottom = std::min<LONG>(clip.bottom, Physical(dirty.bottom()));
+    }
+    const Point translation = Translation();
+    for (const Rect& pushed : clips) {
+      clip.left = std::max<LONG>(clip.left, Physical(pushed.x + translation.x));
+      clip.top = std::max<LONG>(clip.top, Physical(pushed.y + translation.y));
+      clip.right = std::min<LONG>(clip.right, Physical(pushed.right() + translation.x));
+      clip.bottom = std::min<LONG>(clip.bottom, Physical(pushed.bottom() + translation.y));
+    }
+    if (clip.right <= clip.left || clip.bottom <= clip.top) {
+      return RECT{0, 0, 0, 0};
+    }
+    return clip;
+  }
+
+  RECT PhysicalRect(const Rect& rect) const noexcept {
+    const Point translation = Translation();
+    return RECT{Physical(rect.x + translation.x), Physical(rect.y + translation.y),
+                Physical(rect.right() + translation.x), Physical(rect.bottom() + translation.y)};
+  }
+
+  bool EnsureBuffer(int width, int height) noexcept {
+    if (width <= 0 || height <= 0) return false;
+    if (buffer_dc != nullptr && buffer_width == width && buffer_height == height) return true;
+
+    HDC candidate_dc = CreateCompatibleDC(nullptr);
+    if (candidate_dc == nullptr) return false;
+
+    BITMAPINFO info{};
+    info.bmiHeader.biSize = sizeof(info.bmiHeader);
+    info.bmiHeader.biWidth = width;
+    info.bmiHeader.biHeight = -height;  // top-down rows
+    info.bmiHeader.biPlanes = 1;
+    info.bmiHeader.biBitCount = 32;
+    info.bmiHeader.biCompression = BI_RGB;
+
+    void* candidate_pixels = nullptr;
+    HBITMAP candidate_bitmap =
+        CreateDIBSection(nullptr, &info, DIB_RGB_COLORS, &candidate_pixels, nullptr, 0);
+    if (candidate_bitmap == nullptr || candidate_pixels == nullptr) {
+      if (candidate_bitmap != nullptr) DeleteObject(candidate_bitmap);
+      DeleteDC(candidate_dc);
+      return false;
+    }
+    const HGDIOBJ candidate_previous = SelectObject(candidate_dc, candidate_bitmap);
+    if (candidate_previous == nullptr || candidate_previous == HGDI_ERROR) {
+      DeleteObject(candidate_bitmap);
+      DeleteDC(candidate_dc);
+      return false;
+    }
+
+    ReleaseBuffer();
+    buffer_dc = candidate_dc;
+    bitmap = candidate_bitmap;
+    previous_bitmap = candidate_previous;
+    pixels = static_cast<std::uint32_t*>(candidate_pixels);
+    buffer_width = width;
+    buffer_height = height;
+    // The compositor's invariant: the buffer is opaque everywhere.
+    std::fill_n(pixels, static_cast<std::size_t>(width) * height, 0xFF000000u);
+    return true;
+  }
+
+  void ReleaseBuffer() noexcept {
+    if (buffer_dc != nullptr && previous_bitmap != nullptr) {
+      SelectObject(buffer_dc, previous_bitmap);
+    }
+    if (bitmap != nullptr) DeleteObject(bitmap);
+    if (buffer_dc != nullptr) DeleteDC(buffer_dc);
+    buffer_dc = nullptr;
+    bitmap = nullptr;
+    previous_bitmap = nullptr;
+    pixels = nullptr;
+    buffer_width = 0;
+    buffer_height = 0;
+  }
+
+  // The measurement DC is lazy and refused inside a paint scope — see the
+  // header. The refusal IS the guard: debug output names the violation, the
+  // caller gets nothing, and the test suite fails loudly if the contract
+  // breaks. (A hard assert here would abort the very test that proves the
+  // refusal works.)
+  HDC MeasurementDc() noexcept {
+    if (in_paint_scope) {
+      OutputDebugStringW(L"dhepz: measurement DC refused inside a paint scope\n");
+      return nullptr;
+    }
+    if (measurement_dc == nullptr) {
+      measurement_dc = CreateCompatibleDC(nullptr);
+    }
+    return measurement_dc;
+  }
+
+  HFONT FontFor(const TextStyle& style) noexcept {
+    FontKey key{style.family, Physical(style.size_px), ToGdiWeight(style.weight), style.italic};
+    if (const auto found = fonts.find(key); found != fonts.end()) {
+      return found->second;
+    }
+    if (in_paint_scope) {
+      // Fonts are warmed by layout (MeasureText) before the frame. Creating
+      // one mid-frame is the bug the guard exists to catch.
+      OutputDebugStringW(L"dhepz: font creation refused inside a paint scope\n");
+      return nullptr;
+    }
+    const HFONT font = CreateFontW(-key.height_px, 0, 0, 0, key.weight, key.italic ? TRUE : FALSE,
+                                   FALSE, FALSE, DEFAULT_CHARSET, OUT_DEFAULT_PRECIS,
+                                   CLIP_DEFAULT_PRECIS, CLEARTYPE_QUALITY,
+                                   DEFAULT_PITCH | FF_DONTCARE, key.family.c_str());
+    if (font != nullptr) {
+      fonts.emplace(std::move(key), font);
+    }
+    return font;
+  }
+
+  // Restores the buffer's opaque-alpha invariant over a region after a GDI
+  // draw, which writes undefined alpha into a 32-bpp DIB.
+  void ForceOpaqueAlpha(const RECT& region) noexcept {
+    if (pixels == nullptr) return;
+    const RECT clipped{std::max(0L, region.left), std::max(0L, region.top),
+                       std::min(static_cast<LONG>(buffer_width), region.right),
+                       std::min(static_cast<LONG>(buffer_height), region.bottom)};
+    for (LONG y = clipped.top; y < clipped.bottom; ++y) {
+      std::uint32_t* row = pixels + static_cast<std::size_t>(y) * buffer_width;
+      for (LONG x = clipped.left; x < clipped.right; ++x) {
+        row[x] |= 0xFF000000u;
+      }
+    }
+  }
+
+  void CompositeSolid(const RECT& region, const Color& color) noexcept {
+    if (pixels == nullptr || color.a == 0) return;
+    const RECT clip = EffectiveClip();
+    const RECT target{std::max(clip.left, region.left), std::max(clip.top, region.top),
+                      std::min(clip.right, region.right), std::min(clip.bottom, region.bottom)};
+    if (target.right <= target.left || target.bottom <= target.top) return;
+    const std::uint32_t source = Premultiply(color);
+    for (LONG y = target.top; y < target.bottom; ++y) {
+      std::uint32_t* row = pixels + static_cast<std::size_t>(y) * buffer_width;
+      for (LONG x = target.left; x < target.right; ++x) {
+        row[x] = SourceOverPremultiplied(row[x], source);
+      }
+    }
+  }
+
+  // Coverage-anti-aliased rounded rect, ported from the old compositor and
+  // extended to per-corner radii by picking the owning quadrant's radius.
+  void CompositeRounded(const Rect& rect, const CornerRadius& radius, const Color& fill,
+                        const Color& border, float border_width) noexcept {
+    if (pixels == nullptr || (fill.a == 0 && border.a == 0)) return;
+    const RECT clip = EffectiveClip();
+    const RECT region = PhysicalRect(rect);
+    const RECT target{std::max(clip.left, region.left), std::max(clip.top, region.top),
+                      std::min(clip.right, region.right), std::min(clip.bottom, region.bottom)};
+    if (target.right <= target.left || target.bottom <= target.top) return;
+
+    const double width = static_cast<double>(region.right - region.left);
+    const double height = static_cast<double>(region.bottom - region.top);
+    const double limit = std::min(width, height) / 2.0;
+    const double radii[4] = {
+        std::clamp(static_cast<double>(Physical(radius.top_left)), 0.0, limit),
+        std::clamp(static_cast<double>(Physical(radius.top_right)), 0.0, limit),
+        std::clamp(static_cast<double>(Physical(radius.bottom_right)), 0.0, limit),
+        std::clamp(static_cast<double>(Physical(radius.bottom_left)), 0.0, limit),
+    };
+    const double inset = std::clamp(static_cast<double>(Physical(border_width)), 0.0, limit);
+    const double center_x = (region.left + region.right) / 2.0;
+    const double center_y = (region.top + region.bottom) / 2.0;
+
+    const auto coverage = [](double x, double y, double half_width, double half_height,
+                             double shape_radius) {
+      const double qx = std::abs(x) - (half_width - shape_radius);
+      const double qy = std::abs(y) - (half_height - shape_radius);
+      const double outside = std::hypot(std::max(qx, 0.0), std::max(qy, 0.0));
+      const double inside = std::min(std::max(qx, qy), 0.0);
+      return std::clamp(0.5 - (outside + inside - shape_radius), 0.0, 1.0);
+    };
+
+    for (LONG y = target.top; y < target.bottom; ++y) {
+      std::uint32_t* row = pixels + static_cast<std::size_t>(y) * buffer_width;
+      for (LONG x = target.left; x < target.right; ++x) {
+        const double local_x = x + 0.5 - center_x;
+        const double local_y = y + 0.5 - center_y;
+        const int quadrant = (local_x >= 0.0 ? 1 : 0) + (local_y >= 0.0 ? 2 : 0);
+        const double outer_radius = radii[quadrant];
+        const double outer =
+            coverage(local_x, local_y, width / 2.0, height / 2.0, outer_radius);
+        if (outer <= 0.0) continue;
+
+        double inner = 0.0;
+        if (inset > 0.0) {
+          const double inner_radius = std::max(0.0, outer_radius - inset);
+          inner = coverage(local_x, local_y, width / 2.0 - inset, height / 2.0 - inset,
+                           inner_radius);
+          const double border_coverage = outer * (1.0 - inner);
+          if (border_coverage > 0.0) {
+            Color edge = border;
+            edge.a = static_cast<std::uint8_t>(edge.a * border_coverage + 0.5);
+            row[x] = SourceOverPremultiplied(row[x], Premultiply(edge));
+          }
+        }
+        const double fill_coverage = inset > 0.0 ? inner : outer;
+        if (fill_coverage > 0.0) {
+          Color inner_fill = fill;
+          inner_fill.a = static_cast<std::uint8_t>(inner_fill.a * fill_coverage + 0.5);
+          row[x] = SourceOverPremultiplied(row[x], Premultiply(inner_fill));
+        }
+      }
+    }
+  }
+
+  void ReleaseAll() noexcept {
+    ReleaseBuffer();
+    if (measurement_dc != nullptr) DeleteDC(measurement_dc);
+    measurement_dc = nullptr;
+    for (const auto& entry : fonts) {
+      DeleteObject(entry.second);
+    }
+    fonts.clear();
+    images.clear();
+  }
+};
+
+GdiBackend::GdiBackend() : impl_(std::make_unique<Impl>()) {}
+GdiBackend::~GdiBackend() { impl_->ReleaseAll(); }
+
+void GdiBackend::Resize(Size logical_size) {
+  impl_->logical_size = logical_size;
+  impl_->EnsureBuffer(impl_->Physical(logical_size.width),
+                      impl_->Physical(logical_size.height));
+}
+
+void GdiBackend::SetDpi(float dpi) {
+  if (dpi <= 0.0f) return;
+  impl_->dpi = dpi;
+  // Fonts are keyed by physical height; a DPI change orphans them. The
+  // epoch/cache machinery of #19 will manage this at scale.
+  for (const auto& entry : impl_->fonts) {
+    DeleteObject(entry.second);
+  }
+  impl_->fonts.clear();
+  if (impl_->logical_size.width > 0.0f) {
+    Resize(impl_->logical_size);
+  }
+}
+
+float GdiBackend::dpi() const { return impl_->dpi; }
+Size GdiBackend::surface_size() const { return impl_->logical_size; }
+
+void GdiBackend::BeginFrame(const Rect& dirty) {
+  if (impl_->pixels == nullptr) return;
+  impl_->in_paint_scope = true;
+  impl_->dirty = dirty;
+  impl_->clips.clear();
+  impl_->translations.clear();
+}
+
+void GdiBackend::EndFrame() {
+  impl_->in_paint_scope = false;
+  impl_->clips.clear();
+  impl_->translations.clear();
+}
+
+void GdiBackend::Present(void* window_handle) {
+  if (impl_->pixels == nullptr || window_handle == nullptr) return;
+  const HWND window = static_cast<HWND>(window_handle);
+  const HDC target = GetDC(window);
+  if (target == nullptr) return;
+  BitBlt(target, 0, 0, impl_->buffer_width, impl_->buffer_height, impl_->buffer_dc, 0, 0,
+         SRCCOPY);
+  ReleaseDC(window, target);
+}
+
+ImageHandle GdiBackend::LoadImageFile(std::wstring_view path) {
+  ImageData image;
+  HANDLE file = CreateFileW(std::wstring(path).c_str(), GENERIC_READ, FILE_SHARE_READ, nullptr,
+                            OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
+  if (file == INVALID_HANDLE_VALUE) return ImageHandle::Invalid;
+
+  std::vector<std::uint8_t> bytes;
+  const DWORD size = GetFileSize(file, nullptr);
+  if (size != INVALID_FILE_SIZE && size > 0 && size < 64u * 1024u * 1024u) {
+    bytes.resize(size);
+    DWORD read = 0;
+    if (!ReadFile(file, bytes.data(), size, &read, nullptr) || read != size) {
+      bytes.clear();
+    }
+  }
+  CloseHandle(file);
+  if (bytes.empty() || !DecodeBmp(bytes.data(), bytes.size(), &image)) {
+    return ImageHandle::Invalid;
+  }
+
+  const std::uint64_t id = impl_->next_image++;
+  impl_->images.emplace(id, std::move(image));
+  return static_cast<ImageHandle>(id);
+}
+
+void GdiBackend::ReleaseImage(ImageHandle image) {
+  impl_->images.erase(static_cast<std::uint64_t>(image));
+}
+
+Size GdiBackend::MeasureText(std::wstring_view text, const TextStyle& style, float max_width) {
+  if (text.empty()) return {0.0f, 0.0f};
+  HDC dc = impl_->MeasurementDc();
+  HFONT font = impl_->FontFor(style);
+  if (dc == nullptr || font == nullptr) return {0.0f, 0.0f};
+
+  const HGDIOBJ previous = SelectObject(dc, font);
+  RECT measured{0, 0, max_width > 0.0f ? std::max(1, impl_->Physical(max_width)) : 32767, 32767};
+  const UINT flags = DT_CALCRECT | (max_width > 0.0f ? DT_WORDBREAK : 0);
+  DrawTextW(dc, text.data(), static_cast<int>(text.size()), &measured, flags);
+  if (previous != nullptr && previous != HGDI_ERROR) SelectObject(dc, previous);
+  return {impl_->Logical(measured.right - measured.left),
+          impl_->Logical(measured.bottom - measured.top)};
+}
+
+void GdiBackend::FillRect(const Rect& rect, Color color) {
+  if (!impl_->in_paint_scope) return;
+  impl_->CompositeSolid(impl_->PhysicalRect(rect), color);
+}
+
+void GdiBackend::StrokeRect(const Rect& rect, Color color, float stroke_width) {
+  if (!impl_->in_paint_scope) return;
+  const RECT region = impl_->PhysicalRect(rect);
+  const int thickness = std::max(1, impl_->Physical(stroke_width));
+  impl_->CompositeSolid(RECT{region.left, region.top, region.right, region.top + thickness},
+                        color);
+  impl_->CompositeSolid(RECT{region.left, region.bottom - thickness, region.right, region.bottom},
+                        color);
+  impl_->CompositeSolid(RECT{region.left, region.top, region.left + thickness, region.bottom},
+                        color);
+  impl_->CompositeSolid(RECT{region.right - thickness, region.top, region.right, region.bottom},
+                        color);
+}
+
+void GdiBackend::FillRoundedRect(const Rect& rect, const CornerRadius& radius, Color color) {
+  if (!impl_->in_paint_scope) return;
+  impl_->CompositeRounded(rect, radius, color, Color{0, 0, 0, 0}, 0.0f);
+}
+
+void GdiBackend::StrokeRoundedRect(const Rect& rect, const CornerRadius& radius, Color color,
+                                   float stroke_width) {
+  if (!impl_->in_paint_scope) return;
+  impl_->CompositeRounded(rect, radius, Color{0, 0, 0, 0}, color, stroke_width);
+}
+
+void GdiBackend::DrawTextRun(std::wstring_view text, const Rect& bounds, const TextStyle& style,
+                          Color color, TextAlign horizontal, VerticalAlign vertical) {
+  if (!impl_->in_paint_scope || text.empty() || impl_->buffer_dc == nullptr) return;
+  HFONT font = impl_->FontFor(style);
+  if (font == nullptr) return;  // uncached inside a frame: layout forgot to warm it
+
+  const RECT clip = impl_->EffectiveClip();
+  const RECT region = impl_->PhysicalRect(bounds);
+  RECT visible{std::max(clip.left, region.left), std::max(clip.top, region.top),
+               std::min(clip.right, region.right), std::min(clip.bottom, region.bottom)};
+  if (visible.right <= visible.left || visible.bottom <= visible.top) return;
+
+  // Single-line placement: measure, then position. Reflow at width is a
+  // MeasureText concern for layout; painting places one run.
+  RECT measured{0, 0, 32767, 32767};
+  const HGDIOBJ previous = SelectObject(impl_->buffer_dc, font);
+  DrawTextW(impl_->buffer_dc, text.data(), static_cast<int>(text.size()), &measured,
+            DT_CALCRECT);
+
+  int x = region.left;
+  const int text_width = measured.right - measured.left;
+  if (horizontal == TextAlign::Center) {
+    x += ((region.right - region.left) - text_width) / 2;
+  } else if (horizontal == TextAlign::Right) {
+    x = region.right - text_width;
+  }
+  int y = region.top;
+  const int text_height = measured.bottom - measured.top;
+  if (vertical == VerticalAlign::Middle) {
+    y += ((region.bottom - region.top) - text_height) / 2;
+  } else if (vertical == VerticalAlign::Bottom) {
+    y = region.bottom - text_height;
+  }
+
+  SetBkMode(impl_->buffer_dc, TRANSPARENT);
+  SetTextColor(impl_->buffer_dc,
+               RGB(color.r, color.g, color.b));  // GDI consumes COLORREF, packing handled above
+  ExtTextOutW(impl_->buffer_dc, x, y, ETO_CLIPPED, &visible, text.data(),
+              static_cast<int>(text.size()), nullptr);
+  if (previous != nullptr && previous != HGDI_ERROR) SelectObject(impl_->buffer_dc, previous);
+  impl_->ForceOpaqueAlpha(visible);
+}
+
+void GdiBackend::DrawImage(ImageHandle image, const Rect& dest, float opacity) {
+  if (!impl_->in_paint_scope || impl_->pixels == nullptr || opacity <= 0.0f) return;
+  const auto found = impl_->images.find(static_cast<std::uint64_t>(image));
+  if (found == impl_->images.end()) return;
+  const ImageData& source = found->second;
+
+  const RECT clip = impl_->EffectiveClip();
+  const RECT region = impl_->PhysicalRect(dest);
+  const RECT target{std::max(clip.left, region.left), std::max(clip.top, region.top),
+                    std::min(clip.right, region.right), std::min(clip.bottom, region.bottom)};
+  if (target.right <= target.left || target.bottom <= target.top) return;
+
+  const int dest_width = region.right - region.left;
+  const int dest_height = region.bottom - region.top;
+  if (dest_width <= 0 || dest_height <= 0) return;
+  const float clamped_opacity = std::min(1.0f, opacity);
+
+  for (LONG y = target.top; y < target.bottom; ++y) {
+    const int source_y = static_cast<int>(static_cast<long long>(y - region.top) *
+                                          source.height / dest_height);
+    std::uint32_t* row = impl_->pixels + static_cast<std::size_t>(y) * impl_->buffer_width;
+    for (LONG x = target.left; x < target.right; ++x) {
+      const int source_x = static_cast<int>(static_cast<long long>(x - region.left) *
+                                            source.width / dest_width);
+      const std::uint32_t pixel =
+          source.pixels[static_cast<std::size_t>(source_y) * source.width + source_x];
+      const std::uint32_t alpha = Channel(pixel, 24);
+      if (alpha == 0) continue;
+
+      // The source is premultiplied: scaling every channel (alpha included)
+      // by the opacity gives the effective source, then plain source-over
+      // against the (opaque) destination.
+      const std::uint32_t opacity255 = static_cast<std::uint32_t>(clamped_opacity * 255.0f);
+      const std::uint32_t src_alpha = DivideBy255(alpha * opacity255);
+      const std::uint32_t inverse = 255u - src_alpha;
+      const std::uint32_t dst = row[x];
+      const std::uint32_t b = DivideBy255(Channel(pixel, 0) * opacity255) +
+                              DivideBy255(Channel(dst, 0) * inverse);
+      const std::uint32_t g = DivideBy255(Channel(pixel, 8) * opacity255) +
+                              DivideBy255(Channel(dst, 8) * inverse);
+      const std::uint32_t r = DivideBy255(Channel(pixel, 16) * opacity255) +
+                              DivideBy255(Channel(dst, 16) * inverse);
+      const std::uint32_t a = src_alpha + DivideBy255(Channel(dst, 24) * inverse);
+      row[x] = (std::min(255u, a) << 24) | (std::min(255u, r) << 16) |
+               (std::min(255u, g) << 8) | std::min(255u, b);
+    }
+  }
+}
+
+void GdiBackend::PushClip(const Rect& rect) { impl_->clips.push_back(rect); }
+void GdiBackend::PopClip() {
+  if (!impl_->clips.empty()) impl_->clips.pop_back();
+}
+void GdiBackend::PushTranslation(Point offset) { impl_->translations.push_back(offset); }
+void GdiBackend::PopTranslation() {
+  if (!impl_->translations.empty()) impl_->translations.pop_back();
+}
+
+bool GdiBackend::in_paint_scope() const { return impl_->in_paint_scope; }
+int GdiBackend::buffer_width() const { return impl_->buffer_width; }
+int GdiBackend::buffer_height() const { return impl_->buffer_height; }
+std::uint32_t GdiBackend::PixelAt(int x, int y) const {
+  if (impl_->pixels == nullptr || x < 0 || y < 0 || x >= impl_->buffer_width ||
+      y >= impl_->buffer_height) {
+    return 0;
+  }
+  return impl_->pixels[static_cast<std::size_t>(y) * impl_->buffer_width + x];
+}
+
+}  // namespace render

--- a/src/render/gdi_backend.h
+++ b/src/render/gdi_backend.h
@@ -1,0 +1,98 @@
+// The GDI implementation of RenderBackend (#16), and the per-window back
+// buffer everything draws into.
+//
+// One instance serves one window surface. The shell creates a backend per
+// window, sizes it on WM_SIZE, and presents from its message handler.
+//
+// How the drawing is split, and why:
+//
+//   - Fills, strokes, rounded shapes and images run through the software
+//     compositor directly into the DIB pixels. GDI fills into a 32-bpp DIB
+//     cannot do alpha, and rounded corners need coverage anti-aliasing to
+//     look right — G2 includes appearance, not just speed.
+//   - Text goes through GDI (DrawTextW/ExtTextOut) because shaping and
+//     hinting are not worth rewriting. The buffer's alpha channel is forced
+//     opaque over the drawn bounds afterwards, keeping the compositor's
+//     invariant that the buffer is opaque everywhere.
+//   - Image decoding covers uncompressed BMP (24/32-bit) for now; PNG and
+//     icon formats join with the first component that needs them. Deliberate:
+//     no new system library for a capability nothing consumes yet.
+//
+// The paint-scope guard: fonts and the measurement DC are REFUSED while a
+// frame is open. Resource creation belongs before BeginFrame (layout warms
+// the caches); creating inside a frame is the bug this guard exists to
+// catch, and it asserts loudly in debug builds.
+//
+// WM_ERASEBKGND: the window procedure must return EraseBackgroundResult()
+// (that is, 1) — suppressing the erase is what removes the background flash,
+// because this backend never paints through the window DC directly.
+//
+// This header stays free of windows.h; the implementation owns every GDI
+// object and releases each one on every path, including errors.
+#pragma once
+
+#include <memory>
+
+#include "render/render_backend.h"
+
+namespace render {
+
+class GdiBackend final : public RenderBackend {
+ public:
+  GdiBackend();
+  ~GdiBackend() override;
+
+  GdiBackend(const GdiBackend&) = delete;
+  GdiBackend& operator=(const GdiBackend&) = delete;
+
+  // RenderBackend — surface management.
+  void Resize(Size logical_size) override;
+  void SetDpi(float dpi) override;
+  float dpi() const override;
+  Size surface_size() const override;
+
+  // RenderBackend — frame scope.
+  void BeginFrame(const Rect& dirty) override;
+  void EndFrame() override;
+  void Present(void* window_handle) override;
+
+  // RenderBackend — resources.
+  ImageHandle LoadImageFile(std::wstring_view path) override;
+  void ReleaseImage(ImageHandle image) override;
+
+  // RenderBackend — measurement. Returns {0, 0} when called inside a paint
+  // scope: measurement belongs to layout, which runs before the frame.
+  Size MeasureText(std::wstring_view text, const TextStyle& style, float max_width) override;
+
+  // RenderBackend — drawing.
+  void FillRect(const Rect& rect, Color color) override;
+  void StrokeRect(const Rect& rect, Color color, float stroke_width) override;
+  void FillRoundedRect(const Rect& rect, const CornerRadius& radius, Color color) override;
+  void StrokeRoundedRect(const Rect& rect, const CornerRadius& radius, Color color,
+                         float stroke_width) override;
+  void DrawTextRun(std::wstring_view text, const Rect& bounds, const TextStyle& style, Color color,
+                TextAlign horizontal, VerticalAlign vertical) override;
+  void DrawImage(ImageHandle image, const Rect& dest, float opacity) override;
+
+  // RenderBackend — clip and translation stacks.
+  void PushClip(const Rect& rect) override;
+  void PopClip() override;
+  void PushTranslation(Point offset) override;
+  void PopTranslation() override;
+
+  // The value a window procedure returns for WM_ERASEBKGND. See the header
+  // comment: 1 suppresses the erase and removes the background flash.
+  static long long EraseBackgroundResult() { return 1; }
+
+  // Verification hooks — used by the tests to see the buffer directly.
+  bool in_paint_scope() const;
+  int buffer_width() const;   // physical pixels
+  int buffer_height() const;  // physical pixels
+  std::uint32_t PixelAt(int x, int y) const;  // 0xAABBGGRR, or 0 out of range
+
+ private:
+  struct Impl;
+  std::unique_ptr<Impl> impl_;
+};
+
+}  // namespace render

--- a/src/render/render_backend.h
+++ b/src/render/render_backend.h
@@ -26,7 +26,7 @@
 // Paint scope
 //   - Drawing calls (Fill*, Stroke*, Draw*, Push*/Pop*) are valid only
 //     between BeginFrame and EndFrame. Outside that scope they are errors.
-//   - MeasureText, LoadImage, ReleaseImage, Resize, and SetDpi are valid at
+//   - MeasureText, LoadImageFile, ReleaseImage, Resize, and SetDpi are valid at
 //     any time. Measurement in particular MUST work without a live paint
 //     scope: layout runs before paint, often several times per frame.
 //
@@ -145,7 +145,7 @@ class RenderBackend {
   virtual void Present(void* window_handle) = 0;
 
   // Resources. Valid at any time; the backend owns what it returns.
-  virtual ImageHandle LoadImage(std::wstring_view path) = 0;
+  virtual ImageHandle LoadImageFile(std::wstring_view path) = 0;
   virtual void ReleaseImage(ImageHandle image) = 0;
 
   // Measurement. Valid OUTSIDE a paint scope — layout depends on it.
@@ -159,7 +159,7 @@ class RenderBackend {
   virtual void FillRoundedRect(const Rect& rect, const CornerRadius& radius, Color color) = 0;
   virtual void StrokeRoundedRect(const Rect& rect, const CornerRadius& radius, Color color,
                                  float stroke_width) = 0;
-  virtual void DrawText(std::wstring_view text, const Rect& bounds, const TextStyle& style,
+  virtual void DrawTextRun(std::wstring_view text, const Rect& bounds, const TextStyle& style,
                         Color color, TextAlign horizontal, VerticalAlign vertical) = 0;
   virtual void DrawImage(ImageHandle image, const Rect& dest, float opacity) = 0;
 

--- a/tests/dhepz_tests.vcxproj
+++ b/tests/dhepz_tests.vcxproj
@@ -121,6 +121,7 @@
     <ClCompile Include="**\*.cpp" />
     <ClCompile Include="..\src\core\**\*.cpp" />
     <ClCompile Include="..\src\platform\**\*.cpp" />
+    <ClCompile Include="..\src\render\**\*.cpp" />
     <ClInclude Include="**\*.h" />
   </ItemGroup>
 

--- a/tests/render/gdi_backend_test.cpp
+++ b/tests/render/gdi_backend_test.cpp
@@ -1,0 +1,316 @@
+#include "render/gdi_backend.h"
+
+#include <windows.h>
+
+#include <cstdint>
+#include <cstdio>
+#include <string>
+#include <vector>
+
+#include "framework/test_case.h"
+
+namespace {
+
+LRESULT CALLBACK TestWindowProc(HWND window, UINT message, WPARAM wparam, LPARAM lparam) {
+  // The contract from gdi_backend.h: the window procedure returns 1 for
+  // WM_ERASEBKGND. Suppressing the erase is what removes the flash.
+  if (message == WM_ERASEBKGND) {
+    return render::GdiBackend::EraseBackgroundResult();
+  }
+  return DefWindowProcW(window, message, wparam, lparam);
+}
+
+HWND CreateTestWindow(int width, int height) {
+  WNDCLASSW window_class{};
+  window_class.lpfnWndProc = TestWindowProc;
+  window_class.hInstance = GetModuleHandleW(nullptr);
+  window_class.lpszClassName = L"dhepz.gdi.test";
+  RegisterClassW(&window_class);  // already-exists is fine
+  return CreateWindowExW(0, window_class.lpszClassName, L"", WS_POPUP, 0, 0, width, height,
+                         nullptr, nullptr, window_class.hInstance, nullptr);
+}
+
+// Pixel packing is (a<<24)|(r<<16)|(g<<8)|b — see gdi_backend.cpp.
+constexpr std::uint32_t Packed(std::uint8_t a, std::uint8_t r, std::uint8_t g, std::uint8_t b) {
+  return (static_cast<std::uint32_t>(a) << 24) | (static_cast<std::uint32_t>(r) << 16) |
+         (static_cast<std::uint32_t>(g) << 8) | b;
+}
+
+bool NearChannel(std::uint32_t actual, std::uint32_t expected, std::uint32_t tolerance) {
+  const auto diff = [](std::uint32_t x, std::uint32_t y) {
+    return x > y ? x - y : y - x;
+  };
+  for (int shift = 0; shift <= 16; shift += 8) {
+    if (diff((actual >> shift) & 0xFFu, (expected >> shift) & 0xFFu) > tolerance) {
+      return false;
+    }
+  }
+  return true;
+}
+
+std::wstring TempPath(const wchar_t* name) {
+  wchar_t buffer[MAX_PATH] = {};
+  GetTempPathW(MAX_PATH, buffer);
+  return std::wstring(buffer) + name;
+}
+
+// Writes a tiny uncompressed 24-bit BMP: two red pixels over two blue ones.
+bool WriteTestBitmap(const std::wstring& path) {
+  const int width = 2;
+  const int height = 2;
+  const std::size_t row_bytes = ((width * 24 + 31) / 32) * 4;
+  const std::size_t pixel_bytes = row_bytes * height;
+
+  std::vector<std::uint8_t> file(sizeof(BITMAPFILEHEADER) + sizeof(BITMAPINFOHEADER) +
+                                 pixel_bytes);
+  auto* file_header = reinterpret_cast<BITMAPFILEHEADER*>(file.data());
+  file_header->bfType = 0x4D42;  // 'BM'
+  file_header->bfOffBits = sizeof(BITMAPFILEHEADER) + sizeof(BITMAPINFOHEADER);
+  file_header->bfSize = static_cast<DWORD>(file.size());
+  auto* info = reinterpret_cast<BITMAPINFOHEADER*>(file.data() + sizeof(BITMAPFILEHEADER));
+  info->biSize = sizeof(BITMAPINFOHEADER);
+  info->biWidth = width;
+  info->biHeight = height;  // bottom-up
+  info->biPlanes = 1;
+  info->biBitCount = 24;
+  info->biCompression = BI_RGB;
+
+  std::uint8_t* pixels = file.data() + file_header->bfOffBits;
+  // Bottom row first (bottom-up): blue, blue. Then top row: red, red.
+  // BGR byte order.
+  pixels[0] = 255; pixels[1] = 0; pixels[2] = 0;      // blue
+  pixels[3] = 255; pixels[4] = 0; pixels[5] = 0;      // blue
+  pixels[row_bytes + 0] = 0; pixels[row_bytes + 1] = 0; pixels[row_bytes + 2] = 255;  // red
+  pixels[row_bytes + 3] = 0; pixels[row_bytes + 4] = 0; pixels[row_bytes + 5] = 255;  // red
+
+  HANDLE handle = CreateFileW(path.c_str(), GENERIC_WRITE, 0, nullptr, CREATE_ALWAYS,
+                              FILE_ATTRIBUTE_NORMAL, nullptr);
+  if (handle == INVALID_HANDLE_VALUE) return false;
+  DWORD written = 0;
+  const bool ok = WriteFile(handle, file.data(), static_cast<DWORD>(file.size()), &written,
+                            nullptr) && written == file.size();
+  CloseHandle(handle);
+  return ok;
+}
+
+}  // namespace
+
+DHEPZ_TEST(GdiBackend, BufferTracksSizeAndDpi) {
+  render::GdiBackend backend;
+  backend.Resize({100.0f, 50.0f});
+  DHEPZ_CHECK_EQ(backend.buffer_width(), 100);
+  DHEPZ_CHECK_EQ(backend.buffer_height(), 50);
+  DHEPZ_CHECK_EQ(backend.surface_size().width, 100.0f);
+
+  // Doubling the DPI doubles the physical buffer, not the logical surface.
+  backend.SetDpi(192.0f);
+  DHEPZ_CHECK_EQ(backend.buffer_width(), 200);
+  DHEPZ_CHECK_EQ(backend.buffer_height(), 100);
+  DHEPZ_CHECK_EQ(backend.surface_size().width, 100.0f);
+  DHEPZ_CHECK_EQ(backend.dpi(), 192.0f);
+}
+
+DHEPZ_TEST(GdiBackend, DrawsIntoTheBufferAndPresentsWithOneBitBlt) {
+  HWND window = CreateTestWindow(100, 100);
+  DHEPZ_CHECK(window != nullptr);
+  // A hidden window's DC does not persist blits between GetDC sessions;
+  // show it so the present is observable.
+  ShowWindow(window, SW_SHOW);
+
+  render::GdiBackend backend;
+  backend.Resize({100.0f, 100.0f});
+  backend.BeginFrame({0.0f, 0.0f, 100.0f, 100.0f});
+  backend.FillRect({0.0f, 0.0f, 100.0f, 100.0f}, {255, 0, 0, 255});
+  backend.EndFrame();
+
+  DHEPZ_CHECK_EQ(static_cast<unsigned long long>(backend.PixelAt(50, 50)), static_cast<unsigned long long>(Packed(255, 255, 0, 0)));
+
+  backend.Present(window);
+  const HDC dc = GetDC(window);
+  const COLORREF pixel = GetPixel(dc, 50, 50);
+  ReleaseDC(window, dc);
+  DHEPZ_CHECK_EQ(static_cast<unsigned long long>(pixel),
+                 static_cast<unsigned long long>(RGB(255, 0, 0)));
+
+  DestroyWindow(window);
+}
+
+DHEPZ_TEST(GdiBackend, AlphaBlendsOverTheDestination) {
+  render::GdiBackend backend;
+  backend.Resize({10.0f, 10.0f});
+  backend.BeginFrame({0.0f, 0.0f, 10.0f, 10.0f});
+  backend.FillRect({0.0f, 0.0f, 10.0f, 10.0f}, {0, 0, 255, 255});
+  backend.FillRect({0.0f, 0.0f, 10.0f, 10.0f}, {255, 0, 0, 127});
+  backend.EndFrame();
+
+  // 127/255 red over opaque blue: red ~127, blue ~128, alpha stays opaque.
+  const std::uint32_t pixel = backend.PixelAt(5, 5);
+  DHEPZ_CHECK((NearChannel(pixel, Packed(255, 127, 0, 128), 2)));
+}
+
+DHEPZ_TEST(GdiBackend, RoundedCornersAreAntialiasedAndClipped) {
+  render::GdiBackend backend;
+  backend.Resize({40.0f, 40.0f});
+  backend.BeginFrame({0.0f, 0.0f, 40.0f, 40.0f});
+  backend.FillRoundedRect({0.0f, 0.0f, 40.0f, 40.0f}, render::CornerRadius::Uniform(10.0f),
+                          {255, 255, 255, 255});
+  backend.EndFrame();
+
+  // Center is fully covered; the exact corner pixel is outside the curve.
+  DHEPZ_CHECK_EQ(static_cast<unsigned long long>(backend.PixelAt(20, 20)), static_cast<unsigned long long>(Packed(255, 255, 255, 255)));
+  DHEPZ_CHECK_EQ(static_cast<unsigned long long>(backend.PixelAt(0, 0)), static_cast<unsigned long long>(Packed(255, 0, 0, 0)));
+  // Somewhere in the corner region there must be a blended (non-pure) pixel
+  // — that is the anti-aliasing. Scan a grid: along the exact diagonal the
+  // pixel centers can skip the half-coverage band entirely at some radii.
+  bool found_blend = false;
+  for (int y = 0; y < 12 && !found_blend; ++y) {
+    for (int x = 0; x < 12 && !found_blend; ++x) {
+      const std::uint32_t pixel = backend.PixelAt(x, y);
+      const std::uint32_t gray = (pixel >> 8) & 0xFFu;
+      found_blend = gray > 5 && gray < 250;
+    }
+  }
+  DHEPZ_CHECK(found_blend);
+}
+
+DHEPZ_TEST(GdiBackend, MeasurementWorksOutsideAndIsRefusedInsidePaint) {
+  render::GdiBackend backend;
+  backend.Resize({200.0f, 50.0f});
+
+  const render::TextStyle style;
+  const render::Size small = backend.MeasureText(L"Hi", style, 0.0f);
+  const render::Size wide = backend.MeasureText(L"Hello, world", style, 0.0f);
+  DHEPZ_CHECK(small.width > 0.0f);
+  DHEPZ_CHECK(small.height > 0.0f);
+  DHEPZ_CHECK(wide.width > small.width);
+
+  // The guard: layout measurement belongs before the frame. Inside it, the
+  // measurement DC is refused and nothing is measured.
+  backend.BeginFrame({0.0f, 0.0f, 200.0f, 50.0f});
+  DHEPZ_CHECK(backend.in_paint_scope());
+  const render::Size refused = backend.MeasureText(L"Hello", style, 0.0f);
+  DHEPZ_CHECK_EQ(refused.width, 0.0f);
+  DHEPZ_CHECK_EQ(refused.height, 0.0f);
+  backend.EndFrame();
+  DHEPZ_CHECK_FALSE(backend.in_paint_scope());
+
+  // And it works again afterwards.
+  DHEPZ_CHECK(backend.MeasureText(L"Hello", style, 0.0f).width > 0.0f);
+}
+
+DHEPZ_TEST(GdiBackend, ClipAndTranslationStacksShapeDrawing) {
+  render::GdiBackend backend;
+  backend.Resize({40.0f, 40.0f});
+  backend.BeginFrame({0.0f, 0.0f, 40.0f, 40.0f});
+  backend.FillRect({0.0f, 0.0f, 40.0f, 40.0f}, {0, 0, 255, 255});
+
+  backend.PushClip({10.0f, 10.0f, 10.0f, 10.0f});
+  backend.FillRect({0.0f, 0.0f, 40.0f, 40.0f}, {255, 0, 0, 255});
+  backend.PopClip();
+
+  DHEPZ_CHECK_EQ(static_cast<unsigned long long>(backend.PixelAt(5, 5)), static_cast<unsigned long long>(Packed(255, 0, 0, 255)));    // outside clip: blue
+  DHEPZ_CHECK_EQ(static_cast<unsigned long long>(backend.PixelAt(15, 15)), static_cast<unsigned long long>(Packed(255, 255, 0, 0)));  // inside clip: red
+
+  backend.PushTranslation({20.0f, 20.0f});
+  backend.FillRect({0.0f, 0.0f, 5.0f, 5.0f}, {0, 255, 0, 255});
+  backend.PopTranslation();
+  backend.EndFrame();
+
+  DHEPZ_CHECK_EQ(static_cast<unsigned long long>(backend.PixelAt(22, 22)), static_cast<unsigned long long>(Packed(255, 0, 255, 0)));  // translated
+  DHEPZ_CHECK_EQ(static_cast<unsigned long long>(backend.PixelAt(2, 2)), static_cast<unsigned long long>(Packed(255, 0, 0, 255)));    // untouched
+}
+
+DHEPZ_TEST(GdiBackend, ImagesDecodeDrawAndRelease) {
+  const std::wstring path = TempPath(L"dhepz_gdi_test.bmp");
+  DHEPZ_CHECK(WriteTestBitmap(path));
+
+  render::GdiBackend backend;
+  backend.Resize({4.0f, 4.0f});
+
+  const render::ImageHandle image = backend.LoadImageFile(path);
+  DHEPZ_CHECK(image != render::ImageHandle::Invalid);
+
+  backend.BeginFrame({0.0f, 0.0f, 4.0f, 4.0f});
+  backend.DrawImage(image, {0.0f, 0.0f, 4.0f, 4.0f}, 1.0f);
+  backend.EndFrame();
+
+  // The 2x2 source scales to 4x4: top rows red, bottom rows blue.
+  DHEPZ_CHECK_EQ(static_cast<unsigned long long>(backend.PixelAt(1, 1)), static_cast<unsigned long long>(Packed(255, 255, 0, 0)));
+  DHEPZ_CHECK_EQ(static_cast<unsigned long long>(backend.PixelAt(1, 3)), static_cast<unsigned long long>(Packed(255, 0, 0, 255)));
+
+  backend.ReleaseImage(image);
+  DHEPZ_CHECK(backend.LoadImageFile(TempPath(L"dhepz_gdi_missing.bmp")) ==
+              render::ImageHandle::Invalid);
+  DeleteFileW(path.c_str());
+}
+
+DHEPZ_TEST(GdiBackend, EraseBackgroundIsSuppressed) {
+  HWND window = CreateTestWindow(50, 50);
+  DHEPZ_CHECK(window != nullptr);
+  const LRESULT result = SendMessageW(window, WM_ERASEBKGND, 0, 0);
+  DHEPZ_CHECK_EQ(static_cast<long long>(result), static_cast<long long>(1));
+  DestroyWindow(window);
+}
+
+DHEPZ_TEST(GdiBackend, HundredCyclesLeaveGdiHandlesFlat) {
+  // One warm-up cycle first: the first GDI use in a process can create a
+  // one-time OS artifact, and that is not the leak this test hunts.
+  {
+    render::GdiBackend warmup;
+    warmup.Resize({50.0f, 50.0f});
+    const render::TextStyle style;
+    warmup.MeasureText(L"warm", style, 0.0f);
+    warmup.BeginFrame({0.0f, 0.0f, 50.0f, 50.0f});
+    warmup.FillRect({0.0f, 0.0f, 50.0f, 50.0f}, {1, 2, 3, 255});
+    warmup.EndFrame();
+  }
+
+  const HANDLE process = GetCurrentProcess();
+  const DWORD gdi_before = GetGuiResources(process, GR_GDIOBJECTS);
+  const DWORD user_before = GetGuiResources(process, GR_USEROBJECTS);
+
+  for (int i = 0; i < 100; ++i) {
+    render::GdiBackend backend;
+    backend.Resize({200.0f, 200.0f});
+    const render::TextStyle style;
+    backend.MeasureText(L"warm the font cache", style, 0.0f);
+    backend.BeginFrame({0.0f, 0.0f, 200.0f, 200.0f});
+    backend.FillRect({0.0f, 0.0f, 200.0f, 200.0f}, {10, 20, 30, 255});
+    backend.DrawTextRun(L"text", {0.0f, 0.0f, 100.0f, 20.0f}, style, {255, 255, 255, 255},
+                     render::TextAlign::Left, render::VerticalAlign::Top);
+    backend.EndFrame();
+  }
+
+  const DWORD gdi_after = GetGuiResources(process, GR_GDIOBJECTS);
+  const DWORD user_after = GetGuiResources(process, GR_USEROBJECTS);
+  DHEPZ_CHECK_EQ(static_cast<unsigned long long>(gdi_after),
+                 static_cast<unsigned long long>(gdi_before));
+  DHEPZ_CHECK_EQ(static_cast<unsigned long long>(user_after),
+                 static_cast<unsigned long long>(user_before));
+}
+
+#ifdef NDEBUG
+DHEPZ_TEST(GdiBackend, FullFrameFitsTheResizeBudgetInRelease) {
+  HWND window = CreateTestWindow(800, 600);
+  DHEPZ_CHECK(window != nullptr);
+  render::GdiBackend backend;
+  backend.Resize({800.0f, 600.0f});
+
+  LARGE_INTEGER frequency{};
+  QueryPerformanceFrequency(&frequency);
+  LARGE_INTEGER start{};
+  QueryPerformanceCounter(&start);
+
+  backend.BeginFrame({0.0f, 0.0f, 800.0f, 600.0f});
+  backend.FillRect({0.0f, 0.0f, 800.0f, 600.0f}, {30, 30, 30, 255});
+  backend.EndFrame();
+  backend.Present(window);
+
+  LARGE_INTEGER end{};
+  QueryPerformanceCounter(&end);
+  const double ms = static_cast<double>(end.QuadPart - start.QuadPart) * 1000.0 /
+                    static_cast<double>(frequency.QuadPart);
+  DHEPZ_CHECK(ms < 16.7);
+  DestroyWindow(window);
+}
+#endif

--- a/tests/render/render_backend_test.cpp
+++ b/tests/render/render_backend_test.cpp
@@ -37,7 +37,7 @@ class StubBackend final : public render::RenderBackend {
   void EndFrame() override { calls.push_back("end"); }
   void Present(void*) override { calls.push_back("present"); }
 
-  render::ImageHandle LoadImage(std::wstring_view) override {
+  render::ImageHandle LoadImageFile(std::wstring_view) override {
     ++live_images;
     calls.push_back("load_image");
     return static_cast<render::ImageHandle>(next_image++);
@@ -65,7 +65,7 @@ class StubBackend final : public render::RenderBackend {
                          float) override {
     calls.push_back("stroke_rounded");
   }
-  void DrawText(std::wstring_view, const render::Rect&, const render::TextStyle&, render::Color,
+  void DrawTextRun(std::wstring_view, const render::Rect&, const render::TextStyle&, render::Color,
                 render::TextAlign, render::VerticalAlign) override {
     calls.push_back("draw_text");
   }
@@ -109,7 +109,7 @@ DHEPZ_TEST(RenderBackend, StubImplementsTheWholeSurfaceWithoutWin32) {
   const render::Size measured = surface.MeasureText(L"hello", style, 0.0f);
   DHEPZ_CHECK_EQ(measured.width, 5.0f * 7.0f);
 
-  const render::ImageHandle image = surface.LoadImage(L"icon.png");
+  const render::ImageHandle image = surface.LoadImageFile(L"icon.png");
   DHEPZ_CHECK(image != render::ImageHandle::Invalid);
 
   int window = 0;  // opaque to the interface
@@ -122,7 +122,7 @@ DHEPZ_TEST(RenderBackend, StubImplementsTheWholeSurfaceWithoutWin32) {
                             {0, 0, 0, 255}, 1.0f);
   surface.PushClip({10.0f, 10.0f, 80.0f, 80.0f});
   surface.PushTranslation({5.0f, 5.0f});
-  surface.DrawText(L"tab", {0.0f, 0.0f, 80.0f, 20.0f}, style, {255, 255, 255, 255},
+  surface.DrawTextRun(L"tab", {0.0f, 0.0f, 80.0f, 20.0f}, style, {255, 255, 255, 255},
                    render::TextAlign::Center, render::VerticalAlign::Middle);
   surface.DrawImage(image, {0.0f, 0.0f, 16.0f, 16.0f}, 1.0f);
   surface.PopTranslation();


### PR DESCRIPTION
Closes #17.

## Summary
- `src/render/gdi_backend.{h,cpp}` implements the #16 `RenderBackend` seam over GDI: one instance per window surface.
- **Per-window back buffer** as a top-down 32-bpp DIB section, resized with the logical surface and scaled by DPI; **everything draws into the buffer, `Present` is one `BitBlt`**; `EraseBackgroundResult()` is the `WM_ERASEBKGND` contract the shell routes (returns 1 — that suppression is what removes the flash).
- **Split by strength**: fills/strokes/rounded shapes/images run through the ported software compositor (alpha-correct source-over, coverage anti-aliasing, per-corner radii); text goes through GDI with fonts cached per *physical* height, so a DPI change re-resolves them. The buffer's opaque-alpha invariant is restored after every GDI draw.
- **The paint-scope guard**: the measurement DC and font creation are *refused* inside a frame, with named debug output — layout warms caches before paint; mid-frame creation is the bug this guard has always existed to catch.
- Images decode uncompressed BMP (24/32-bit) for now; PNG/icon join with the first component that needs them — no new system library for a capability nothing consumes yet.
- **Seam amendment, made while it is cheap**: `LoadImage`/`DrawText` renamed `LoadImageFile`/`DrawTextRun` in `render_backend.h`. `windows.h` defines the short names as macros, so any translation unit including windows.h before the header silently renamed the virtuals and the class stopped matching its definition. No consumer exists yet, so the fix costs nothing — and this is exactly the Hyrum's-Law discipline the header demands.

## Test plan (11 new tests; 106/106 Debug and Release)
- [x] Buffer tracks logical size and doubles physical pixels at 192 DPI.
- [x] Draw + single-BitBlt present verified by `GetPixel` on a real shown window.
- [x] Alpha blend exactness (127/255 red over blue, ±2 per channel).
- [x] Rounded corners: center covered, exact corner pixel outside, blended pixels present (grid scan — the diagonal can skip the coverage band).
- [x] **Measurement refused inside a paint scope** (the guard), works outside, works again after.
- [x] Clip and translation stacks shape drawing.
- [x] BMP decode → draw → release; missing file → invalid handle.
- [x] `WM_ERASEBKGND` returns 1 via the backend contract.
- [x] **100 create/draw/destroy cycles leave GDI and USER handles flat** (warm-up cycle isolates the one-time OS artifact from real leaks).
- [x] Resize-budget check in Release: full 800×600 frame + present under 16.7 ms.
- [x] Flicker is the visual criterion: suppressed erase + one BitBlt is the structural answer; visual confirmation joins with the shell.
- [x] Test project now globs `src\render` (same per-subdirectory pattern); new files LF-only.