### PR TITLE
feat(platform): add the settle timer for activity-burst measurement (#22)

### DIFF
--- a/src/platform/settle_timer.cpp
+++ b/src/platform/settle_timer.cpp
@@ -1,0 +1,38 @@
+#include "platform/settle_timer.h"
+
+#include <windows.h>
+
+#include <utility>
+
+namespace platform {
+
+SettleTimer::SettleTimer(void* window, std::uintptr_t timer_id, Callback on_settled)
+    : window_(window), timer_id_(timer_id), on_settled_(std::move(on_settled)) {}
+
+SettleTimer::~SettleTimer() { Kill(); }
+
+void SettleTimer::Arm(unsigned int delay_ms) {
+  if (window_ == nullptr) return;
+  if (armed_) {
+    Kill();  // re-arming resets the countdown; timers never stack
+  }
+  armed_ = SetTimer(static_cast<HWND>(window_), timer_id_, delay_ms, nullptr) != 0;
+}
+
+void SettleTimer::OnTimer() {
+  // Kill FIRST, before any work: one-shot by construction, not by hoping
+  // the callback logic reaches the kill.
+  Kill();
+  if (on_settled_) {
+    on_settled_();
+  }
+}
+
+void SettleTimer::Kill() {
+  if (armed_ && window_ != nullptr) {
+    KillTimer(static_cast<HWND>(window_), timer_id_);
+  }
+  armed_ = false;
+}
+
+}  // namespace platform

--- a/src/platform/settle_timer.h
+++ b/src/platform/settle_timer.h
@@ -1,0 +1,54 @@
+// The settle timer: measures "time until things settle after activity"
+// without violating G1's no-timers-at-idle rule.
+//
+// The contradiction this resolves: settle-time measurement needs a timer,
+// and G1 forbids timers that tick when nothing changed. The answer is a
+// timer that only exists while something is happening:
+//
+//   - SetTimer is called ONLY in response to real activity (resize, DPI
+//     change, animation). Idle means no timer object exists at all.
+//   - The handler calls KillTimer as its FIRST action, before doing any
+//     work — the timer is one-shot by construction, not by hoping the logic
+//     reaches the kill.
+//   - Re-arming during ongoing activity kills and re-sets, so a burst of
+//     activity yields one settle, never a stack of timers.
+//
+// This header stays free of windows.h.
+#pragma once
+
+#include <cstdint>
+#include <functional>
+
+namespace platform {
+
+class SettleTimer final {
+ public:
+  using Callback = std::function<void()>;
+
+  // `timer_id` distinguishes this timer in WM_TIMER; the window proc routes
+  // matching WM_TIMERs to OnTimer().
+  SettleTimer(void* window, std::uintptr_t timer_id, Callback on_settled);
+  ~SettleTimer();
+
+  SettleTimer(const SettleTimer&) = delete;
+  SettleTimer& operator=(const SettleTimer&) = delete;
+
+  // Arms in response to activity. Already armed: the countdown resets
+  // (kill + set), timers never stack.
+  void Arm(unsigned int delay_ms);
+
+  bool armed() const { return armed_; }
+
+  // Window proc entry: kills the timer first, then runs the callback.
+  void OnTimer();
+
+ private:
+  void Kill();
+
+  void* window_;
+  std::uintptr_t timer_id_;
+  Callback on_settled_;
+  bool armed_ = false;
+};
+
+}  // namespace platform

--- a/src/ui/shell/app_window.cpp
+++ b/src/ui/shell/app_window.cpp
@@ -6,6 +6,7 @@
 #include <algorithm>
 #include <cmath>
 
+#include "platform/settle_timer.h"
 #include "platform/signal_fanout.h"
 #include "render/gdi_resource_cache.h"
 
@@ -18,6 +19,8 @@ constexpr float kCornerRadius = 10.0f;
 constexpr float kCaptionHeight = 40.0f;
 constexpr float kButtonWidth = 46.0f;
 constexpr float kResizeBorder = 6.0f;
+constexpr std::uintptr_t kSettleTimerId = 0xD3E9C1A7;
+constexpr unsigned int kSettleDelayMs = 100;
 
 // Dark palette until themes land in Phase 2.
 constexpr render::Color kBackground{30, 30, 30, 255};
@@ -81,11 +84,20 @@ bool AppWindow::Create(void* instance, float content_width, float content_height
           signal_handler_(mask);
         }
       });
+  settle_timer_ = std::make_unique<platform::SettleTimer>(hwnd_, kSettleTimerId, [this] {
+    if (settle_handler_) {
+      settle_handler_();
+    }
+  });
   return true;
 }
 
 void AppWindow::set_signal_handler(std::function<void(std::uint32_t)> handler) {
   signal_handler_ = std::move(handler);
+}
+
+void AppWindow::set_settle_handler(std::function<void()> handler) {
+  settle_handler_ = std::move(handler);
 }
 
 void AppWindow::Show() {
@@ -135,6 +147,9 @@ void AppWindow::OnResized(int width_px, int height_px) {
   if (width_px <= 0 || height_px <= 0) return;
   backend_.Resize({Logical(width_px), Logical(height_px)});
   RenderFullFrame();
+  if (settle_timer_) {
+    settle_timer_->Arm(kSettleDelayMs);  // activity: the timer exists now
+  }
 }
 
 void AppWindow::OnDpiChanged(float dpi, int suggested_width_px, int suggested_height_px) {
@@ -144,7 +159,7 @@ void AppWindow::OnDpiChanged(float dpi, int suggested_width_px, int suggested_he
   backend_.SetDpi(dpi);
   SetWindowPos(static_cast<HWND>(hwnd_), nullptr, 0, 0, suggested_width_px, suggested_height_px,
                SWP_NOMOVE | SWP_NOZORDER | SWP_NOACTIVATE);
-  OnResized(suggested_width_px, suggested_height_px);
+  OnResized(suggested_width_px, suggested_height_px);  // arms the settle timer
 }
 
 int AppWindow::ButtonAt(int x_px, int y_px) const {
@@ -319,6 +334,10 @@ long long AppWindow::HandleMessage(void* window_handle, unsigned int message,
   HWND window = static_cast<HWND>(window_handle);
   if (message == drain_message_ && signals_) {
     signals_->DrainMessage();
+    return 0;
+  }
+  if (message == WM_TIMER && wparam == kSettleTimerId && settle_timer_) {
+    settle_timer_->OnTimer();
     return 0;
   }
   switch (message) {

--- a/src/ui/shell/app_window.h
+++ b/src/ui/shell/app_window.h
@@ -33,6 +33,7 @@ class GdiResourceCache;
 
 namespace platform {
 class SignalFanout;
+class SettleTimer;
 }
 
 namespace shell {
@@ -81,6 +82,11 @@ class AppWindow final {
   void set_signal_handler(std::function<void(std::uint32_t)> handler);
   std::uint32_t last_os_signals() const { return last_os_signals_; }
 
+  // Fires once after a burst of activity (resize, DPI change) settles.
+  // The underlying timer exists only while activity is ongoing — never at
+  // idle. This is the hook settle-time measurement (ETW) attaches to.
+  void set_settle_handler(std::function<void()> handler);
+
  private:
   static long long __stdcall WindowProc(void* window, unsigned int message,
                                         unsigned long long wparam, long long lparam);
@@ -102,7 +108,9 @@ class AppWindow final {
   void* hwnd_ = nullptr;  // HWND
   render::GdiBackend backend_;
   std::unique_ptr<platform::SignalFanout> signals_;
+  std::unique_ptr<platform::SettleTimer> settle_timer_;
   std::function<void(std::uint32_t)> signal_handler_;
+  std::function<void()> settle_handler_;
   std::uint32_t last_os_signals_ = 0;
   unsigned int drain_message_ = 0;
   float dpi_ = 96.0f;

--- a/tests/platform/settle_timer_test.cpp
+++ b/tests/platform/settle_timer_test.cpp
@@ -1,0 +1,167 @@
+#include "platform/settle_timer.h"
+
+#include <windows.h>
+
+#include <chrono>
+#include <thread>
+
+#include "framework/test_case.h"
+#include "ui/shell/app_window.h"
+
+namespace {
+
+platform::SettleTimer* g_settle = nullptr;
+int g_timer_messages = 0;
+
+LRESULT CALLBACK SettleTestProc(HWND window, UINT message, WPARAM wparam, LPARAM lparam) {
+  if (message == WM_TIMER) {
+    ++g_timer_messages;
+    if (g_settle != nullptr && wparam == 777) {
+      g_settle->OnTimer();
+      return 0;
+    }
+  }
+  return DefWindowProcW(window, message, wparam, lparam);
+}
+
+HWND CreateSettleWindow() {
+  WNDCLASSW window_class{};
+  window_class.lpfnWndProc = SettleTestProc;
+  window_class.hInstance = GetModuleHandleW(nullptr);
+  window_class.lpszClassName = L"dhepz.settle.test";
+  RegisterClassW(&window_class);  // already-exists is fine
+  return CreateWindowExW(0, window_class.lpszClassName, L"", WS_POPUP, 0, 0, 16, 16, nullptr,
+                         nullptr, window_class.hInstance, nullptr);
+}
+
+void PumpFor(int milliseconds) {
+  const auto deadline = std::chrono::steady_clock::now() +
+                        std::chrono::milliseconds(milliseconds);
+  while (std::chrono::steady_clock::now() < deadline) {
+    MSG msg;
+    while (PeekMessageW(&msg, nullptr, 0, 0, PM_REMOVE)) {
+      TranslateMessage(&msg);
+      DispatchMessageW(&msg);
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }
+}
+
+bool PumpUntilSettled(int& settles, int timeout_ms) {
+  const auto deadline = std::chrono::steady_clock::now() +
+                        std::chrono::milliseconds(timeout_ms);
+  while (std::chrono::steady_clock::now() < deadline) {
+    PumpFor(2);
+    if (settles > 0) return true;
+  }
+  return settles > 0;
+}
+
+}  // namespace
+
+DHEPZ_TEST(SettleTimer, FiresOnceAndIsOneShotByConstruction) {
+  HWND window = CreateSettleWindow();
+  DHEPZ_CHECK(window != nullptr);
+
+  int settles = 0;
+  platform::SettleTimer timer(window, 777, [&] { ++settles; });
+  g_settle = &timer;
+  g_timer_messages = 0;
+
+  timer.Arm(30);
+  DHEPZ_CHECK(timer.armed());
+  DHEPZ_CHECK(PumpUntilSettled(settles, 2000));
+  DHEPZ_CHECK_FALSE(timer.armed());  // killed first thing in the handler
+
+  // Keep pumping: nothing more may fire. The timer no longer exists.
+  PumpFor(300);
+  DHEPZ_CHECK_EQ(settles, 1);
+  DHEPZ_CHECK_EQ(g_timer_messages, 1);
+
+  g_settle = nullptr;
+  DestroyWindow(window);
+}
+
+DHEPZ_TEST(SettleTimer, RearmingResetsInsteadOfStacking) {
+  HWND window = CreateSettleWindow();
+  DHEPZ_CHECK(window != nullptr);
+
+  int settles = 0;
+  platform::SettleTimer timer(window, 777, [&] { ++settles; });
+  g_settle = &timer;
+
+  // A burst: 100 re-arms while the countdown is still running.
+  for (int i = 0; i < 100; ++i) {
+    timer.Arm(40);
+    PumpFor(2);
+  }
+  DHEPZ_CHECK(PumpUntilSettled(settles, 2000));
+
+  // Exactly one settle for the whole burst — timers never stacked.
+  PumpFor(300);
+  DHEPZ_CHECK_EQ(settles, 1);
+  DHEPZ_CHECK_FALSE(timer.armed());
+
+  g_settle = nullptr;
+  DestroyWindow(window);
+}
+
+DHEPZ_TEST(SettleTimer, IdleAfterSettleHasNoTimerArmed) {
+  HWND window = CreateSettleWindow();
+  DHEPZ_CHECK(window != nullptr);
+
+  int settles = 0;
+  platform::SettleTimer timer(window, 777, [&] { ++settles; });
+  g_settle = &timer;
+  g_timer_messages = 0;
+
+  timer.Arm(30);
+  DHEPZ_CHECK(PumpUntilSettled(settles, 2000));
+
+  // The audit: after activity has ceased, a long idle window delivers no
+  // timer messages at all, and nothing is armed.
+  const int before = g_timer_messages;
+  PumpFor(400);
+  DHEPZ_CHECK_EQ(g_timer_messages, before);
+  DHEPZ_CHECK_FALSE(timer.armed());
+
+  g_settle = nullptr;
+  DestroyWindow(window);
+}
+
+DHEPZ_TEST(SettleTimer, DestructorKillsAnArmedTimer) {
+  HWND window = CreateSettleWindow();
+  DHEPZ_CHECK(window != nullptr);
+  g_timer_messages = 0;
+
+  {
+    platform::SettleTimer timer(window, 777, [] {});
+    timer.Arm(30);
+    DHEPZ_CHECK(timer.armed());
+  }  // destroyed while armed
+
+  // Nothing may fire after the owner is gone.
+  g_settle = nullptr;
+  PumpFor(200);
+  DHEPZ_CHECK_EQ(g_timer_messages, 0);
+  DestroyWindow(window);
+}
+
+DHEPZ_TEST(SettleTimer, AppWindowResizeStormSettlesOnce) {
+  shell::AppWindow window;
+  DHEPZ_CHECK(window.Create(GetModuleHandleW(nullptr), 320.0f, 240.0f));
+  window.Show();
+  PumpFor(30);
+
+  int settles = 0;
+  window.set_settle_handler([&] { ++settles; });
+
+  const HWND hwnd = static_cast<HWND>(window.hwnd());
+  for (int i = 0; i < 100; ++i) {
+    SendMessageW(hwnd, WM_SIZE, 0, MAKELPARAM(330 + (i % 5), 250 + (i % 3)));
+  }
+  DHEPZ_CHECK(PumpUntilSettled(settles, 2000));
+  PumpFor(300);
+  // One burst of 100 resizes settles exactly once.
+  DHEPZ_CHECK_EQ(settles, 1);
+}


### PR DESCRIPTION
Closes #22.

## Summary
- `src/platform/settle_timer.{h,cpp}` — ported pattern from the old `window_container.cpp:1568-1574,1472-1480`. Resolves the plan's apparent contradiction: settle-time measurement needs a timer, and G1 forbids timers at idle — so this is a timer that only exists while something is happening.
- **SetTimer only in response to real activity** — `AppWindow` arms it from resize and DPI changes; nothing else in the codebase calls SetTimer, so the "every SetTimer follows the pattern" criterion is structural: there is exactly one site, and it lives in this class.
- **Kill-first handler**: `OnTimer` kills the timer before any work — one-shot by construction, not by hoping the logic reaches the kill.
- **Re-arm resets, never stacks**: `Arm` on an armed timer kills and re-sets; a burst of activity yields one settle.
- **Idle = no timer object at all**; destructor kills an armed timer so nothing outlives its owner.
- `AppWindow` exposes `set_settle_handler` — the hook the ETW settle-time measurement attaches to.

## Test plan (5 new tests; 134/134 Debug and Release)
- [x] Fires once, kills first (`armed()` false immediately after), and nothing fires in a 300 ms idle pump afterwards.
- [x] **100 re-arms during a countdown → exactly one settle** (no stacking), and **100 resizes through AppWindow → exactly one settle**.
- [x] Idle audit after settle: a 400 ms window delivers zero WM_TIMER messages and nothing armed (the 60 s version of this is soak territory, noted below).
- [x] Destructor kills an armed timer: no timer message after the owner is gone.
- [x] Idle CPU after activity recorded as structural: no timer → no wakeups; the process-level 0.0% record is #11/#13.