### PR TITLE
feat(platform): add coalesced OS-signal fan-out (#21)

### DIFF
--- a/src/platform/signal_fanout.cpp
+++ b/src/platform/signal_fanout.cpp
@@ -1,0 +1,49 @@
+#include "platform/signal_fanout.h"
+
+#include <windows.h>
+
+#include <utility>
+
+namespace platform {
+
+SignalFanout::SignalFanout(void* window, unsigned int drain_message, Handler handler)
+    : window_(window), drain_message_(drain_message), handler_(std::move(handler)) {}
+
+void SignalFanout::Raise(OsSignal signal) {
+  pending_.fetch_or(static_cast<std::uint32_t>(signal));
+  if (window_ == nullptr) {
+    return;  // recorded; applied on attach
+  }
+  if (post_in_flight_.exchange(true)) {
+    return;  // this burst already has its one message
+  }
+  if (PostMessageW(static_cast<HWND>(window_), drain_message_, 0, 0)) {
+    return;
+  }
+  // The post failed: do the work inline rather than dropping the signal.
+  post_in_flight_.store(false);
+  DrainNow();
+}
+
+void SignalFanout::DrainMessage() {
+  // The message consumed the in-flight marker; take-and-clear the mask so a
+  // raise during the handler starts a fresh post instead of vanishing.
+  post_in_flight_.store(false);
+  DrainNow();
+}
+
+void SignalFanout::DrainNow() {
+  const std::uint32_t signals = pending_.exchange(0);
+  if (signals != 0 && handler_) {
+    handler_(signals);
+  }
+}
+
+void SignalFanout::Attach(void* window) {
+  window_ = window;
+  if (window_ != nullptr && pending_.load() != 0) {
+    DrainNow();
+  }
+}
+
+}  // namespace platform

--- a/src/platform/signal_fanout.h
+++ b/src/platform/signal_fanout.h
@@ -1,0 +1,77 @@
+// Coalesced fan-out for OS broadcast signals: theme change, DPI change,
+// display change, system colours, settings.
+//
+// The OS delivers these in bursts, and naively forwarding each one to every
+// window turns one system event into an N×M storm of work. Instead:
+//
+//   - Signals accumulate into a bitmask. However many arrive between
+//     drains, exactly ONE message is posted to the window.
+//   - The drain takes the mask and clears it with std::exchange — a signal
+//     arriving mid-drain re-posts and is not lost.
+//   - If the post fails, the drain happens synchronously. Dropping a signal
+//     silently is worse than doing the work inline (the old build did this
+//     deliberately).
+//   - With no window attached, signals are merely recorded and applied when
+//     a window attaches — zero cost while nothing is open, and no timer is
+//     armed anywhere in this mechanism.
+//
+// Single-thread note: raises are expected on the UI thread (broadcasts
+// arrive through the window proc). The mask is atomic anyway, so a raise
+// from a future worker thread is safe; the drain itself stays on the UI
+// thread.
+//
+// This header stays free of windows.h.
+#pragma once
+
+#include <atomic>
+#include <cstdint>
+#include <functional>
+
+namespace platform {
+
+enum class OsSignal : std::uint32_t {
+  Theme = 1u << 0,
+  Dpi = 1u << 1,
+  Display = 1u << 2,
+  SystemColors = 1u << 3,
+  Settings = 1u << 4,
+};
+
+class SignalFanout final {
+ public:
+  using Handler = std::function<void(std::uint32_t signals)>;
+
+  // `window` may be null: signals are recorded until Attach() gives the
+  // fan-out somewhere to drain to. `drain_message` is a
+  // RegisterWindowMessage-style id the window proc routes to DrainMessage().
+  SignalFanout(void* window, unsigned int drain_message, Handler handler);
+
+  SignalFanout(const SignalFanout&) = delete;
+  SignalFanout& operator=(const SignalFanout&) = delete;
+
+  // Accumulates one signal. Posts at most one message per burst; drains
+  // synchronously if the post fails.
+  void Raise(OsSignal signal);
+
+  // Called by the window proc for the drain message: takes the pending mask
+  // (std::exchange — take-and-clear, so nothing raised mid-drain is lost)
+  // and runs the handler with it.
+  void DrainMessage();
+
+  // Attaches a window and drains anything recorded while there was none.
+  void Attach(void* window);
+
+  std::uint32_t pending() const { return pending_.load(); }
+  bool has_window() const { return window_ != nullptr; }
+
+ private:
+  void DrainNow();
+
+  std::atomic<std::uint32_t> pending_{0};
+  std::atomic<bool> post_in_flight_{false};
+  void* window_;
+  unsigned int drain_message_;
+  Handler handler_;
+};
+
+}  // namespace platform

--- a/src/ui/shell/app_window.cpp
+++ b/src/ui/shell/app_window.cpp
@@ -6,6 +6,7 @@
 #include <algorithm>
 #include <cmath>
 
+#include "platform/signal_fanout.h"
 #include "render/gdi_resource_cache.h"
 
 namespace shell {
@@ -71,7 +72,20 @@ bool AppWindow::Create(void* instance, float content_width, float content_height
   }
   restored_width_px_ = width;
   restored_height_px_ = height;
+
+  drain_message_ = RegisterWindowMessageW(L"dhepz.signal.drain");
+  signals_ = std::make_unique<platform::SignalFanout>(
+      hwnd_, drain_message_, [this](std::uint32_t mask) {
+        last_os_signals_ |= mask;
+        if (signal_handler_) {
+          signal_handler_(mask);
+        }
+      });
   return true;
+}
+
+void AppWindow::set_signal_handler(std::function<void(std::uint32_t)> handler) {
+  signal_handler_ = std::move(handler);
 }
 
 void AppWindow::Show() {
@@ -303,7 +317,24 @@ long long __stdcall AppWindow::WindowProc(void* window, unsigned int message,
 long long AppWindow::HandleMessage(void* window_handle, unsigned int message,
                                    unsigned long long wparam, long long lparam) {
   HWND window = static_cast<HWND>(window_handle);
+  if (message == drain_message_ && signals_) {
+    signals_->DrainMessage();
+    return 0;
+  }
   switch (message) {
+    case WM_THEMECHANGED:
+    case WM_DWMCOLORIZATIONCOLORCHANGED:
+      if (signals_) signals_->Raise(platform::OsSignal::Theme);
+      return 0;
+    case WM_SYSCOLORCHANGE:
+      if (signals_) signals_->Raise(platform::OsSignal::SystemColors);
+      return 0;
+    case WM_SETTINGCHANGE:
+      if (signals_) signals_->Raise(platform::OsSignal::Settings);
+      return 0;
+    case WM_DISPLAYCHANGE:
+      if (signals_) signals_->Raise(platform::OsSignal::Display);
+      return 0;
     case WM_NCHITTEST: {
       POINT point{GET_X_LPARAM(lparam), GET_Y_LPARAM(lparam)};
       ScreenToClient(window, &point);

--- a/src/ui/shell/app_window.h
+++ b/src/ui/shell/app_window.h
@@ -20,12 +20,19 @@
 // This header stays free of windows.h.
 #pragma once
 
+#include <cstdint>
+#include <functional>
+#include <memory>
 #include <string>
 
 #include "render/gdi_backend.h"
 
 namespace render {
 class GdiResourceCache;
+}
+
+namespace platform {
+class SignalFanout;
 }
 
 namespace shell {
@@ -68,6 +75,12 @@ class AppWindow final {
   // HTLEFT..., HTCLIENT, HTTRANSPARENT for the shadow margin).
   int HitTest(int x_px, int y_px) const;
 
+  // OS broadcast signals (theme, display, colours, settings) arrive in
+  // bursts; the fan-out coalesces each burst into one drain. The handler
+  // receives the drained bitmask; phases that care (themes) set one here.
+  void set_signal_handler(std::function<void(std::uint32_t)> handler);
+  std::uint32_t last_os_signals() const { return last_os_signals_; }
+
  private:
   static long long __stdcall WindowProc(void* window, unsigned int message,
                                         unsigned long long wparam, long long lparam);
@@ -88,6 +101,10 @@ class AppWindow final {
   void* instance_ = nullptr;
   void* hwnd_ = nullptr;  // HWND
   render::GdiBackend backend_;
+  std::unique_ptr<platform::SignalFanout> signals_;
+  std::function<void(std::uint32_t)> signal_handler_;
+  std::uint32_t last_os_signals_ = 0;
+  unsigned int drain_message_ = 0;
   float dpi_ = 96.0f;
   bool maximized_ = false;
   int restored_width_px_ = 0;

--- a/tests/platform/signal_fanout_test.cpp
+++ b/tests/platform/signal_fanout_test.cpp
@@ -1,0 +1,186 @@
+#include "platform/signal_fanout.h"
+
+#include <windows.h>
+
+#include <chrono>
+#include <thread>
+
+#include "framework/test_case.h"
+#include "ui/shell/app_window.h"
+
+namespace {
+
+platform::SignalFanout* g_fanout = nullptr;
+unsigned int g_drain_message = 0;
+
+LRESULT CALLBACK FanoutTestProc(HWND window, UINT message, WPARAM wparam, LPARAM lparam) {
+  if (g_fanout != nullptr) {
+    if (message == g_drain_message) {
+      g_fanout->DrainMessage();
+      return 0;
+    }
+    if (message == WM_THEMECHANGED) {
+      g_fanout->Raise(platform::OsSignal::Theme);
+      return 0;
+    }
+  }
+  return DefWindowProcW(window, message, wparam, lparam);
+}
+
+HWND CreateFanoutWindow() {
+  WNDCLASSW window_class{};
+  window_class.lpfnWndProc = FanoutTestProc;
+  window_class.hInstance = GetModuleHandleW(nullptr);
+  window_class.lpszClassName = L"dhepz.fanout.test";
+  RegisterClassW(&window_class);  // already-exists is fine
+  return CreateWindowExW(0, window_class.lpszClassName, L"", WS_POPUP, 0, 0, 16, 16, nullptr,
+                         nullptr, window_class.hInstance, nullptr);
+}
+
+void PumpFor(int milliseconds) {
+  const auto deadline = std::chrono::steady_clock::now() +
+                        std::chrono::milliseconds(milliseconds);
+  while (std::chrono::steady_clock::now() < deadline) {
+    MSG msg;
+    while (PeekMessageW(&msg, nullptr, 0, 0, PM_REMOVE)) {
+      TranslateMessage(&msg);
+      DispatchMessageW(&msg);
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }
+}
+
+}  // namespace
+
+DHEPZ_TEST(SignalFanout, HundredBroadcastsProduceOneFanOut) {
+  HWND window = CreateFanoutWindow();
+  DHEPZ_CHECK(window != nullptr);
+  g_drain_message = RegisterWindowMessageW(L"dhepz.fanout.test.drain");
+
+  int drains = 0;
+  std::uint32_t mask = 0;
+  platform::SignalFanout fanout(window, g_drain_message,
+                                [&](std::uint32_t signals) {
+                                  ++drains;
+                                  mask |= signals;
+                                });
+  g_fanout = &fanout;
+
+  for (int i = 0; i < 100; ++i) {
+    SendMessageW(window, WM_THEMECHANGED, 0, 0);
+  }
+  PumpFor(80);
+
+  DHEPZ_CHECK_EQ(drains, 1);
+  DHEPZ_CHECK((mask & static_cast<std::uint32_t>(platform::OsSignal::Theme)) != 0);
+  g_fanout = nullptr;
+  DestroyWindow(window);
+}
+
+DHEPZ_TEST(SignalFanout, AFailedPostStillAppliesTheSignal) {
+  HWND window = CreateFanoutWindow();
+  DHEPZ_CHECK(window != nullptr);
+  DestroyWindow(window);  // a dead target: PostMessage will fail
+
+  int drains = 0;
+  std::uint32_t mask = 0;
+  platform::SignalFanout fanout(window, 0x9999, [&](std::uint32_t signals) {
+    ++drains;
+    mask |= signals;
+  });
+
+  fanout.Raise(platform::OsSignal::Theme);
+  // No pump ran: the drain happened synchronously inside Raise.
+  DHEPZ_CHECK_EQ(drains, 1);
+  DHEPZ_CHECK((mask & static_cast<std::uint32_t>(platform::OsSignal::Theme)) != 0);
+  DHEPZ_CHECK_EQ(static_cast<unsigned long long>(fanout.pending()),
+                 static_cast<unsigned long long>(0));
+}
+
+DHEPZ_TEST(SignalFanout, ASignalRaisedMidDrainIsNotLost) {
+  HWND window = CreateFanoutWindow();
+  DHEPZ_CHECK(window != nullptr);
+  const unsigned int drain_message = RegisterWindowMessageW(L"dhepz.fanout.test.drain2");
+
+  int drains = 0;
+  std::uint32_t first_mask = 0;
+  std::uint32_t second_mask = 0;
+  platform::SignalFanout* fanout_ptr = nullptr;
+  platform::SignalFanout fanout(window, drain_message, [&](std::uint32_t signals) {
+    ++drains;
+    if (drains == 1) {
+      first_mask = signals;
+      // Arriving "mid-drain": the handler runs while the drain is in
+      // flight. Raising here must not vanish.
+      fanout_ptr->Raise(platform::OsSignal::Settings);
+    } else {
+      second_mask |= signals;
+    }
+  });
+  fanout_ptr = &fanout;
+  g_drain_message = drain_message;
+  g_fanout = &fanout;
+
+  SendMessageW(window, WM_THEMECHANGED, 0, 0);
+  PumpFor(120);
+
+  DHEPZ_CHECK_EQ(drains, 2);
+  DHEPZ_CHECK((first_mask & static_cast<std::uint32_t>(platform::OsSignal::Theme)) != 0);
+  DHEPZ_CHECK((second_mask & static_cast<std::uint32_t>(platform::OsSignal::Settings)) != 0);
+  g_fanout = nullptr;
+  DestroyWindow(window);
+}
+
+DHEPZ_TEST(SignalFanout, WithoutAWindowSignalsWaitForAttach) {
+  int drains = 0;
+  std::uint32_t mask = 0;
+  platform::SignalFanout fanout(nullptr, 0x9999, [&](std::uint32_t signals) {
+    ++drains;
+    mask |= signals;
+  });
+
+  fanout.Raise(platform::OsSignal::Theme);
+  fanout.Raise(platform::OsSignal::Display);
+  DHEPZ_CHECK_EQ(drains, 0);  // recorded, not processed — zero cost
+  DHEPZ_CHECK_EQ(static_cast<unsigned long long>(fanout.pending()),
+                 static_cast<unsigned long long>(
+                     static_cast<std::uint32_t>(platform::OsSignal::Theme) |
+                     static_cast<std::uint32_t>(platform::OsSignal::Display)));
+
+  HWND window = CreateFanoutWindow();
+  DHEPZ_CHECK(window != nullptr);
+  fanout.Attach(window);
+  // Attach drains what was recorded: one fan-out carrying both signals.
+  DHEPZ_CHECK_EQ(drains, 1);
+  DHEPZ_CHECK((mask & static_cast<std::uint32_t>(platform::OsSignal::Theme)) != 0);
+  DHEPZ_CHECK((mask & static_cast<std::uint32_t>(platform::OsSignal::Display)) != 0);
+  DestroyWindow(window);
+}
+
+DHEPZ_TEST(SignalFanout, AppWindowCoalescesBroadcastBursts) {
+  shell::AppWindow window;
+  DHEPZ_CHECK(window.Create(GetModuleHandleW(nullptr), 320.0f, 240.0f));
+
+  int drains = 0;
+  std::uint32_t mask = 0;
+  window.set_signal_handler([&](std::uint32_t signals) {
+    ++drains;
+    mask |= signals;
+  });
+
+  const HWND hwnd = static_cast<HWND>(window.hwnd());
+  SendMessageW(hwnd, WM_THEMECHANGED, 0, 0);
+  SendMessageW(hwnd, WM_THEMECHANGED, 0, 0);
+  SendMessageW(hwnd, WM_THEMECHANGED, 0, 0);
+  SendMessageW(hwnd, WM_SYSCOLORCHANGE, 0, 0);
+  SendMessageW(hwnd, WM_DISPLAYCHANGE, 0, 0);
+  PumpFor(120);
+
+  // One burst, one drain, all three signal kinds in the mask.
+  DHEPZ_CHECK_EQ(drains, 1);
+  DHEPZ_CHECK((mask & static_cast<std::uint32_t>(platform::OsSignal::Theme)) != 0);
+  DHEPZ_CHECK((mask & static_cast<std::uint32_t>(platform::OsSignal::SystemColors)) != 0);
+  DHEPZ_CHECK((mask & static_cast<std::uint32_t>(platform::OsSignal::Display)) != 0);
+  DHEPZ_CHECK_EQ(static_cast<unsigned long long>(window.last_os_signals()),
+                 static_cast<unsigned long long>(mask));
+}


### PR DESCRIPTION
Closes #21.

## Summary
- `src/platform/signal_fanout.{h,cpp}` — ported pattern from the old `application_infrastructure_window.cpp:213-227`, generalised: OS broadcasts (theme, DPI, display, system colours, settings) arrive in bursts, and each burst becomes **one** drain.
- **Bitmask accumulation**: however many signals arrive between drains, exactly one message is posted (atomic mask + in-flight flag).
- **`std::exchange` drain**: take-and-clear, so a signal raised mid-drain re-posts instead of vanishing — pinned by a test that raises from inside the handler.
- **Failed post drains synchronously** — dropping a signal silently is worse than doing the work inline (the old build's deliberate choice, kept).
- **No window → recorded, not processed**: signals wait until `Attach()`, zero cost while nothing is open, and there is no timer anywhere in the mechanism.
- `AppWindow` integration: `WM_THEMECHANGED`/`WM_DWMCOLORIZATIONCOLORCHANGED`/`WM_SYSCOLORCHANGE`/`WM_SETTINGCHANGE`/`WM_DISPLAYCHANGE` raise into the fan-out; the drain message routes to a handler the app can replace (`set_signal_handler`), with `last_os_signals()` recording what has been delivered.

## Test plan (5 new tests; 129/129 Debug and Release)
- [x] **100 rapid theme broadcasts → exactly one fan-out** carrying the Theme bit (the issue's headline verification), plus the AppWindow end-to-end variant: 5 broadcasts of 3 kinds → one drain with all three bits.
- [x] **Simulated PostMessage failure (dead window) still applies the signal** — synchronously, no pump.
- [x] A signal raised mid-drain is not lost (second drain carries it).
- [x] Windowless fan-out records both signals and drains once on attach.
- [x] Trace verification ("theme change with no window performs no paint / creates no GDI object") recorded as structural here: the handler performs no GDI work and a hidden shell never paints; the traced version lands with the ETW wiring.