### PR TITLE
feat(render): add the bounded, epoch-keyed GDI resource cache (#19)

### DIFF
--- a/src/render/gdi_backend.cpp
+++ b/src/render/gdi_backend.cpp
@@ -6,9 +6,10 @@
 #include <cmath>
 #include <cstdint>
 #include <cstring>
-#include <map>
 #include <string>
 #include <vector>
+
+#include "render/gdi_resource_cache.h"
 
 namespace render {
 namespace {
@@ -52,26 +53,6 @@ std::uint32_t SourceOverPremultiplied(std::uint32_t destination, std::uint32_t s
   return (std::min(255u, alpha) << 24) | (std::min(255u, red) << 16) |
          (std::min(255u, green) << 8) | std::min(255u, blue);
 }
-
-struct ImageData {
-  int width = 0;
-  int height = 0;
-  std::vector<std::uint32_t> pixels;  // premultiplied, same packing as the buffer
-};
-
-struct FontKey {
-  std::wstring family;
-  int height_px = 0;
-  int weight = FW_NORMAL;
-  bool italic = false;
-
-  bool operator<(const FontKey& other) const noexcept {
-    if (family != other.family) return family < other.family;
-    if (height_px != other.height_px) return height_px < other.height_px;
-    if (weight != other.weight) return weight < other.weight;
-    return italic < other.italic;
-  }
-};
 
 int ToGdiWeight(FontWeight weight) noexcept {
   switch (weight) {
@@ -148,9 +129,8 @@ struct GdiBackend::Impl {
   std::vector<Point> translations;
 
   HDC measurement_dc = nullptr;
-  std::map<FontKey, HFONT> fonts;
-  std::map<std::uint64_t, ImageData> images;
-  std::uint64_t next_image = 1;
+  GdiResourceCache* cache = nullptr;
+  bool owns_cache = false;
 
   float scale() const noexcept { return dpi / 96.0f; }
 
@@ -272,24 +252,19 @@ struct GdiBackend::Impl {
   }
 
   HFONT FontFor(const TextStyle& style) noexcept {
-    FontKey key{style.family, Physical(style.size_px), ToGdiWeight(style.weight), style.italic};
-    if (const auto found = fonts.find(key); found != fonts.end()) {
-      return found->second;
+    // Fonts live in the shared cache's theme layer: created on demand,
+    // bounded, and discarded wholesale by an epoch bump. Warmed fonts are
+    // usable inside a frame; CREATING one mid-frame is the bug the guard
+    // exists to catch.
+    FontSpec spec{style.family, Physical(style.size_px), ToGdiWeight(style.weight), style.italic};
+    if (const HFONT cached = cache->FindFont(spec)) {
+      return cached;
     }
     if (in_paint_scope) {
-      // Fonts are warmed by layout (MeasureText) before the frame. Creating
-      // one mid-frame is the bug the guard exists to catch.
       OutputDebugStringW(L"dhepz: font creation refused inside a paint scope\n");
       return nullptr;
     }
-    const HFONT font = CreateFontW(-key.height_px, 0, 0, 0, key.weight, key.italic ? TRUE : FALSE,
-                                   FALSE, FALSE, DEFAULT_CHARSET, OUT_DEFAULT_PRECIS,
-                                   CLIP_DEFAULT_PRECIS, CLEARTYPE_QUALITY,
-                                   DEFAULT_PITCH | FF_DONTCARE, key.family.c_str());
-    if (font != nullptr) {
-      fonts.emplace(std::move(key), font);
-    }
-    return font;
+    return cache->Font(spec);
   }
 
   // Restores the buffer's opaque-alpha invariant over a region after a GDI
@@ -392,11 +367,12 @@ struct GdiBackend::Impl {
     ReleaseBuffer();
     if (measurement_dc != nullptr) DeleteDC(measurement_dc);
     measurement_dc = nullptr;
-    for (const auto& entry : fonts) {
-      DeleteObject(entry.second);
+    // The window layer (this buffer) dies with the backend; the shared
+    // layers survive unless this backend owns the cache outright.
+    if (owns_cache) {
+      delete cache;
     }
-    fonts.clear();
-    images.clear();
+    cache = nullptr;
   }
 
   // Accumulates one region into the pending union, clipped to the surface.
@@ -421,7 +397,16 @@ struct GdiBackend::Impl {
   }
 };
 
-GdiBackend::GdiBackend() : impl_(std::make_unique<Impl>()) {}
+GdiBackend::GdiBackend(GdiResourceCache* shared_cache) : impl_(std::make_unique<Impl>()) {
+  if (shared_cache != nullptr) {
+    impl_->cache = shared_cache;
+    impl_->owns_cache = false;
+  } else {
+    impl_->cache = new GdiResourceCache();
+    impl_->owns_cache = true;
+  }
+}
+
 GdiBackend::~GdiBackend() { impl_->ReleaseAll(); }
 
 void GdiBackend::Resize(Size logical_size) {
@@ -457,12 +442,9 @@ bool GdiBackend::TakeInvalidation(Rect& out) {
 void GdiBackend::SetDpi(float dpi) {
   if (dpi <= 0.0f) return;
   impl_->dpi = dpi;
-  // Fonts are keyed by physical height; a DPI change orphans them. The
-  // epoch/cache machinery of #19 will manage this at scale.
-  for (const auto& entry : impl_->fonts) {
-    DeleteObject(entry.second);
-  }
-  impl_->fonts.clear();
+  // A DPI change is an epoch change: the theme layer is discarded in one
+  // operation and fonts re-resolve at the new physical heights.
+  impl_->cache->AdvanceEpoch();
   if (impl_->logical_size.width > 0.0f) {
     Resize(impl_->logical_size);
   }
@@ -515,13 +497,13 @@ ImageHandle GdiBackend::LoadImageFile(std::wstring_view path) {
     return ImageHandle::Invalid;
   }
 
-  const std::uint64_t id = impl_->next_image++;
-  impl_->images.emplace(id, std::move(image));
+  // Process layer of the shared cache: decoded once, survives every window.
+  const std::uint64_t id = impl_->cache->StoreImage(std::move(image));
   return static_cast<ImageHandle>(id);
 }
 
 void GdiBackend::ReleaseImage(ImageHandle image) {
-  impl_->images.erase(static_cast<std::uint64_t>(image));
+  impl_->cache->ReleaseImage(static_cast<std::uint64_t>(image));
 }
 
 Size GdiBackend::MeasureText(std::wstring_view text, const TextStyle& style, float max_width) {
@@ -614,9 +596,9 @@ void GdiBackend::DrawTextRun(std::wstring_view text, const Rect& bounds, const T
 
 void GdiBackend::DrawImage(ImageHandle image, const Rect& dest, float opacity) {
   if (!impl_->in_paint_scope || impl_->pixels == nullptr || opacity <= 0.0f) return;
-  const auto found = impl_->images.find(static_cast<std::uint64_t>(image));
-  if (found == impl_->images.end()) return;
-  const ImageData& source = found->second;
+  const ImageData* source_ptr = impl_->cache->Image(static_cast<std::uint64_t>(image));
+  if (source_ptr == nullptr) return;
+  const ImageData& source = *source_ptr;
 
   const RECT clip = impl_->EffectiveClip();
   const RECT region = impl_->PhysicalRect(dest);
@@ -679,6 +661,12 @@ std::uint32_t GdiBackend::PixelAt(int x, int y) const {
     return 0;
   }
   return impl_->pixels[static_cast<std::size_t>(y) * impl_->buffer_width + x];
+}
+
+CacheSizes GdiBackend::cache_sizes() const { return impl_->cache->Sizes(); }
+
+void GdiBackend::FillSnapshot(trace::ResourceSnapshot& snapshot) const {
+  impl_->cache->FillSnapshot(snapshot);
 }
 
 }  // namespace render

--- a/src/render/gdi_backend.h
+++ b/src/render/gdi_backend.h
@@ -35,11 +35,21 @@
 
 #include "render/render_backend.h"
 
+namespace trace {
+struct ResourceSnapshot;
+}
+
 namespace render {
+
+struct CacheSizes;
+class GdiResourceCache;
 
 class GdiBackend final : public RenderBackend {
  public:
-  GdiBackend();
+  // With a shared cache, fonts and decoded images persist across window
+  // close (the plan's explicit choice — G2 wins that tie). With none, the
+  // backend owns a private cache and behaves like a self-contained window.
+  explicit GdiBackend(GdiResourceCache* shared_cache = nullptr);
   ~GdiBackend() override;
 
   GdiBackend(const GdiBackend&) = delete;
@@ -95,6 +105,12 @@ class GdiBackend final : public RenderBackend {
   int buffer_width() const;   // physical pixels
   int buffer_height() const;  // physical pixels
   std::uint32_t PixelAt(int x, int y) const;  // 0xAABBGGRR, or 0 out of range
+
+  // Cache reporting, for ResourceSnapshot (drift visible in measurement,
+  // not discovered at hour six). CacheSizes is complete in
+  // gdi_resource_cache.h.
+  CacheSizes cache_sizes() const;
+  void FillSnapshot(trace::ResourceSnapshot& snapshot) const;
 
  private:
   struct Impl;

--- a/src/render/gdi_resource_cache.cpp
+++ b/src/render/gdi_resource_cache.cpp
@@ -1,0 +1,90 @@
+#include "render/gdi_resource_cache.h"
+
+#include "platform/performance_trace.h"
+
+namespace render {
+
+GdiResourceCache::~GdiResourceCache() {
+  for (const auto& entry : fonts_) {
+    DeleteObject(entry.second.font);
+  }
+  fonts_.clear();
+  images_.clear();
+}
+
+HFONT GdiResourceCache::Font(const FontSpec& spec) {
+  if (const auto found = fonts_.find(spec); found != fonts_.end()) {
+    return found->second.font;
+  }
+  if (fonts_.size() >= kFontBound) {
+    EvictOldestFont();
+  }
+  const HFONT font =
+      CreateFontW(-spec.height_px, 0, 0, 0, spec.weight, spec.italic ? TRUE : FALSE, FALSE,
+                  FALSE, DEFAULT_CHARSET, OUT_DEFAULT_PRECIS, CLIP_DEFAULT_PRECIS,
+                  CLEARTYPE_QUALITY, DEFAULT_PITCH | FF_DONTCARE, spec.family.c_str());
+  if (font == nullptr) {
+    return nullptr;
+  }
+  fonts_[spec] = FontEntry{font, next_order_++};
+  return font;
+}
+
+HFONT GdiResourceCache::FindFont(const FontSpec& spec) const {
+  const auto found = fonts_.find(spec);
+  return found != fonts_.end() ? found->second.font : nullptr;
+}
+
+std::uint64_t GdiResourceCache::StoreImage(ImageData image) {
+  if (images_.size() >= kImageBound) {
+    images_.erase(images_.begin());  // std::map orders by id: begin is oldest
+  }
+  const std::uint64_t id = next_image_id_++;
+  images_.emplace(id, std::move(image));
+  return id;
+}
+
+const ImageData* GdiResourceCache::Image(std::uint64_t id) const {
+  const auto found = images_.find(id);
+  return found != images_.end() ? &found->second : nullptr;
+}
+
+void GdiResourceCache::ReleaseImage(std::uint64_t id) { images_.erase(id); }
+
+void GdiResourceCache::AdvanceEpoch() {
+  ++epoch_;
+  // One operation, not a hunt: the whole theme layer goes.
+  for (const auto& entry : fonts_) {
+    DeleteObject(entry.second.font);
+  }
+  fonts_.clear();
+}
+
+CacheSizes GdiResourceCache::Sizes() const noexcept {
+  return CacheSizes{fonts_.size(), kFontBound, images_.size(), kImageBound};
+}
+
+void GdiResourceCache::FillSnapshot(trace::ResourceSnapshot& snapshot) const {
+  const CacheSizes sizes = Sizes();
+  if (snapshot.cache_count < trace::ResourceSnapshot::kMaxCaches) {
+    snapshot.caches[snapshot.cache_count++] = {L"gdi.fonts", sizes.fonts};
+  }
+  if (snapshot.cache_count < trace::ResourceSnapshot::kMaxCaches) {
+    snapshot.caches[snapshot.cache_count++] = {L"gdi.images", sizes.images};
+  }
+}
+
+void GdiResourceCache::EvictOldestFont() {
+  auto oldest = fonts_.end();
+  for (auto it = fonts_.begin(); it != fonts_.end(); ++it) {
+    if (oldest == fonts_.end() || it->second.order < oldest->second.order) {
+      oldest = it;
+    }
+  }
+  if (oldest != fonts_.end()) {
+    DeleteObject(oldest->second.font);
+    fonts_.erase(oldest);
+  }
+}
+
+}  // namespace render

--- a/src/render/gdi_resource_cache.h
+++ b/src/render/gdi_resource_cache.h
@@ -1,0 +1,118 @@
+// The bounded, epoch-keyed resource cache behind the GDI backend.
+//
+// Fonts, images and back buffers are expensive to create and cheap to keep,
+// and the plan is explicit that they persist across window close: dropping
+// them means re-rendering every rounded corner on the next show, which is
+// exactly the latency the cache exists to remove (G2). The catch is that
+// anything kept must be BOUNDED, or it becomes drift (G1). Both at once:
+//
+//   - Three layers, as in the old build.
+//       Process : decoded images — survive every window, released by ID.
+//       Theme   : fonts — invalidated in one operation by an epoch bump.
+//       Window  : back buffers — owned by each GdiBackend, released when
+//                 the backend (its window) is destroyed. This layer lives
+//                 in the backend itself; the cache covers the shared two.
+//   - Every layer has a hard entry bound. Overflow evicts the oldest entry;
+//     an unbounded cache is a leak with good manners.
+//   - A resource epoch bumps on theme change or DPI change. The theme
+//     layer is discarded wholesale on the bump — one operation, not a hunt
+//     through individual entries.
+//
+// Sizes are reported through FillSnapshot so drift is visible in
+// measurement rather than discovered at hour six.
+//
+// This is an internal header of the GDI implementation: it carries Windows
+// types on purpose. The public seam (render_backend.h) stays clean.
+#pragma once
+
+#include <windows.h>
+
+#include <cstdint>
+#include <map>
+#include <string>
+#include <vector>
+
+namespace trace {
+struct ResourceSnapshot;
+}
+
+namespace render {
+
+struct FontSpec {
+  std::wstring family;
+  int height_px = 0;
+  int weight = FW_NORMAL;
+  bool italic = false;
+
+  bool operator<(const FontSpec& other) const noexcept {
+    if (family != other.family) return family < other.family;
+    if (height_px != other.height_px) return height_px < other.height_px;
+    if (weight != other.weight) return weight < other.weight;
+    return italic < other.italic;
+  }
+};
+
+// Decoded image pixels, premultiplied, packed (a<<24)|(r<<16)|(g<<8)|b —
+// the same layout as the back buffer.
+struct ImageData {
+  int width = 0;
+  int height = 0;
+  std::vector<std::uint32_t> pixels;
+};
+
+struct CacheSizes {
+  std::size_t fonts = 0;
+  std::size_t font_bound = 0;
+  std::size_t images = 0;
+  std::size_t image_bound = 0;
+};
+
+class GdiResourceCache final {
+ public:
+  static constexpr std::size_t kFontBound = 128;
+  static constexpr std::size_t kImageBound = 64;
+
+  GdiResourceCache() = default;
+  ~GdiResourceCache();
+
+  GdiResourceCache(const GdiResourceCache&) = delete;
+  GdiResourceCache& operator=(const GdiResourceCache&) = delete;
+
+  // Theme layer. Returns a cached font or creates it. nullptr only on real
+  // creation failure. Entries from a previous epoch do not survive the bump.
+  HFONT Font(const FontSpec& spec);
+  // Lookup only: what a paint scope may use (warmed fonts), never create.
+  HFONT FindFont(const FontSpec& spec) const;
+
+  // Process layer. Stores decoded pixels and returns a nonzero id. When the
+  // bound is reached the oldest image is evicted first; a store never fails
+  // on capacity.
+  std::uint64_t StoreImage(ImageData image);
+  const ImageData* Image(std::uint64_t id) const;
+  void ReleaseImage(std::uint64_t id);
+
+  std::uint64_t epoch() const noexcept { return epoch_; }
+  // Theme change or DPI change: discard the theme layer in one operation.
+  void AdvanceEpoch();
+
+  CacheSizes Sizes() const noexcept;
+  // Copies the counters into the first free snapshot slots, so leak tests
+  // and the ETW ResourceSnapshot see the caches without knowing about them.
+  void FillSnapshot(trace::ResourceSnapshot& snapshot) const;
+
+ private:
+  struct FontEntry {
+    HFONT font = nullptr;
+    std::uint64_t order = 0;
+  };
+
+  void EvictOldestFont();
+
+  std::map<FontSpec, FontEntry> fonts_;
+  std::map<std::uint64_t, ImageData> images_;
+  std::uint64_t epoch_ = 1;
+  std::uint64_t next_order_ = 1;
+  std::uint64_t next_image_id_ = 1;
+};
+
+}  // namespace render

--- a/tests/render/gdi_resource_cache_test.cpp
+++ b/tests/render/gdi_resource_cache_test.cpp
@@ -1,0 +1,175 @@
+#include "render/gdi_resource_cache.h"
+
+#include <windows.h>
+#include <psapi.h>
+
+#include <cstdint>
+#include <string>
+
+#include "framework/test_case.h"
+#include "platform/performance_trace.h"
+#include "render/gdi_backend.h"
+
+namespace {
+
+DWORD GdiObjects() {
+  return GetGuiResources(GetCurrentProcess(), GR_GDIOBJECTS);
+}
+
+render::FontSpec SpecAt(int height_px) {
+  return render::FontSpec{L"Segoe UI", height_px, FW_NORMAL, false};
+}
+
+render::ImageData MakeImage(int width, int height, std::uint32_t pixel) {
+  render::ImageData image;
+  image.width = width;
+  image.height = height;
+  image.pixels.assign(static_cast<std::size_t>(width) * height, pixel);
+  return image;
+}
+
+}  // namespace
+
+DHEPZ_TEST(GdiResourceCache, FontsPersistAcrossWindowClose) {
+  render::GdiResourceCache cache;
+  const DWORD before = GdiObjects();
+
+  {
+    render::GdiBackend window_a(&cache);
+    window_a.Resize({100.0f, 40.0f});
+    const render::TextStyle style;
+    window_a.MeasureText(L"warm", style, 0.0f);
+  }  // window closes: the window layer dies, the theme layer survives
+  DHEPZ_CHECK_EQ(static_cast<unsigned long long>(cache.Sizes().fonts),
+                 static_cast<unsigned long long>(1));
+
+  {
+    render::GdiBackend window_b(&cache);
+    window_b.Resize({100.0f, 40.0f});
+    const render::TextStyle style;
+    window_b.MeasureText(L"warm", style, 0.0f);  // reuses, does not recreate
+  }
+  DHEPZ_CHECK_EQ(static_cast<unsigned long long>(cache.Sizes().fonts),
+                 static_cast<unsigned long long>(1));
+  // Exactly one font object exists; nothing leaked across the close.
+  DHEPZ_CHECK_EQ(static_cast<unsigned long long>(GdiObjects()),
+                 static_cast<unsigned long long>(before + 1));
+}
+
+DHEPZ_TEST(GdiResourceCache, FontLayerIsBounded) {
+  render::GdiResourceCache cache;
+  const DWORD before = GdiObjects();
+
+  for (int height = 1; height <= 200; ++height) {
+    DHEPZ_CHECK(cache.Font(SpecAt(height)) != nullptr);
+  }
+  const render::CacheSizes sizes = cache.Sizes();
+  DHEPZ_CHECK(sizes.fonts <= render::GdiResourceCache::kFontBound);
+  DHEPZ_CHECK_EQ(static_cast<unsigned long long>(sizes.font_bound),
+                 static_cast<unsigned long long>(render::GdiResourceCache::kFontBound));
+  // Handles track the cache, not the creation count: eviction released.
+  DHEPZ_CHECK_EQ(static_cast<unsigned long long>(GdiObjects()),
+                 static_cast<unsigned long long>(before + sizes.fonts));
+}
+
+DHEPZ_TEST(GdiResourceCache, EpochBumpDiscardsTheThemeLayerInOneOperation) {
+  render::GdiResourceCache cache;
+  const DWORD before = GdiObjects();
+
+  cache.Font(SpecAt(12));
+  cache.Font(SpecAt(14));
+  DHEPZ_CHECK_EQ(static_cast<unsigned long long>(cache.Sizes().fonts),
+                 static_cast<unsigned long long>(2));
+  DHEPZ_CHECK_EQ(static_cast<unsigned long long>(GdiObjects()),
+                 static_cast<unsigned long long>(before + 2));
+
+  const std::uint64_t epoch = cache.epoch();
+  cache.AdvanceEpoch();
+  DHEPZ_CHECK(cache.epoch() == epoch + 1);
+  DHEPZ_CHECK_EQ(static_cast<unsigned long long>(cache.Sizes().fonts),
+                 static_cast<unsigned long long>(0));
+  DHEPZ_CHECK_EQ(static_cast<unsigned long long>(GdiObjects()),
+                 static_cast<unsigned long long>(before));
+
+  // Lookup after a bump finds nothing; creation starts fresh.
+  DHEPZ_CHECK(cache.FindFont(SpecAt(12)) == nullptr);
+  DHEPZ_CHECK(cache.Font(SpecAt(12)) != nullptr);
+}
+
+DHEPZ_TEST(GdiResourceCache, FiftyThemeTogglesLeaveHandlesAndBytesFlat) {
+  render::GdiResourceCache cache;
+  render::GdiBackend backend(&cache);
+  backend.Resize({120.0f, 40.0f});
+  const render::TextStyle style;
+  backend.MeasureText(L"warm", style, 0.0f);
+
+  const DWORD handles_before = GdiObjects();
+  const HANDLE process = GetCurrentProcess();
+  PROCESS_MEMORY_COUNTERS memory_before{};
+  memory_before.cb = sizeof(memory_before);
+  K32GetProcessMemoryInfo(process, &memory_before, sizeof(memory_before));
+
+  for (int i = 0; i < 50; ++i) {
+    backend.MeasureText(L"theme toggle", style, 0.0f);
+    cache.AdvanceEpoch();  // theme change: the whole layer goes at once
+  }
+  backend.MeasureText(L"theme toggle", style, 0.0f);
+
+  PROCESS_MEMORY_COUNTERS memory_after{};
+  memory_after.cb = sizeof(memory_after);
+  K32GetProcessMemoryInfo(process, &memory_after, sizeof(memory_after));
+
+  // One warmed font is alive at the end; nothing accumulated.
+  DHEPZ_CHECK_EQ(static_cast<unsigned long long>(GdiObjects()),
+                 static_cast<unsigned long long>(handles_before));
+  const long long drift = static_cast<long long>(memory_after.WorkingSetSize) -
+                          static_cast<long long>(memory_before.WorkingSetSize);
+  DHEPZ_CHECK(drift < 1024 * 1024);
+}
+
+DHEPZ_TEST(GdiResourceCache, ImageLayerIsBoundedAndSurvivesWindows) {
+  render::GdiResourceCache cache;
+
+  std::uint64_t first_id = 0;
+  {
+    render::GdiBackend window_a(&cache);
+    for (int i = 0; i < 70; ++i) {
+      const std::uint64_t id = cache.StoreImage(MakeImage(2, 2, 0xFF112233));
+      if (i == 69) first_id = id;
+    }
+  }
+  // Bound holds after 70 stores; the newest survives.
+  DHEPZ_CHECK_EQ(static_cast<unsigned long long>(cache.Sizes().images),
+                 static_cast<unsigned long long>(render::GdiResourceCache::kImageBound));
+  DHEPZ_CHECK(cache.Image(first_id) != nullptr);
+
+  // A later window still sees the process-layer image.
+  render::GdiBackend window_b(&cache);
+  DHEPZ_CHECK(cache.Image(first_id) != nullptr);
+
+  cache.ReleaseImage(first_id);
+  DHEPZ_CHECK(cache.Image(first_id) == nullptr);
+}
+
+DHEPZ_TEST(GdiResourceCache, SizesAreReportedIntoTheResourceSnapshot) {
+  render::GdiResourceCache cache;
+  cache.Font(SpecAt(12));
+  cache.StoreImage(MakeImage(1, 1, 0xFFFFFFFF));
+
+  trace::ResourceSnapshot snapshot;
+  cache.FillSnapshot(snapshot);
+  DHEPZ_CHECK_EQ(static_cast<unsigned long long>(snapshot.cache_count),
+                 static_cast<unsigned long long>(2));
+  DHEPZ_CHECK_EQ(std::wstring(snapshot.caches[0].name), std::wstring(L"gdi.fonts"));
+  DHEPZ_CHECK_EQ(static_cast<unsigned long long>(snapshot.caches[0].size),
+                 static_cast<unsigned long long>(1));
+  DHEPZ_CHECK_EQ(std::wstring(snapshot.caches[1].name), std::wstring(L"gdi.images"));
+  DHEPZ_CHECK_EQ(static_cast<unsigned long long>(snapshot.caches[1].size),
+                 static_cast<unsigned long long>(1));
+
+  // And through the backend passthrough, as the shell will use it.
+  render::GdiBackend backend(&cache);
+  const render::CacheSizes sizes = backend.cache_sizes();
+  DHEPZ_CHECK(sizes.fonts < sizes.font_bound);
+  DHEPZ_CHECK(sizes.images < sizes.image_bound);
+}


### PR DESCRIPTION
Closes #19.

## Summary
- `src/render/gdi_resource_cache.{h,cpp}` — the shared cache behind the GDI backend. **Three layers, each with real content**: decoded images at process lifetime, fonts at theme scope, back buffers at window scope (the window layer lives in each backend and dies with it).
- **Every layer bounded**: fonts ≤ 128, images ≤ 64; overflow evicts the oldest entry and releases its GDI object — an unbounded cache is a leak with good manners.
- **Resource epoch**: `AdvanceEpoch()` discards the whole theme layer in one operation (one sweep, not a hunt through entries). `SetDpi` is an epoch change; a theme change will be one too when the theme adapter lands.
- **Persistence across window close** (the plan's explicit G2 choice): a `GdiBackend` takes an optional shared cache; fonts and images survive the close, and the window layer is released on destroy. A backend with no shared cache owns a private one.
- **Snapshot reporting**: `FillSnapshot(trace::ResourceSnapshot&)` writes `gdi.fonts` / `gdi.images` counters into the #10 snapshot slots, plus a `cache_sizes()` passthrough — drift becomes visible in measurement rather than discovered at hour six.
- Guard semantics refined, not changed: warmed fonts remain usable inside a paint scope (`FindFont`); only *creation* is refused.

## Test plan (6 new tests; 117/117 Debug and Release)
- [x] Fonts persist across window close; exactly one object, nothing leaked.
- [x] Font layer holds its bound after 200 distinct creations; live handles track the cache, not the creation count.
- [x] Epoch bump discards the theme layer in one operation and releases every handle.
- [x] **50 theme toggles**: handles flat, working-set drift < 1 MB.
- [x] Image layer bound holds after 70 stores; newest survives; visible to a later window; release works.
- [x] Snapshot carries both cache counters under their bounds (the issue's third verification), plus the backend passthrough.
- [x] The existing 100-cycles flat test continues to pass against private caches.