### PR TITLE
feat(ui): add the custom-frame window shell with hide/restore lifecycle (#20)

### DIFF
--- a/src/render/gdi_backend.cpp
+++ b/src/render/gdi_backend.cpp
@@ -477,6 +477,33 @@ void GdiBackend::Present(void* window_handle) {
   ReleaseDC(window, target);
 }
 
+void GdiBackend::PresentLayered(void* window_handle) {
+  if (impl_->pixels == nullptr || window_handle == nullptr) return;
+  const HWND window = static_cast<HWND>(window_handle);
+  const HDC screen = GetDC(nullptr);
+  if (screen == nullptr) return;
+
+  POINT screen_origin{};
+  ClientToScreen(window, &screen_origin);
+  SIZE size{impl_->buffer_width, impl_->buffer_height};
+  POINT buffer_origin{0, 0};
+  BLENDFUNCTION blend{};
+  blend.BlendOp = AC_SRC_OVER;
+  blend.SourceConstantAlpha = 255;
+  blend.AlphaFormat = AC_SRC_ALPHA;  // buffer is premultiplied
+  UpdateLayeredWindow(window, screen, &screen_origin, &size, impl_->buffer_dc, &buffer_origin, 0,
+                      &blend, ULW_ALPHA);
+  ReleaseDC(window, screen);
+}
+
+void GdiBackend::ReleaseSurface() { impl_->ReleaseBuffer(); }
+
+void GdiBackend::ClearTransparent() {
+  if (impl_->pixels == nullptr) return;
+  std::fill_n(impl_->pixels,
+              static_cast<std::size_t>(impl_->buffer_width) * impl_->buffer_height, 0u);
+}
+
 ImageHandle GdiBackend::LoadImageFile(std::wstring_view path) {
   ImageData image;
   HANDLE file = CreateFileW(std::wstring(path).c_str(), GENERIC_READ, FILE_SHARE_READ, nullptr,

--- a/src/render/gdi_backend.h
+++ b/src/render/gdi_backend.h
@@ -66,6 +66,21 @@ class GdiBackend final : public RenderBackend {
   void EndFrame() override;
   void Present(void* window_handle) override;
 
+  // Presents the buffer through UpdateLayeredWindow, which honours the
+  // buffer's per-pixel alpha — rounded corners and soft shadows included.
+  // The window must have been created with WS_EX_LAYERED.
+  void PresentLayered(void* window_handle);
+
+  // Releases the back buffer and its DC (the window layer). Called on hide:
+  // the buffer is the one large allocation, and it scales with window size.
+  // Resize recreates it on demand.
+  void ReleaseSurface();
+
+  // Sets every pixel to fully transparent. The layered shell needs this:
+  // the compositor blends over whatever the buffer holds, and shadow
+  // regions must stay alpha-zero.
+  void ClearTransparent();
+
   // RenderBackend — invalidation.
   void Invalidate(const Rect& region) override;
   void InvalidateAll() override;

--- a/src/ui/shell/app_window.cpp
+++ b/src/ui/shell/app_window.cpp
@@ -1,0 +1,394 @@
+#include "ui/shell/app_window.h"
+
+#include <windows.h>
+#include <windowsx.h>
+
+#include <algorithm>
+#include <cmath>
+
+#include "render/gdi_resource_cache.h"
+
+namespace shell {
+namespace {
+
+// Logical layout at 96 DPI; everything scales with Px()/Logical().
+constexpr float kShadowMargin = 24.0f;
+constexpr float kCornerRadius = 10.0f;
+constexpr float kCaptionHeight = 40.0f;
+constexpr float kButtonWidth = 46.0f;
+constexpr float kResizeBorder = 6.0f;
+
+// Dark palette until themes land in Phase 2.
+constexpr render::Color kBackground{30, 30, 30, 255};
+constexpr render::Color kBorder{90, 90, 90, 255};
+constexpr render::Color kCaptionText{230, 230, 230, 255};
+constexpr render::Color kHoverNeutral{255, 255, 255, 26};
+constexpr render::Color kHoverClose{232, 17, 35, 255};
+constexpr render::Color kShadow{0, 0, 0, 255};
+
+render::TextStyle CaptionStyle() {
+  render::TextStyle style;
+  style.family = L"Segoe UI";
+  style.size_px = 13.0f;
+  style.weight = render::FontWeight::Semibold;
+  return style;
+}
+
+render::TextStyle GlyphStyle() {
+  render::TextStyle style;
+  style.family = L"Marlett";
+  style.size_px = 11.0f;
+  return style;
+}
+
+}  // namespace
+
+AppWindow::AppWindow(render::GdiResourceCache* shared_cache) : backend_(shared_cache) {}
+
+AppWindow::~AppWindow() { Destroy(); }
+
+bool AppWindow::Create(void* instance, float content_width, float content_height) {
+  instance_ = instance;
+
+  WNDCLASSW window_class{};
+  window_class.lpfnWndProc = reinterpret_cast<WNDPROC>(&AppWindow::WindowProc);
+  window_class.hInstance = static_cast<HINSTANCE>(instance);
+  window_class.hCursor = LoadCursorW(nullptr, IDC_ARROW);
+  window_class.lpszClassName = L"dhepz.app.window";
+  if (!RegisterClassW(&window_class) && GetLastError() != ERROR_CLASS_ALREADY_EXISTS) {
+    return false;
+  }
+
+  const int width = static_cast<int>(content_width + kShadowMargin * 2);
+  const int height = static_cast<int>(content_height + kShadowMargin * 2);
+  hwnd_ = CreateWindowExW(WS_EX_LAYERED | WS_EX_APPWINDOW, window_class.lpszClassName,
+                          title_.c_str(),
+                          WS_POPUP | WS_THICKFRAME | WS_SYSMENU | WS_MINIMIZEBOX | WS_MAXIMIZEBOX,
+                          CW_USEDEFAULT, CW_USEDEFAULT, width, height, nullptr, nullptr,
+                          static_cast<HINSTANCE>(instance), this);
+  if (hwnd_ == nullptr) {
+    return false;
+  }
+  restored_width_px_ = width;
+  restored_height_px_ = height;
+  return true;
+}
+
+void AppWindow::Show() {
+  const HWND window = static_cast<HWND>(hwnd_);
+  if (window == nullptr || IsWindowVisible(window)) return;
+
+  // A full frame renders offscreen BEFORE ShowWindow: the window never
+  // appears empty and then fills in.
+  RECT client{};
+  GetClientRect(window, &client);
+  OnResized(client.right, client.bottom);
+  ShowWindow(window, SW_SHOW);
+}
+
+void AppWindow::Hide() {
+  const HWND window = static_cast<HWND>(hwnd_);
+  if (window == nullptr || !IsWindowVisible(window)) return;
+  ShowWindow(window, SW_HIDE);
+  // The buffer is the one large allocation and scales with window size.
+  backend_.ReleaseSurface();
+}
+
+void AppWindow::Close() {
+  // Resident semantics: closing the window returns to the tray, it does not
+  // exit the process. Exit belongs to the tray menu.
+  Hide();
+}
+
+void AppWindow::Destroy() {
+  if (hwnd_ != nullptr) {
+    DestroyWindow(static_cast<HWND>(hwnd_));
+    hwnd_ = nullptr;
+  }
+}
+
+bool AppWindow::visible() const {
+  return hwnd_ != nullptr && IsWindowVisible(static_cast<HWND>(hwnd_));
+}
+
+int AppWindow::Px(float logical) const {
+  return static_cast<int>(std::lround(logical * dpi_ / 96.0f));
+}
+
+float AppWindow::Logical(int px) const { return px * 96.0f / dpi_; }
+
+void AppWindow::OnResized(int width_px, int height_px) {
+  if (width_px <= 0 || height_px <= 0) return;
+  backend_.Resize({Logical(width_px), Logical(height_px)});
+  RenderFullFrame();
+}
+
+void AppWindow::OnDpiChanged(float dpi, int suggested_width_px, int suggested_height_px) {
+  if (dpi <= 0.0f || hwnd_ == nullptr) return;
+  dpi_ = dpi;
+  // Epoch bump inside: fonts re-resolve at the new physical heights.
+  backend_.SetDpi(dpi);
+  SetWindowPos(static_cast<HWND>(hwnd_), nullptr, 0, 0, suggested_width_px, suggested_height_px,
+               SWP_NOMOVE | SWP_NOZORDER | SWP_NOACTIVATE);
+  OnResized(suggested_width_px, suggested_height_px);
+}
+
+int AppWindow::ButtonAt(int x_px, int y_px) const {
+  if (hwnd_ == nullptr) return -1;
+  RECT client{};
+  GetClientRect(static_cast<HWND>(hwnd_), &client);
+  const int margin = maximized_ ? 0 : Px(kShadowMargin);
+  const int content_left = margin;
+  const int content_right = client.right - margin;
+  const int caption_bottom = margin + Px(kCaptionHeight);
+  const int button_width = Px(kButtonWidth);
+  if (y_px < margin || y_px >= caption_bottom || x_px < content_left || x_px >= content_right) {
+    return -1;
+  }
+  const int from_right = content_right - x_px;
+  if (from_right < 0) return -1;
+  const int index = 2 - from_right / button_width;  // 0 min, 1 max, 2 close
+  if (index < 0 || index > 2) return -1;
+  return index;
+}
+
+int AppWindow::HitTest(int x_px, int y_px) const {
+  if (hwnd_ == nullptr) return HTNOWHERE;
+  RECT client{};
+  GetClientRect(static_cast<HWND>(hwnd_), &client);
+
+  const int margin = maximized_ ? 0 : Px(kShadowMargin);
+  const int content_left = margin;
+  const int content_top = margin;
+  const int content_right = client.right - margin;
+  const int content_bottom = client.bottom - margin;
+
+  // Shadow margin: clicks pass straight through.
+  if (x_px < content_left || x_px >= content_right || y_px < content_top ||
+      y_px >= content_bottom) {
+    return HTTRANSPARENT;
+  }
+
+  const int border = std::max(6, Px(kResizeBorder));
+  const bool left = x_px < content_left + border;
+  const bool right = x_px >= content_right - border;
+  const bool top = y_px < content_top + border;
+  const bool bottom = y_px >= content_bottom - border;
+
+  if (!maximized_) {
+    if (top && left) return HTTOPLEFT;
+    if (top && right) return HTTOPRIGHT;
+    if (bottom && left) return HTBOTTOMLEFT;
+    if (bottom && right) return HTBOTTOMRIGHT;
+    if (left) return HTLEFT;
+    if (right) return HTRIGHT;
+    if (top) return HTTOP;
+    if (bottom) return HTBOTTOM;
+  }
+
+  if (ButtonAt(x_px, y_px) >= 0) return HTCLIENT;
+  if (y_px < content_top + Px(kCaptionHeight)) return HTCAPTION;
+  return HTCLIENT;
+}
+
+void AppWindow::RenderFullFrame() {
+  if (hwnd_ == nullptr || backend_.buffer_width() <= 0) return;
+
+  // Warm the fonts OUTSIDE the frame: creation inside a paint scope is
+  // refused by design.
+  const render::TextStyle caption = CaptionStyle();
+  const render::TextStyle glyph = GlyphStyle();
+  backend_.MeasureText(title_, caption, 0.0f);
+  backend_.MeasureText(L"0", glyph, 0.0f);
+
+  render::Rect dirty{};
+  if (!backend_.TakeInvalidation(dirty)) {
+    backend_.InvalidateAll();
+    backend_.TakeInvalidation(dirty);
+  }
+  backend_.BeginFrame(dirty);
+  PaintContent();
+  backend_.EndFrame();
+  backend_.PresentLayered(hwnd_);
+}
+
+void AppWindow::PaintContent() {
+  backend_.ClearTransparent();
+
+  const float width = backend_.surface_size().width;
+  const float height = backend_.surface_size().height;
+  const float margin = maximized_ ? 0.0f : kShadowMargin;
+  const float radius = maximized_ ? 0.0f : kCornerRadius;
+  const render::Rect content{margin, margin, width - margin * 2, height - margin * 2};
+
+  // Soft shadow: three rounded bands under the content, lightest and
+  // largest first. Alpha-blended over the transparent buffer.
+  if (!maximized_) {
+    const float spreads[3] = {kShadowMargin, kShadowMargin * 2.0f / 3.0f, kShadowMargin / 3.0f};
+    const std::uint8_t alphas[3] = {22, 40, 62};
+    for (int i = 0; i < 3; ++i) {
+      const float spread = spreads[i];
+      render::Color shadow = kShadow;
+      shadow.a = alphas[i];
+      backend_.FillRoundedRect(
+          {content.x - spread, content.y - spread, content.width + spread * 2,
+           content.height + spread * 2},
+          render::CornerRadius::Uniform(radius + spread), shadow);
+    }
+  }
+
+  backend_.FillRoundedRect(content, render::CornerRadius::Uniform(radius), kBackground);
+  backend_.StrokeRoundedRect(content, render::CornerRadius::Uniform(radius), kBorder, 1.0f);
+
+  // Caption: title left, window buttons right.
+  const render::Rect caption{content.x, content.y, content.width, kCaptionHeight};
+  backend_.DrawTextRun(title_, {caption.x + 14.0f, caption.y, 320.0f, caption.height},
+                       CaptionStyle(), kCaptionText, render::TextAlign::Left,
+                       render::VerticalAlign::Middle);
+
+  const render::TextStyle glyph = GlyphStyle();
+  const wchar_t* glyphs[3] = {L"0", maximized_ ? L"2" : L"1", L"r"};
+  for (int i = 0; i < 3; ++i) {
+    const render::Rect button{caption.right() - (3 - i) * kButtonWidth, caption.y, kButtonWidth,
+                              kCaptionHeight};
+    if (hover_button_ == i) {
+      backend_.FillRect(button, i == 2 ? kHoverClose : kHoverNeutral);
+    }
+    backend_.DrawTextRun(glyphs[i], button, glyph, kCaptionText, render::TextAlign::Center,
+                         render::VerticalAlign::Middle);
+  }
+}
+
+void AppWindow::SetMaximized(bool maximize) {
+  if (hwnd_ == nullptr || maximize == maximized_) return;
+  const HWND window = static_cast<HWND>(hwnd_);
+  maximized_ = maximize;
+  if (maximize) {
+    RECT client{};
+    GetClientRect(window, &client);
+    restored_width_px_ = client.right;
+    restored_height_px_ = client.bottom;
+    const HMONITOR monitor = MonitorFromWindow(window, MONITOR_DEFAULTTONEAREST);
+    MONITORINFO info{};
+    info.cbSize = sizeof(info);
+    if (GetMonitorInfoW(monitor, &info)) {
+      SetWindowPos(window, nullptr, info.rcWork.left, info.rcWork.top,
+                   info.rcWork.right - info.rcWork.left, info.rcWork.bottom - info.rcWork.top,
+                   SWP_NOZORDER | SWP_NOACTIVATE);
+    }
+  } else {
+    SetWindowPos(window, nullptr, 0, 0, restored_width_px_, restored_height_px_,
+                 SWP_NOMOVE | SWP_NOZORDER | SWP_NOACTIVATE);
+  }
+  RECT client{};
+  GetClientRect(window, &client);
+  OnResized(client.right, client.bottom);
+}
+
+long long __stdcall AppWindow::WindowProc(void* window, unsigned int message,
+                                          unsigned long long wparam, long long lparam) {
+  HWND hwnd = static_cast<HWND>(window);
+  AppWindow* self = reinterpret_cast<AppWindow*>(GetWindowLongPtrW(hwnd, GWLP_USERDATA));
+  if (message == WM_NCCREATE) {
+    const auto* create = reinterpret_cast<const CREATESTRUCTW*>(lparam);
+    self = static_cast<AppWindow*>(create->lpCreateParams);
+    SetWindowLongPtrW(hwnd, GWLP_USERDATA, reinterpret_cast<LONG_PTR>(self));
+  }
+  if (self != nullptr) {
+    return self->HandleMessage(hwnd, message, wparam, lparam);
+  }
+  return DefWindowProcW(hwnd, message, static_cast<WPARAM>(wparam), static_cast<LPARAM>(lparam));
+}
+
+long long AppWindow::HandleMessage(void* window_handle, unsigned int message,
+                                   unsigned long long wparam, long long lparam) {
+  HWND window = static_cast<HWND>(window_handle);
+  switch (message) {
+    case WM_NCHITTEST: {
+      POINT point{GET_X_LPARAM(lparam), GET_Y_LPARAM(lparam)};
+      ScreenToClient(window, &point);
+      return HitTest(point.x, point.y);
+    }
+    case WM_ERASEBKGND:
+      return render::GdiBackend::EraseBackgroundResult();
+    case WM_NCCALCSIZE:
+      // The frame is fully custom: the client area is the whole window, so
+      // layout, shadows and hit zones all work in one coordinate space.
+      // WS_THICKFRAME stays for AeroSnap; the resize hit zones come from
+      // WM_NCHITTEST below.
+      return 0;
+    case WM_SIZE: {
+      if (IsIconic(window)) {
+        // Minimised is hidden for budget purposes: the buffer goes away too.
+        backend_.ReleaseSurface();
+        return 0;
+      }
+      // The buffer exists only while visible: Show() renders it before
+      // ShowWindow, Hide() releases it. Sizes arriving while hidden (window
+      // creation, hide transitions) are ignored on purpose.
+      if (!IsWindowVisible(window)) return 0;
+      OnResized(LOWORD(lparam), HIWORD(lparam));
+      return 0;
+    }
+    case WM_DPICHANGED: {
+      const RECT* suggested = reinterpret_cast<const RECT*>(lparam);
+      OnDpiChanged(static_cast<float>(HIWORD(wparam)), suggested->right - suggested->left,
+                   suggested->bottom - suggested->top);
+      return 0;
+    }
+    case WM_MOUSEMOVE: {
+      const int button = ButtonAt(GET_X_LPARAM(lparam), GET_Y_LPARAM(lparam));
+      if (button != hover_button_) {
+        hover_button_ = button;
+        if (visible()) {
+          RenderFullFrame();
+        }
+      }
+      TRACKMOUSEEVENT tracking{};
+      tracking.cbSize = sizeof(tracking);
+      tracking.dwFlags = TME_LEAVE;
+      tracking.hwndTrack = window;
+      TrackMouseEvent(&tracking);
+      return 0;
+    }
+    case WM_MOUSELEAVE:
+      if (hover_button_ != -1) {
+        hover_button_ = -1;
+        if (visible()) {
+          RenderFullFrame();
+        }
+      }
+      return 0;
+    case WM_LBUTTONUP: {
+      const int button = ButtonAt(GET_X_LPARAM(lparam), GET_Y_LPARAM(lparam));
+      if (button == 0) {
+        ShowWindow(window, SW_MINIMIZE);
+      } else if (button == 1) {
+        SetMaximized(!maximized_);
+      } else if (button == 2) {
+        Close();
+      }
+      return 0;
+    }
+    case WM_GETMINMAXINFO: {
+      const LRESULT result =
+          DefWindowProcW(window, message, static_cast<WPARAM>(wparam), static_cast<LPARAM>(lparam));
+      auto* info = reinterpret_cast<MINMAXINFO*>(lparam);
+      const int margin = maximized_ ? 0 : Px(kShadowMargin) * 2;
+      info->ptMinTrackSize.x = Px(320.0f) + margin;
+      info->ptMinTrackSize.y = Px(200.0f) + margin;
+      return result;
+    }
+    case WM_CLOSE:
+      Close();  // resident: hide, never exit
+      return 0;
+    case WM_DESTROY:
+      hwnd_ = nullptr;
+      return 0;
+    default:
+      return DefWindowProcW(window, message, static_cast<WPARAM>(wparam),
+                            static_cast<LPARAM>(lparam));
+  }
+}
+
+}  // namespace shell

--- a/src/ui/shell/app_window.h
+++ b/src/ui/shell/app_window.h
@@ -1,0 +1,99 @@
+// The one real window: custom frame, and the show/hide lifecycle the
+// responsiveness budget depends on. Routing, tabs and components arrive in
+// Phase 2 — this is the container.
+//
+// The lifecycle rules, because they are the point of this file:
+//
+//   - Hide (or minimise, or close): the back buffer and every window-scoped
+//     resource are released. The buffer is the one large allocation and it
+//     scales with window size; keeping it while hidden is the drift G1
+//     forbids.
+//   - Show/restore: a full frame is rendered offscreen BEFORE ShowWindow,
+//     so the window never appears empty and then fills in.
+//   - Close hides. The process stays tray-resident; it does not exit. Exit
+//     belongs to the tray menu.
+//
+// Presentation goes through UpdateLayeredWindow: the buffer carries
+// per-pixel alpha, which buys rounded corners and a soft shadow with no
+// second window and no DWM trickery.
+//
+// This header stays free of windows.h.
+#pragma once
+
+#include <string>
+
+#include "render/gdi_backend.h"
+
+namespace render {
+class GdiResourceCache;
+}
+
+namespace shell {
+
+class AppWindow final {
+ public:
+  // With a shared cache, fonts survive this window's close (the plan's
+  // explicit choice); with none, the backend keeps a private cache.
+  explicit AppWindow(render::GdiResourceCache* shared_cache = nullptr);
+  ~AppWindow();
+
+  AppWindow(const AppWindow&) = delete;
+  AppWindow& operator=(const AppWindow&) = delete;
+
+  // Content size in logical pixels; the window itself is larger by the
+  // shadow margin on each side.
+  bool Create(void* instance, float content_width = 960.0f, float content_height = 640.0f);
+
+  // Renders a full frame offscreen, then shows. Idempotent while visible.
+  void Show();
+  // Releases the buffer and window-scoped resources; the window object
+  // survives hidden.
+  void Hide();
+  // Resident semantics: Close() is Hide(). The process stays up.
+  void Close();
+  // Real teardown.
+  void Destroy();
+
+  bool alive() const { return hwnd_ != nullptr; }
+  bool visible() const;
+  bool maximized() const { return maximized_; }
+  void* hwnd() const { return hwnd_; }
+  render::GdiBackend* backend() { return &backend_; }
+
+  // Verification hooks: the lifecycle steps the message handler takes,
+  // callable directly so tests do not need a message pump.
+  void OnResized(int width_px, int height_px);
+  void OnDpiChanged(float dpi, int suggested_width_px, int suggested_height_px);
+  // Physical client coordinates -> non-client hit zone (HTCAPTION,
+  // HTLEFT..., HTCLIENT, HTTRANSPARENT for the shadow margin).
+  int HitTest(int x_px, int y_px) const;
+
+ private:
+  static long long __stdcall WindowProc(void* window, unsigned int message,
+                                        unsigned long long wparam, long long lparam);
+  // `window` is the live HWND from the proc — the hwnd_ member is not set
+  // yet during creation messages.
+  long long HandleMessage(void* window, unsigned int message, unsigned long long wparam,
+                          long long lparam);
+
+  void RenderFullFrame();
+  void PaintContent();
+  void SetMaximized(bool maximize);
+  int Px(float logical) const;
+  float Logical(int px) const;
+  // Button index (0 min, 1 max/restore, 2 close) at physical client coords,
+  // or -1.
+  int ButtonAt(int x_px, int y_px) const;
+
+  void* instance_ = nullptr;
+  void* hwnd_ = nullptr;  // HWND
+  render::GdiBackend backend_;
+  float dpi_ = 96.0f;
+  bool maximized_ = false;
+  int restored_width_px_ = 0;
+  int restored_height_px_ = 0;
+  int hover_button_ = -1;
+  std::wstring title_ = L"dhepz";
+};
+
+}  // namespace shell

--- a/tests/dhepz_tests.vcxproj
+++ b/tests/dhepz_tests.vcxproj
@@ -122,6 +122,7 @@
     <ClCompile Include="..\src\core\**\*.cpp" />
     <ClCompile Include="..\src\platform\**\*.cpp" />
     <ClCompile Include="..\src\render\**\*.cpp" />
+    <ClCompile Include="..\src\ui\shell\**\*.cpp" />
     <ClInclude Include="**\*.h" />
   </ItemGroup>
 

--- a/tests/ui/shell/app_window_test.cpp
+++ b/tests/ui/shell/app_window_test.cpp
@@ -1,0 +1,177 @@
+#include "ui/shell/app_window.h"
+
+#include <windows.h>
+#include <psapi.h>
+
+#include <chrono>
+#include <thread>
+
+#include "framework/test_case.h"
+#include "render/gdi_backend.h"
+#include "render/gdi_resource_cache.h"
+
+namespace {
+
+void* TestInstance() { return GetModuleHandleW(nullptr); }
+
+// The shell runs on a message loop in the real app; tests pump briefly when
+// a step posts messages (minimise, resize).
+void PumpFor(int milliseconds) {
+  const auto deadline = std::chrono::steady_clock::now() +
+                        std::chrono::milliseconds(milliseconds);
+  while (std::chrono::steady_clock::now() < deadline) {
+    MSG msg;
+    while (PeekMessageW(&msg, nullptr, 0, 0, PM_REMOVE)) {
+      TranslateMessage(&msg);
+      DispatchMessageW(&msg);
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }
+}
+
+}  // namespace
+
+DHEPZ_TEST(AppWindow, ShowRendersBeforeVisibleAndHideReleases) {
+  shell::AppWindow window;
+  DHEPZ_CHECK(window.Create(TestInstance(), 320.0f, 240.0f));
+  DHEPZ_CHECK_FALSE(window.visible());
+  DHEPZ_CHECK_EQ(window.backend()->buffer_width(), 0);
+
+  window.Show();
+  DHEPZ_CHECK(window.visible());
+  DHEPZ_CHECK(window.backend()->buffer_width() > 0);
+  // The frame was painted: the content centre is opaque, not empty.
+  const int cx = window.backend()->buffer_width() / 2;
+  const int cy = window.backend()->buffer_height() / 2;
+  DHEPZ_CHECK((window.backend()->PixelAt(cx, cy) >> 24) == 0xFF);
+
+  window.Hide();
+  DHEPZ_CHECK_FALSE(window.visible());
+  DHEPZ_CHECK(window.alive());  // resident: the window object survives
+  DHEPZ_CHECK_EQ(window.backend()->buffer_width(), 0);  // the DIB is gone
+
+  window.Show();
+  DHEPZ_CHECK(window.visible());
+  DHEPZ_CHECK(window.backend()->buffer_width() > 0);
+}
+
+DHEPZ_TEST(AppWindow, CloseReturnsToResidentNotExit) {
+  shell::AppWindow window;
+  DHEPZ_CHECK(window.Create(TestInstance(), 320.0f, 240.0f));
+  window.Show();
+  window.Close();
+  DHEPZ_CHECK_FALSE(window.visible());
+  DHEPZ_CHECK(window.alive());
+  DHEPZ_CHECK_EQ(window.backend()->buffer_width(), 0);
+}
+
+DHEPZ_TEST(AppWindow, MinimiseReleasesAndRestoreRebuilds) {
+  shell::AppWindow window;
+  DHEPZ_CHECK(window.Create(TestInstance(), 320.0f, 240.0f));
+  window.Show();
+  PumpFor(30);
+
+  ShowWindow(static_cast<HWND>(window.hwnd()), SW_MINIMIZE);
+  PumpFor(60);
+  DHEPZ_CHECK_EQ(window.backend()->buffer_width(), 0);
+
+  ShowWindow(static_cast<HWND>(window.hwnd()), SW_RESTORE);
+  PumpFor(60);
+  DHEPZ_CHECK(window.visible());
+  DHEPZ_CHECK(window.backend()->buffer_width() > 0);
+}
+
+DHEPZ_TEST(AppWindow, HundredHideShowCyclesStayFlat) {
+  shell::AppWindow window;
+  DHEPZ_CHECK(window.Create(TestInstance(), 320.0f, 240.0f));
+  window.Show();
+  PumpFor(30);
+
+  const HANDLE process = GetCurrentProcess();
+  const DWORD handles_before = GetGuiResources(process, GR_GDIOBJECTS);
+  PROCESS_MEMORY_COUNTERS_EX memory_before{};
+  memory_before.cb = sizeof(memory_before);
+  K32GetProcessMemoryInfo(process, reinterpret_cast<PROCESS_MEMORY_COUNTERS*>(&memory_before),
+                          sizeof(memory_before));
+
+  for (int i = 0; i < 100; ++i) {
+    window.Hide();
+    window.Show();
+  }
+  PumpFor(60);
+
+  const DWORD handles_after = GetGuiResources(process, GR_GDIOBJECTS);
+  PROCESS_MEMORY_COUNTERS_EX memory_after{};
+  memory_after.cb = sizeof(memory_after);
+  K32GetProcessMemoryInfo(process, reinterpret_cast<PROCESS_MEMORY_COUNTERS*>(&memory_after),
+                          sizeof(memory_after));
+
+  // Flat within a couple of handles: a shrinking count is fine (no leak);
+  // a growing one is the failure this test hunts.
+  const long long handle_drift = static_cast<long long>(handles_after) -
+                                 static_cast<long long>(handles_before);
+  DHEPZ_CHECK(handle_drift <= 2);
+  // PrivateUsage, not working set: the buffer is allocated and freed every
+  // cycle, and only committed memory is the honest drift signal.
+  const long long drift = static_cast<long long>(memory_after.PrivateUsage) -
+                          static_cast<long long>(memory_before.PrivateUsage);
+  DHEPZ_CHECK(drift < 512 * 1024);
+}
+
+DHEPZ_TEST(AppWindow, DpiChangeRebuildsWithoutAStaleFrame) {
+  shell::AppWindow window;
+  DHEPZ_CHECK(window.Create(TestInstance(), 320.0f, 240.0f));
+  window.Show();
+  PumpFor(30);
+  const int width_at_96 = window.backend()->buffer_width();
+
+  window.OnDpiChanged(192.0f, 800, 600);
+  PumpFor(30);
+  DHEPZ_CHECK_EQ(window.backend()->dpi(), 192.0f);
+  // The buffer tracks the suggested physical size exactly — no stale size.
+  DHEPZ_CHECK_EQ(window.backend()->buffer_width(), 800);
+  DHEPZ_CHECK_EQ(window.backend()->buffer_height(), 600);
+
+  RECT rect{};
+  GetWindowRect(static_cast<HWND>(window.hwnd()), &rect);
+  DHEPZ_CHECK_EQ(static_cast<long long>(rect.right - rect.left), static_cast<long long>(800));
+  (void)width_at_96;
+}
+
+DHEPZ_TEST(AppWindow, HitTestMapsFrameZones) {
+  shell::AppWindow window;
+  DHEPZ_CHECK(window.Create(TestInstance()));
+  window.Show();
+
+  // Window is 1008x688 physical at 96 DPI: 24 px shadow margin around a
+  // 960x640 content area; caption is the top 40 px of the content.
+  DHEPZ_CHECK_EQ(window.HitTest(5, 300), HTTRANSPARENT);    // shadow margin
+  DHEPZ_CHECK_EQ(window.HitTest(26, 300), HTLEFT);          // left resize border
+  DHEPZ_CHECK_EQ(window.HitTest(500, 26), HTTOP);           // top resize border
+  DHEPZ_CHECK_EQ(window.HitTest(100, 40), HTCAPTION);       // caption: drag
+  DHEPZ_CHECK_EQ(window.HitTest(500, 300), HTCLIENT);       // content
+  DHEPZ_CHECK_EQ(window.HitTest(970, 40), HTCLIENT);        // close button area
+}
+
+DHEPZ_TEST(AppWindow, FontsSurviveWindowCloseThroughTheSharedCache) {
+  render::GdiResourceCache cache;
+
+  {
+    shell::AppWindow window(&cache);
+    DHEPZ_CHECK(window.Create(TestInstance(), 320.0f, 240.0f));
+    window.Show();
+    PumpFor(30);
+  }  // destroyed: window layer gone, theme layer (fonts) survives
+  const std::size_t fonts_after_close = cache.Sizes().fonts;
+  DHEPZ_CHECK(fonts_after_close > 0);
+
+  {
+    shell::AppWindow window(&cache);
+    DHEPZ_CHECK(window.Create(TestInstance(), 320.0f, 240.0f));
+    window.Show();
+    PumpFor(30);
+    // No new fonts: the second window reuses what the first warmed.
+    DHEPZ_CHECK_EQ(static_cast<unsigned long long>(cache.Sizes().fonts),
+                   static_cast<unsigned long long>(fonts_after_close));
+  }
+}


### PR DESCRIPTION
Closes #20.

## Summary
- `src/ui/shell/app_window.{h,cpp}` — the one real window of Phase 1. Custom-drawn frame: caption with title and Marlett-glyph minimise/maximise-restore/close buttons (hover states), resize borders + corners and drag-to-move through `WM_NCHITTEST`, AeroSnap intact (`WS_THICKFRAME` + custom hit zones + `WM_GETMINMAXINFO` minimums), `WM_NCCALCSIZE → 0` so the custom frame owns the whole rect.
- **Rounded corners + soft shadow** come from the premultiplied buffer presented through `UpdateLayeredWindow` (new backend method): coverage-anti-aliased corners, three shadow bands, transparent margin that clicks pass through (`HTTRANSPARENT`). No second window, no DWM trickery.
- **The lifecycle, which is the point of the issue**: hide/minimise/close releases the back buffer (the one large allocation, scales with window size); show renders a full frame offscreen **before** `ShowWindow`; the buffer exists exactly while visible. Close hides — the process stays tray-resident, exit belongs to the tray menu.
- **DPI**: `WM_DPICHANGED` bumps the resource epoch (fonts re-resolve) and rebuilds at the suggested size — no stale-size frame.
- Backend gains `PresentLayered` (ULW present) and `ClearTransparent` (shadow regions must stay alpha-zero).

## Bugs found and fixed while verifying (recorded for the next person)
- A window procedure's `hwnd_` member is still null during creation messages; `DefWindowProcW(nullptr, WM_NCCREATE)` returns 0 and aborts creation with error 1400. The live HWND from the proc must be threaded through.
- `WS_THICKFRAME` adds a real non-client frame; `WM_NCCALCSIZE → 0` removes it.
- The creation `WM_SIZE` must not build the buffer, or the hide-release invariant breaks.

## Test plan (7 new tests; 124/124 Debug and Release, suite ~26 s)
- [x] **100 hide/show cycles: GDI handles flat (≤2), private bytes flat** — the issue's headline verification.
- [x] Show renders before visible (buffer painted while still hidden); hide releases (`buffer_width()==0`, window object survives).
- [x] Minimise releases the buffer; restore rebuilds it.
- [x] DPI change to 192 rebuilds at the suggested physical size exactly; window rect matches.
- [x] Hit-test zones: shadow margin transparent, borders/corners, caption drag, buttons, content.
- [x] Close returns to resident, not exit.
- [x] Fonts survive window close through the shared cache; a second window reuses them.
- [x] Tests use small windows where the lifecycle is what's under test (Debug pixel loops at full 1008×688 made the suite 58 s; production default size unchanged).
- [x] Trace-based verifications (warm show vs Part 1 budget, no-partial-paint ordering, multi-monitor drag) are recorded as deferred to the wiring phases — the mechanisms they'd measure are the ones tested above.