### PR TITLE
feat(render): add dirty-rect invalidation to the seam and GDI backend (#18)

### DIFF
--- a/src/render/gdi_backend.cpp
+++ b/src/render/gdi_backend.cpp
@@ -140,6 +140,10 @@ struct GdiBackend::Impl {
   bool in_paint_scope = false;
   Rect dirty{};
 
+  // Pending invalidation in logical coordinates, coalesced into its union.
+  Rect invalidation{};
+  bool has_invalidation = false;
+
   std::vector<Rect> clips;
   std::vector<Point> translations;
 
@@ -394,15 +398,60 @@ struct GdiBackend::Impl {
     fonts.clear();
     images.clear();
   }
+
+  // Accumulates one region into the pending union, clipped to the surface.
+  void AddInvalidation(const Rect& region) noexcept {
+    if (logical_size.width <= 0.0f || logical_size.height <= 0.0f) return;
+    const float left = std::max(0.0f, region.x);
+    const float top = std::max(0.0f, region.y);
+    const float right = std::min(logical_size.width, region.right());
+    const float bottom = std::min(logical_size.height, region.bottom());
+    if (right <= left || bottom <= top) return;
+    if (!has_invalidation) {
+      invalidation = Rect{left, top, right - left, bottom - top};
+      has_invalidation = true;
+      return;
+    }
+    const float merged_left = std::min(invalidation.x, left);
+    const float merged_top = std::min(invalidation.y, top);
+    const float merged_right = std::max(invalidation.right(), right);
+    const float merged_bottom = std::max(invalidation.bottom(), bottom);
+    invalidation = Rect{merged_left, merged_top, merged_right - merged_left,
+                        merged_bottom - merged_top};
+  }
 };
 
 GdiBackend::GdiBackend() : impl_(std::make_unique<Impl>()) {}
 GdiBackend::~GdiBackend() { impl_->ReleaseAll(); }
 
 void GdiBackend::Resize(Size logical_size) {
+  const int old_width = impl_->buffer_width;
+  const int old_height = impl_->buffer_height;
   impl_->logical_size = logical_size;
   impl_->EnsureBuffer(impl_->Physical(logical_size.width),
                       impl_->Physical(logical_size.height));
+  // A fresh or resized buffer has no presented content: everything must be
+  // painted on the next frame.
+  if (impl_->buffer_width != old_width || impl_->buffer_height != old_height) {
+    InvalidateAll();
+  }
+}
+
+void GdiBackend::Invalidate(const Rect& region) { impl_->AddInvalidation(region); }
+
+void GdiBackend::InvalidateAll() {
+  impl_->AddInvalidation(Rect{0.0f, 0.0f, impl_->logical_size.width,
+                              impl_->logical_size.height});
+}
+
+bool GdiBackend::HasInvalidation() const { return impl_->has_invalidation; }
+
+bool GdiBackend::TakeInvalidation(Rect& out) {
+  if (!impl_->has_invalidation) return false;
+  out = impl_->invalidation;
+  impl_->invalidation = Rect{};
+  impl_->has_invalidation = false;
+  return true;
 }
 
 void GdiBackend::SetDpi(float dpi) {

--- a/src/render/gdi_backend.h
+++ b/src/render/gdi_backend.h
@@ -56,6 +56,12 @@ class GdiBackend final : public RenderBackend {
   void EndFrame() override;
   void Present(void* window_handle) override;
 
+  // RenderBackend — invalidation.
+  void Invalidate(const Rect& region) override;
+  void InvalidateAll() override;
+  bool HasInvalidation() const override;
+  bool TakeInvalidation(Rect& out) override;
+
   // RenderBackend — resources.
   ImageHandle LoadImageFile(std::wstring_view path) override;
   void ReleaseImage(ImageHandle image) override;

--- a/src/render/render_backend.h
+++ b/src/render/render_backend.h
@@ -144,6 +144,18 @@ class RenderBackend {
   // the shell knows what it really is.
   virtual void Present(void* window_handle) = 0;
 
+  // Invalidation. A component marks what changed; the regions accumulate,
+  // coalescing into their union. TakeInvalidation atomically takes and
+  // clears the pending region — the shell then opens exactly one frame
+  // clipped to it, so ten invalidations in one message-loop iteration cost
+  // one paint. Invalidating while no window is visible merely accumulates:
+  // nothing paints and nothing is armed (G1). Regions are clipped to the
+  // surface.
+  virtual void Invalidate(const Rect& region) = 0;
+  virtual void InvalidateAll() = 0;
+  virtual bool HasInvalidation() const = 0;
+  virtual bool TakeInvalidation(Rect& out) = 0;
+
   // Resources. Valid at any time; the backend owns what it returns.
   virtual ImageHandle LoadImageFile(std::wstring_view path) = 0;
   virtual void ReleaseImage(ImageHandle image) = 0;

--- a/tests/render/gdi_backend_test.cpp
+++ b/tests/render/gdi_backend_test.cpp
@@ -314,3 +314,109 @@ DHEPZ_TEST(GdiBackend, FullFrameFitsTheResizeBudgetInRelease) {
   DestroyWindow(window);
 }
 #endif
+
+DHEPZ_TEST(GdiBackend, InvalidationsCoalesceIntoOneUnion) {
+  render::GdiBackend backend;
+  backend.Resize({100.0f, 100.0f});
+  render::Rect drain{};
+  DHEPZ_CHECK(backend.TakeInvalidation(drain));  // fresh-buffer invalidation
+  DHEPZ_CHECK_FALSE(backend.HasInvalidation());
+
+  // Ten separate invalidations in one message-loop iteration...
+  for (int i = 0; i < 10; ++i) {
+    backend.Invalidate({static_cast<float>(i * 5), 10.0f, 4.0f, 4.0f});
+  }
+  DHEPZ_CHECK(backend.HasInvalidation());
+
+  // ...are taken as exactly one region: their bounding union.
+  render::Rect dirty{};
+  DHEPZ_CHECK(backend.TakeInvalidation(dirty));
+  DHEPZ_CHECK_EQ(dirty.x, 0.0f);
+  DHEPZ_CHECK_EQ(dirty.y, 10.0f);
+  DHEPZ_CHECK_EQ(dirty.right(), 49.0f);
+  DHEPZ_CHECK_EQ(dirty.bottom(), 14.0f);
+
+  // Take clears: nothing pending until the next invalidation.
+  DHEPZ_CHECK_FALSE(backend.HasInvalidation());
+  DHEPZ_CHECK_FALSE(backend.TakeInvalidation(dirty));
+}
+
+DHEPZ_TEST(GdiBackend, InvalidationIsClippedToTheSurface) {
+  render::GdiBackend backend;
+  backend.Resize({50.0f, 50.0f});
+  render::Rect drain{};
+  DHEPZ_CHECK(backend.TakeInvalidation(drain));  // fresh-buffer invalidation
+
+  backend.Invalidate({-20.0f, -20.0f, 40.0f, 40.0f});
+  render::Rect dirty{};
+  DHEPZ_CHECK(backend.TakeInvalidation(dirty));
+  DHEPZ_CHECK_EQ(dirty.x, 0.0f);
+  DHEPZ_CHECK_EQ(dirty.y, 0.0f);
+  DHEPZ_CHECK_EQ(dirty.right(), 20.0f);
+  DHEPZ_CHECK_EQ(dirty.bottom(), 20.0f);
+
+  // Fully outside the surface: nothing pending.
+  backend.Invalidate({60.0f, 60.0f, 10.0f, 10.0f});
+  DHEPZ_CHECK_FALSE(backend.HasInvalidation());
+}
+
+DHEPZ_TEST(GdiBackend, AResizedBufferInvalidatesEverything) {
+  render::GdiBackend backend;
+  backend.Resize({40.0f, 40.0f});
+  render::Rect dirty{};
+  DHEPZ_CHECK(backend.TakeInvalidation(dirty));
+  DHEPZ_CHECK_EQ(dirty.width, 40.0f);
+  DHEPZ_CHECK_EQ(dirty.height, 40.0f);
+
+  // Same size again: nothing new pending.
+  backend.Resize({40.0f, 40.0f});
+  DHEPZ_CHECK_FALSE(backend.HasInvalidation());
+
+  // A real resize marks the whole surface dirty again.
+  backend.Resize({60.0f, 30.0f});
+  DHEPZ_CHECK(backend.TakeInvalidation(dirty));
+  DHEPZ_CHECK_EQ(dirty.width, 60.0f);
+  DHEPZ_CHECK_EQ(dirty.height, 30.0f);
+}
+
+DHEPZ_TEST(GdiBackend, PaintTouchesOnlyTheDirtyRegion) {
+  render::GdiBackend backend;
+  backend.Resize({40.0f, 40.0f});
+
+  // First frame paints the base (the fresh buffer is fully invalidated).
+  render::Rect dirty{};
+  DHEPZ_CHECK(backend.TakeInvalidation(dirty));
+  backend.BeginFrame(dirty);
+  backend.FillRect({0.0f, 0.0f, 40.0f, 40.0f}, {0, 0, 255, 255});
+  backend.EndFrame();
+
+  // A caret-sized invalidation: the next frame is clipped to it, so a
+  // full-surface draw only changes those pixels.
+  backend.Invalidate({10.0f, 10.0f, 2.0f, 20.0f});
+  DHEPZ_CHECK(backend.TakeInvalidation(dirty));
+  DHEPZ_CHECK_EQ(dirty.width, 2.0f);
+  backend.BeginFrame(dirty);
+  backend.FillRect({0.0f, 0.0f, 40.0f, 40.0f}, {255, 0, 0, 255});
+  backend.EndFrame();
+
+  DHEPZ_CHECK_EQ(static_cast<unsigned long long>(backend.PixelAt(11, 15)),
+                 static_cast<unsigned long long>(Packed(255, 255, 0, 0)));  // dirty: red
+  DHEPZ_CHECK_EQ(static_cast<unsigned long long>(backend.PixelAt(5, 15)),
+                 static_cast<unsigned long long>(Packed(255, 0, 0, 255)));  // outside: blue
+  DHEPZ_CHECK_EQ(static_cast<unsigned long long>(backend.PixelAt(30, 30)),
+                 static_cast<unsigned long long>(Packed(255, 0, 0, 255)));  // outside: blue
+}
+
+DHEPZ_TEST(GdiBackend, InvalidationWhileIdleOnlyAccumulates) {
+  render::GdiBackend backend;
+  backend.Resize({20.0f, 20.0f});
+  render::Rect dirty{};
+  DHEPZ_CHECK(backend.TakeInvalidation(dirty));  // fresh-buffer invalidation
+
+  // With no frame run, invalidating changes nothing in the buffer and arms
+  // nothing: it merely accumulates until someone paints.
+  backend.Invalidate({0.0f, 0.0f, 5.0f, 5.0f});
+  DHEPZ_CHECK_EQ(static_cast<unsigned long long>(backend.PixelAt(2, 2)),
+                 static_cast<unsigned long long>(Packed(255, 0, 0, 0)));
+  DHEPZ_CHECK(backend.HasInvalidation());
+}

--- a/tests/render/render_backend_test.cpp
+++ b/tests/render/render_backend_test.cpp
@@ -37,6 +37,11 @@ class StubBackend final : public render::RenderBackend {
   void EndFrame() override { calls.push_back("end"); }
   void Present(void*) override { calls.push_back("present"); }
 
+  void Invalidate(const render::Rect&) override { calls.push_back("invalidate"); }
+  void InvalidateAll() override { calls.push_back("invalidate_all"); }
+  bool HasInvalidation() const override { return false; }
+  bool TakeInvalidation(render::Rect&) override { return false; }
+
   render::ImageHandle LoadImageFile(std::wstring_view) override {
     ++live_images;
     calls.push_back("load_image");


### PR DESCRIPTION
Closes #18.

## Summary
- **Seam gains the invalidation contract** (`render_backend.h`): `Invalidate`, `InvalidateAll`, `HasInvalidation`, `TakeInvalidation` — documented as accumulate-into-union, atomic take-and-clear, clipped to the surface, and *never* arming anything at idle.
- **GDI backend implements it**: regions coalesce into their bounding union in logical coordinates; a fresh or resized buffer invalidates itself so the first frame paints everything; `TakeInvalidation` hands the shell exactly one dirty region per paint.
- Clipping to the dirty region was already in the #17 frame path (`EffectiveClip`); this PR proves it: a full-surface draw inside a caret-sized frame changes only the caret's pixels.

## Test plan (5 new tests; 111/111 Debug and Release)
- [x] **Ten invalidations in one iteration → one union → one take**; take clears (the issue's explicit verification).
- [x] Caret-sized (2×20) invalidation: a full-surface fill inside that frame touches only the caret's pixels — the "invalidate only its own bounds" mechanism.
- [x] Regions clip to the surface; fully-outside regions add nothing.
- [x] Resized buffer invalidates everything; same-size resize adds nothing.
- [x] **Invalidating while idle only accumulates** — buffer untouched, no frame, no timer (structural: no timer code exists in the layer).
- [x] Trace-based verifications ("typing produces one paint of the text field", input-to-paint ≤ 16 ms via correlation IDs) deferred until components and the ETW consumer exist — recorded here, same pattern as earlier deferrals.
- [x] New code LF-only; stub backend updated to the wider seam.