### PR TITLE
feat(ui): add caption pin and adaptive settings button (#51)

### DIFF
--- a/src/ui/shell/app_window.cpp
+++ b/src/ui/shell/app_window.cpp
@@ -45,6 +45,25 @@ render::TextStyle GlyphStyle() {
   return style;
 }
 
+// Verified by rendering the font on the target machine; the pair is the
+// user's visual choice: unpinned is the horizontal pin outline (E718),
+// pinned the diagonal pushpin (E840). E713 is the settings gear.
+constexpr wchar_t kPinGlyphUnpinned = 0xE718;  // horizontal pin outline
+constexpr wchar_t kPinGlyphPinned = 0xE840;    // diagonal pushpin
+constexpr wchar_t kGearGlyph = 0xE713;         // Settings
+
+render::TextStyle IconStyle() {
+  render::TextStyle style;
+  style.family = L"Segoe MDL2 Assets";
+  style.size_px = 14.0f;
+  return style;
+}
+
+// Marlett and Segoe MDL2 Assets centre their glyphs differently; the nudges
+// put both families on one visual row (verified against a rendered strip).
+constexpr float kIconNudgeY = 2.0f;
+constexpr float kMarlettNudgeY = -2.0f;
+
 }  // namespace
 
 AppWindow::AppWindow(render::GdiResourceCache* shared_cache) : backend_(shared_cache) {}
@@ -100,6 +119,19 @@ void AppWindow::set_settle_handler(std::function<void()> handler) {
   settle_handler_ = std::move(handler);
 }
 
+void AppWindow::set_settings_handler(std::function<void()> handler) {
+  settings_handler_ = std::move(handler);
+  if (visible()) {
+    RenderFullFrame();  // the button row gained or lost the gear
+  }
+}
+
+int AppWindow::ButtonCount() const {
+  // Left-to-right: pin, [settings], min, max/restore, close. The gear only
+  // exists while something can open — no dead button.
+  return settings_handler_ ? 5 : 4;
+}
+
 void AppWindow::Show() {
   const HWND window = static_cast<HWND>(hwnd_);
   if (window == nullptr || IsWindowVisible(window)) return;
@@ -124,6 +156,16 @@ void AppWindow::Close() {
   // Resident semantics: closing the window returns to the tray, it does not
   // exit the process. Exit belongs to the tray menu.
   Hide();
+}
+
+void AppWindow::TogglePin() {
+  if (hwnd_ == nullptr) return;
+  pinned_ = !pinned_;
+  SetWindowPos(static_cast<HWND>(hwnd_), pinned_ ? HWND_TOPMOST : HWND_NOTOPMOST, 0, 0, 0, 0,
+               SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE);
+  if (visible()) {
+    RenderFullFrame();  // the glyph state changed
+  }
 }
 
 void AppWindow::Destroy() {
@@ -176,8 +218,9 @@ int AppWindow::ButtonAt(int x_px, int y_px) const {
   }
   const int from_right = content_right - x_px;
   if (from_right < 0) return -1;
-  const int index = 2 - from_right / button_width;  // 0 min, 1 max, 2 close
-  if (index < 0 || index > 2) return -1;
+  const int count = ButtonCount();
+  const int index = (count - 1) - from_right / button_width;  // left-to-right
+  if (index < 0 || index >= count) return -1;
   return index;
 }
 
@@ -227,8 +270,14 @@ void AppWindow::RenderFullFrame() {
   // refused by design.
   const render::TextStyle caption = CaptionStyle();
   const render::TextStyle glyph = GlyphStyle();
+  const render::TextStyle icon = IconStyle();
   backend_.MeasureText(title_, caption, 0.0f);
   backend_.MeasureText(L"0", glyph, 0.0f);
+  backend_.MeasureText(std::wstring(1, kPinGlyphUnpinned), icon, 0.0f);
+  backend_.MeasureText(std::wstring(1, kPinGlyphPinned), icon, 0.0f);
+  if (settings_handler_) {
+    backend_.MeasureText(std::wstring(1, kGearGlyph), icon, 0.0f);
+  }
 
   render::Rect dirty{};
   if (!backend_.TakeInvalidation(dirty)) {
@@ -271,20 +320,45 @@ void AppWindow::PaintContent() {
 
   // Caption: title left, window buttons right.
   const render::Rect caption{content.x, content.y, content.width, kCaptionHeight};
-  backend_.DrawTextRun(title_, {caption.x + 14.0f, caption.y, 320.0f, caption.height},
-                       CaptionStyle(), kCaptionText, render::TextAlign::Left,
-                       render::VerticalAlign::Middle);
+  const int count = ButtonCount();
+  const float buttons_width = kButtonWidth * count;
+  const float title_width = content.width - buttons_width - 28.0f;
+  if (title_width > 0.0f) {
+    backend_.DrawTextRun(title_, {caption.x + 14.0f, caption.y, title_width, caption.height},
+                         CaptionStyle(), kCaptionText, render::TextAlign::Left,
+                         render::VerticalAlign::Middle);
+  }
 
   const render::TextStyle glyph = GlyphStyle();
-  const wchar_t* glyphs[3] = {L"0", maximized_ ? L"2" : L"1", L"r"};
-  for (int i = 0; i < 3; ++i) {
-    const render::Rect button{caption.right() - (3 - i) * kButtonWidth, caption.y, kButtonWidth,
-                              kCaptionHeight};
+  const render::TextStyle icon = IconStyle();
+  const wchar_t* marlett[3] = {L"0", maximized_ ? L"2" : L"1", L"r"};  // min, max, close
+  for (int i = 0; i < count; ++i) {
+    // Role by distance from the right edge: 0 close, 1 max, 2 min, then the
+    // left slots: settings (only with a handler) and pin leftmost.
+    const int role = (count - 1) - i;
+    const bool is_pin = role == 4 || (role == 3 && !settings_handler_);
+    const bool is_gear = role == 3 && settings_handler_;
+    const render::Rect button{caption.right() - (count - i) * kButtonWidth, caption.y,
+                              kButtonWidth, kCaptionHeight};
     if (hover_button_ == i) {
-      backend_.FillRect(button, i == 2 ? kHoverClose : kHoverNeutral);
+      backend_.FillRect(button, role == 0 ? kHoverClose : kHoverNeutral);
     }
-    backend_.DrawTextRun(glyphs[i], button, glyph, kCaptionText, render::TextAlign::Center,
-                         render::VerticalAlign::Middle);
+    if (is_pin) {
+      backend_.DrawTextRun(std::wstring(1, pinned_ ? kPinGlyphPinned : kPinGlyphUnpinned),
+                           {button.x, button.y + kIconNudgeY, button.width, button.height}, icon,
+                           kCaptionText, render::TextAlign::Center,
+                           render::VerticalAlign::Middle);
+    } else if (is_gear) {
+      backend_.DrawTextRun(std::wstring(1, kGearGlyph),
+                           {button.x, button.y + kIconNudgeY, button.width, button.height}, icon,
+                           kCaptionText, render::TextAlign::Center,
+                           render::VerticalAlign::Middle);
+    } else {
+      backend_.DrawTextRun(marlett[2 - role],
+                           {button.x, button.y + kMarlettNudgeY, button.width, button.height},
+                           glyph, kCaptionText, render::TextAlign::Center,
+                           render::VerticalAlign::Middle);
+    }
   }
 }
 
@@ -411,12 +485,19 @@ long long AppWindow::HandleMessage(void* window_handle, unsigned int message,
       return 0;
     case WM_LBUTTONUP: {
       const int button = ButtonAt(GET_X_LPARAM(lparam), GET_Y_LPARAM(lparam));
-      if (button == 0) {
-        ShowWindow(window, SW_MINIMIZE);
-      } else if (button == 1) {
-        SetMaximized(!maximized_);
-      } else if (button == 2) {
+      if (button < 0) return 0;
+      const int role = (ButtonCount() - 1) - button;  // 0 close … leftmost pin
+      const bool is_pin = role == 4 || (role == 3 && !settings_handler_);
+      if (role == 0) {
         Close();
+      } else if (role == 1) {
+        SetMaximized(!maximized_);
+      } else if (role == 2) {
+        ShowWindow(window, SW_MINIMIZE);
+      } else if (is_pin) {
+        TogglePin();
+      } else if (role == 3 && settings_handler_) {
+        settings_handler_();
       }
       return 0;
     }

--- a/src/ui/shell/app_window.h
+++ b/src/ui/shell/app_window.h
@@ -68,6 +68,11 @@ class AppWindow final {
   void* hwnd() const { return hwnd_; }
   render::GdiBackend* backend() { return &backend_; }
 
+  // Always-on-top pin: a caption button left of minimise toggles this. The
+  // state is session-only — persistence belongs to the settings module.
+  void TogglePin();
+  bool pinned() const { return pinned_; }
+
   // Verification hooks: the lifecycle steps the message handler takes,
   // callable directly so tests do not need a message pump.
   void OnResized(int width_px, int height_px);
@@ -87,6 +92,11 @@ class AppWindow final {
   // idle. This is the hook settle-time measurement (ETW) attaches to.
   void set_settle_handler(std::function<void()> handler);
 
+  // Opens the settings screen (Phase 5 wires this). While no handler is
+  // registered the caption's settings button does not render at all — no
+  // dead UI. Registering a handler adds the button.
+  void set_settings_handler(std::function<void()> handler);
+
  private:
   static long long __stdcall WindowProc(void* window, unsigned int message,
                                         unsigned long long wparam, long long lparam);
@@ -100,9 +110,11 @@ class AppWindow final {
   void SetMaximized(bool maximize);
   int Px(float logical) const;
   float Logical(int px) const;
-  // Button index (0 min, 1 max/restore, 2 close) at physical client coords,
-  // or -1.
+  // Caption buttons left-to-right: pin, settings (only while a settings
+  // handler is registered), min, max/restore, close. Returns the
+  // left-to-right index or -1.
   int ButtonAt(int x_px, int y_px) const;
+  int ButtonCount() const;
 
   void* instance_ = nullptr;
   void* hwnd_ = nullptr;  // HWND
@@ -111,10 +123,12 @@ class AppWindow final {
   std::unique_ptr<platform::SettleTimer> settle_timer_;
   std::function<void(std::uint32_t)> signal_handler_;
   std::function<void()> settle_handler_;
+  std::function<void()> settings_handler_;
   std::uint32_t last_os_signals_ = 0;
   unsigned int drain_message_ = 0;
   float dpi_ = 96.0f;
   bool maximized_ = false;
+  bool pinned_ = false;
   int restored_width_px_ = 0;
   int restored_height_px_ = 0;
   int hover_button_ = -1;

--- a/tests/ui/shell/app_window_test.cpp
+++ b/tests/ui/shell/app_window_test.cpp
@@ -204,3 +204,119 @@ DHEPZ_TEST(AppWindow, WarmShowFitsTheBudget) {
   DHEPZ_CHECK(ms < 2000.0);
 #endif
 }
+
+namespace {
+
+// Z-order rank from the top of the desktop: lower means closer to the front.
+// Topmost windows walk before non-topmost ones, which is exactly what the
+// pin must buy.
+int ZRank(HWND target) {
+  int rank = 0;
+  for (HWND w = GetTopWindow(nullptr); w != nullptr; w = GetWindow(w, GW_HWNDNEXT)) {
+    if (w == target) return rank;
+    ++rank;
+  }
+  return -1;
+}
+
+HWND MakePlainPopup() {
+  WNDCLASSW wc{};
+  wc.lpfnWndProc = DefWindowProcW;
+  wc.hInstance = GetModuleHandleW(nullptr);
+  wc.lpszClassName = L"dhepz.test.pin.peer";
+  RegisterClassW(&wc);  // already-exists is fine
+  const HWND window = CreateWindowExW(0, wc.lpszClassName, L"peer", WS_POPUP, 0, 0, 120, 90,
+                                      nullptr, nullptr, wc.hInstance, nullptr);
+  ShowWindow(window, SW_SHOW);
+  return window;
+}
+
+}  // namespace
+
+DHEPZ_TEST(AppWindow, PinTogglesTopmostAndSurvivesHideShow) {
+  shell::AppWindow window;
+  DHEPZ_CHECK(window.Create(TestInstance(), 320.0f, 240.0f));
+  window.Show();
+  PumpFor(30);
+  DHEPZ_CHECK_FALSE(window.pinned());
+
+  const HWND peer = MakePlainPopup();
+  SetWindowPos(peer, HWND_TOP, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE);
+  PumpFor(30);
+
+  window.TogglePin();
+  PumpFor(30);
+  DHEPZ_CHECK(window.pinned());
+  DHEPZ_CHECK(ZRank(static_cast<HWND>(window.hwnd())) >= 0);
+  DHEPZ_CHECK(ZRank(peer) >= 0);
+  DHEPZ_CHECK(ZRank(static_cast<HWND>(window.hwnd())) < ZRank(peer));
+
+  // Hide and restore: the pin state and the topmost band both survive.
+  window.Hide();
+  PumpFor(30);
+  window.Show();
+  PumpFor(30);
+  DHEPZ_CHECK(window.pinned());
+  DHEPZ_CHECK(ZRank(static_cast<HWND>(window.hwnd())) < ZRank(peer));
+
+  // Unpin: the peer, raised to the top, comes back in front.
+  window.TogglePin();
+  PumpFor(30);
+  DHEPZ_CHECK_FALSE(window.pinned());
+  SetWindowPos(peer, HWND_TOP, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE);
+  PumpFor(30);
+  DHEPZ_CHECK(ZRank(peer) < ZRank(static_cast<HWND>(window.hwnd())));
+
+  DestroyWindow(peer);
+}
+
+DHEPZ_TEST(AppWindow, PinTogglesDoNotGrowHandles) {
+  shell::AppWindow window;
+  DHEPZ_CHECK(window.Create(TestInstance(), 320.0f, 240.0f));
+  window.Show();
+  PumpFor(30);
+
+  const HANDLE process = GetCurrentProcess();
+  const DWORD gdi_before = GetGuiResources(process, GR_GDIOBJECTS);
+  const DWORD user_before = GetGuiResources(process, GR_USEROBJECTS);
+
+  for (int i = 0; i < 50; ++i) {
+    window.TogglePin();  // repaints every toggle: glyph state changed
+  }
+  PumpFor(60);
+
+  const long long gdi_drift = static_cast<long long>(GetGuiResources(process, GR_GDIOBJECTS)) -
+                              static_cast<long long>(gdi_before);
+  const long long user_drift = static_cast<long long>(GetGuiResources(process, GR_USEROBJECTS)) -
+                               static_cast<long long>(user_before);
+  DHEPZ_CHECK(gdi_drift <= 2);
+  DHEPZ_CHECK(user_drift <= 2);
+}
+
+DHEPZ_TEST(AppWindow, SettingsButtonAppearsOnlyWithHandler) {
+  shell::AppWindow window;
+  DHEPZ_CHECK(window.Create(TestInstance()));  // 960x640 content -> 1008x688
+  window.Show();
+  PumpFor(30);
+  const HWND hwnd = static_cast<HWND>(window.hwnd());
+
+  // Client geometry at 96 DPI: margin 24, content_right 984, button 46 px.
+  // Order left-to-right: pin, [settings], min, max, close.
+  bool opened = false;
+  // No handler: four buttons, the pin occupies x 800..846; the future gear
+  // slot (x 754..800) is plain caption — clicking it does nothing.
+  SendMessageW(hwnd, WM_LBUTTONUP, 0, MAKELPARAM(770, 40));
+  DHEPZ_CHECK_FALSE(opened);
+  DHEPZ_CHECK_FALSE(window.pinned());
+  SendMessageW(hwnd, WM_LBUTTONUP, 0, MAKELPARAM(820, 40));
+  DHEPZ_CHECK(window.pinned());
+  SendMessageW(hwnd, WM_LBUTTONUP, 0, MAKELPARAM(820, 40));
+  DHEPZ_CHECK_FALSE(window.pinned());
+
+  window.set_settings_handler([&opened] { opened = true; });
+  // The gear now takes x 800..846 and the pin shifts left to 754..800.
+  SendMessageW(hwnd, WM_LBUTTONUP, 0, MAKELPARAM(820, 40));
+  DHEPZ_CHECK(opened);
+  SendMessageW(hwnd, WM_LBUTTONUP, 0, MAKELPARAM(770, 40));
+  DHEPZ_CHECK(window.pinned());
+}


### PR DESCRIPTION
Issue #51.

- Pin button toggles HWND_TOPMOST / HWND_NOTOPMOST; state survives hide/restore; session-only (persistence belongs to the settings module).
- Glyph pair verified by rendering Segoe MDL2 Assets on the target machine: horizontal pin (E718) unpinned, diagonal pushpin (E840) pinned. The first draft's E713 turned out to be the settings gear — caught in visual review.
- Settings gear as a separate caption button, adaptive: renders only while set_settings_handler has a handler, so no dead UI before Phase 5.
- Order left-to-right: pin, settings, min, max, close. MDL2 icons at 14 px with per-family vertical nudges so both font families sit on one row.
- Tests: z-order rank vs a peer window, hide/show persistence, 50 toggles flat on GDI/USER, gear appears only with a handler and the pin keeps working at its shifted slot.