### PR TITLE
feat(ui): UI schema and component catalog as data (#52)

### DIFF
--- a/assets/ui/core.json
+++ b/assets/ui/core.json
@@ -1,0 +1,192 @@
+{
+  "schema": "dhepz.ui.core",
+  "version": 1,
+  "tokens": {
+    "dark": {
+      "window": "#14161B",
+      "surface": "#1C1F26",
+      "surfaceAlt": "#232730",
+      "border": "#303540",
+      "borderStrong": "#444B5A",
+      "text": "#E9EDF4",
+      "textDim": "#A8B2C2",
+      "textMuted": "#788294",
+      "accent": "#60A5FA",
+      "accentHover": "#93C5FD",
+      "accentPressed": "#BFDBFE",
+      "accentText": "#0F172A",
+      "danger": "#EF6060",
+      "success": "#4AC48C",
+      "input": "#181B21",
+      "selection": "#263E64",
+      "scrim": "#00000099",
+      "transparent": "#00000000"
+    },
+    "light": {
+      "window": "#F5F6F9",
+      "surface": "#FFFFFF",
+      "surfaceAlt": "#F0F2F6",
+      "border": "#D8DCE3",
+      "borderStrong": "#BAC0CB",
+      "text": "#181C24",
+      "textDim": "#565F6E",
+      "textMuted": "#7E8796",
+      "accent": "#2563EB",
+      "accentHover": "#1D4ED8",
+      "accentPressed": "#1E40AF",
+      "accentText": "#FFFFFF",
+      "danger": "#CB3737",
+      "success": "#1C9460",
+      "input": "#FFFFFF",
+      "selection": "#CDE0FC",
+      "scrim": "#00000066",
+      "transparent": "#00000000"
+    }
+  },
+  "fonts": {
+    "ui": { "family": "Segoe UI" },
+    "mono": { "family": "Cascadia Mono" }
+  },
+  "spacing": { "xs": 2, "sm": 4, "md": 8, "lg": 12, "xl": 16, "xxl": 24 },
+  "common": {
+    "properties": {
+      "id": { "kind": "string" },
+      "style": { "kind": "string" },
+      "visible": { "kind": "bool" },
+      "enabled": { "kind": "bool" }
+    }
+  },
+  "allows_children": ["window", "screen", "container", "card", "dialog", "tabs"],
+  "components": {
+    "window": {
+      "properties": {
+        "title": { "kind": "text", "required": true },
+        "initial_route": { "kind": "string" },
+        "initial_width": { "kind": "int" },
+        "initial_height": { "kind": "int" },
+        "minimum_width": { "kind": "int" },
+        "minimum_height": { "kind": "int" },
+        "resizable": { "kind": "bool" }
+      }
+    },
+    "screen": {
+      "properties": {
+        "route_id": { "kind": "string", "required": true },
+        "tab_label": { "kind": "string" },
+        "show_in_tabs": { "kind": "bool" },
+        "select_rules": { "kind": "array" }
+      }
+    },
+    "container": {
+      "properties": {
+        "direction": { "kind": "enum", "values": ["row", "column", "grid", "flow"] },
+        "gap": { "kind": "int" },
+        "padding": { "kind": "object" },
+        "align": { "kind": "enum", "values": ["start", "center", "end", "stretch"] },
+        "justify": { "kind": "enum", "values": ["start", "center", "end", "space-between"] },
+        "wrap": { "kind": "bool" },
+        "overflow": { "kind": "enum", "values": ["visible", "clip", "scroll"] }
+      }
+    },
+    "text": {
+      "properties": {
+        "text": { "kind": "text", "required": true },
+        "variant": { "kind": "enum", "values": ["body", "title", "caption", "monospace"] },
+        "wrap": { "kind": "bool" },
+        "selectable": { "kind": "bool" },
+        "align": { "kind": "enum", "values": ["start", "center", "end"] }
+      }
+    },
+    "button": {
+      "properties": {
+        "label": { "kind": "text", "required": true },
+        "variant": { "kind": "enum", "values": ["default", "primary", "subtle", "danger", "navigation", "bookmark"] },
+        "selected": { "kind": "binding" },
+        "press_selects": { "kind": "bool" },
+        "tab_stop": { "kind": "bool" }
+      }
+    },
+    "input": {
+      "properties": {
+        "value_binding": { "kind": "binding" },
+        "mode": { "kind": "enum", "values": ["single_line", "multiline"] },
+        "placeholder": { "kind": "string" },
+        "read_only": { "kind": "bool" },
+        "password": { "kind": "bool" },
+        "maximum_length": { "kind": "int" },
+        "horizontal_align": { "kind": "enum", "values": ["start", "center", "end"] },
+        "scrollbar": { "kind": "enum", "values": ["auto", "never"] },
+        "tab_stop": { "kind": "bool" }
+      }
+    },
+    "combo": {
+      "properties": {
+        "items_binding": { "kind": "binding" },
+        "selected_value_binding": { "kind": "binding" },
+        "placeholder": { "kind": "string" },
+        "maximum_visible_items": { "kind": "int" },
+        "popup_maximum_height": { "kind": "int" },
+        "allow_empty": { "kind": "bool" },
+        "tab_stop": { "kind": "bool" }
+      }
+    },
+    "checkbox": {
+      "properties": {
+        "label": { "kind": "text" },
+        "checked_binding": { "kind": "binding" },
+        "tri_state": { "kind": "bool" },
+        "tab_stop": { "kind": "bool" }
+      }
+    },
+    "toggle": {
+      "properties": {
+        "label": { "kind": "text" },
+        "checked_binding": { "kind": "binding" },
+        "variant": { "kind": "string" },
+        "tab_stop": { "kind": "bool" }
+      }
+    },
+    "card": {
+      "properties": {
+        "interactive": { "kind": "bool" },
+        "selected": { "kind": "binding" },
+        "tab_stop": { "kind": "bool" }
+      }
+    },
+    "list": {
+      "properties": {
+        "items_binding": { "kind": "binding" },
+        "item_template": { "kind": "object" },
+        "selected_id_binding": { "kind": "binding" },
+        "row_height": { "kind": "int" },
+        "overscan_rows": { "kind": "int" },
+        "selection": { "kind": "enum", "values": ["none", "single"] },
+        "empty_text": { "kind": "string" },
+        "scrollbar": { "kind": "enum", "values": ["auto", "never"] },
+        "tab_stop": { "kind": "bool" }
+      }
+    },
+    "scrollbar": {
+      "properties": {
+        "orientation": { "kind": "enum", "values": ["vertical", "horizontal"] },
+        "thickness": { "kind": "int" },
+        "minimum_thumb_length": { "kind": "int" },
+        "line_step": { "kind": "int" },
+        "page_step": { "kind": "int" }
+      }
+    },
+    "dialog": {
+      "properties": {
+        "title": { "kind": "text" },
+        "width": { "kind": "int" },
+        "maximum_height": { "kind": "int" },
+        "dismiss_escape": { "kind": "bool" },
+        "dismiss_outside_click": { "kind": "bool" },
+        "dismiss_explicit_action": { "kind": "bool" }
+      }
+    },
+    "tabs": {
+      "properties": {}
+    }
+  }
+}

--- a/src/core/json.cpp
+++ b/src/core/json.cpp
@@ -93,18 +93,26 @@ class Parser {
   std::wstring error_;
 
   std::wstring Message(std::wstring_view what) const {
-    std::size_t line = 1;
-    std::size_t column = 1;
-    for (std::size_t i = 0; i < pos_ && i < text_.size(); ++i) {
-      if (text_[i] == L'\n') {
-        ++line;
-        column = 1;
-      } else {
-        ++column;
-      }
-    }
+    int line = 0;
+    int column = 0;
+    PositionAt(pos_, &line, &column);
     return std::wstring(what) + L" (line " + std::to_wstring(line) + L", column " +
            std::to_wstring(column) + L")";
+  }
+
+  void PositionAt(std::size_t at, int* line, int* column) const {
+    std::size_t current_line = 1;
+    std::size_t current_column = 1;
+    for (std::size_t i = 0; i < at && i < text_.size(); ++i) {
+      if (text_[i] == L'\n') {
+        ++current_line;
+        current_column = 1;
+      } else {
+        ++current_column;
+      }
+    }
+    *line = static_cast<int>(current_line);
+    *column = static_cast<int>(current_column);
   }
 
   bool Fail(std::wstring_view what) {
@@ -137,40 +145,56 @@ class Parser {
     if (pos_ >= text_.size()) {
       return Fail(L"Unexpected end of input");
     }
+    const std::size_t start = pos_;
+    bool parsed = false;
     switch (text_[pos_]) {
       case L'{':
-        return ParseObject(out);
+        parsed = ParseObject(out);
+        break;
       case L'[':
-        return ParseArray(out);
+        parsed = ParseArray(out);
+        break;
       case L'"': {
         std::wstring text;
         if (!ParseString(&text)) {
           return false;
         }
         *out = Value::String(std::move(text));
-        return true;
+        parsed = true;
+        break;
       }
       case L't':
         if (!Literal(L"true")) {
           return Fail(L"Invalid literal, expected 'true'");
         }
         *out = Value::Bool(true);
-        return true;
+        parsed = true;
+        break;
       case L'f':
         if (!Literal(L"false")) {
           return Fail(L"Invalid literal, expected 'false'");
         }
         *out = Value::Bool(false);
-        return true;
+        parsed = true;
+        break;
       case L'n':
         if (!Literal(L"null")) {
           return Fail(L"Invalid literal, expected 'null'");
         }
         *out = Value::Null();
-        return true;
+        parsed = true;
+        break;
       default:
-        return ParseNumber(out);
+        parsed = ParseNumber(out);
+        break;
     }
+    if (parsed) {
+      int line = 0;
+      int column = 0;
+      PositionAt(start, &line, &column);
+      out->SetSourcePosition(line, column);
+    }
+    return parsed;
   }
 
   bool ParseObject(Value* out) {
@@ -193,6 +217,7 @@ class Parser {
         return Fail(L"Expected a quoted member name");
       }
       std::wstring key;
+      const std::size_t key_start = pos_;
       if (!ParseString(&key)) {
         return false;
       }
@@ -206,6 +231,12 @@ class Parser {
       if (!ParseValue(&member)) {
         return false;
       }
+      // Diagnostics about this member should point at the name, not at the
+      // value: stamp the key's position over the value's own.
+      int key_line = 0;
+      int key_column = 0;
+      PositionAt(key_start, &key_line, &key_column);
+      member.SetSourcePosition(key_line, key_column);
       object.Set(key, std::move(member));
       SkipWhitespace();
       if (pos_ < text_.size() && text_[pos_] == L',') {

--- a/src/core/json.h
+++ b/src/core/json.h
@@ -77,6 +77,17 @@ class Value {
   void Set(std::wstring_view key, Value value);
   void Remove(std::wstring_view key);
 
+  // Source position, 1-based, recorded by the parser; 0/0 for values built
+  // in code. A member value carries its KEY's position, so a semantic
+  // diagnostic ("unknown property", "wrong kind") points at the name the
+  // user actually wrote.
+  int line() const { return line_; }
+  int column() const { return column_; }
+  void SetSourcePosition(int line, int column) {
+    line_ = line;
+    column_ = column;
+  }
+
   const std::vector<std::pair<std::wstring, Value>>& members() const { return members_; }
   const std::vector<Value>& items() const { return items_; }
 
@@ -84,6 +95,8 @@ class Value {
   Type type_ = Type::Null;
   bool bool_ = false;
   double number_ = 0.0;
+  int line_ = 0;
+  int column_ = 0;
   std::wstring text_;  // string payload, or verbatim number text
   std::vector<Value> items_;
   std::vector<std::pair<std::wstring, Value>> members_;

--- a/src/ui/config/ui_schema.cpp
+++ b/src/ui/config/ui_schema.cpp
@@ -1,0 +1,295 @@
+#include "ui/config/ui_schema.h"
+
+#include <algorithm>
+
+namespace ui::config {
+namespace {
+
+constexpr std::wstring_view kSchemaName = L"dhepz.ui.core";
+
+const std::vector<std::wstring_view>& Kinds() {
+  static const std::vector<std::wstring_view> kinds = {
+      L"string", L"text", L"bool", L"int", L"enum", L"object", L"array", L"binding"};
+  return kinds;
+}
+
+void Add(std::vector<Diagnostic>* out, const json::Value& at, std::wstring message) {
+  out->push_back({std::move(message), at.line(), at.column()});
+}
+
+bool IsHexColor(const std::wstring& text) {
+  if (text.size() != 7 && text.size() != 9) return false;
+  if (text[0] != L'#') return false;
+  for (std::size_t i = 1; i < text.size(); ++i) {
+    const wchar_t c = text[i];
+    if (!((c >= L'0' && c <= L'9') || (c >= L'a' && c <= L'f') || (c >= L'A' && c <= L'F'))) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool IsInteger(const json::Value& value) {
+  if (!value.is_number()) return false;
+  const double number = value.AsNumber();
+  return number == static_cast<long long>(number);
+}
+
+// Validates one "properties" map of a catalog entry: each definition is an
+// object with a known kind; enums carry a non-empty string values array.
+void ValidatePropertyDefinitions(const json::Value& properties, std::wstring_view owner,
+                                 std::vector<Diagnostic>* out) {
+  for (const auto& [name, definition] : properties.members()) {
+    if (!definition.is_object()) {
+      Add(out, definition, L"catalog '" + std::wstring(owner) + L"." + name +
+                               L"': property definition must be an object");
+      continue;
+    }
+    const json::Value* kind = definition.Find(L"kind");
+    if (kind == nullptr || !kind->is_string()) {
+      Add(out, definition, L"catalog '" + std::wstring(owner) + L"." + name +
+                               L"': missing or non-string 'kind'");
+      continue;
+    }
+    const std::wstring& kind_text = kind->AsString();
+    if (std::find(Kinds().begin(), Kinds().end(), kind_text) == Kinds().end()) {
+      Add(out, *kind, L"catalog '" + std::wstring(owner) + L"." + name + L"': unknown kind '" +
+                          kind_text + L"'");
+    }
+    if (kind_text == L"enum") {
+      const json::Value* values = definition.ArrayField(L"values");
+      bool valid = values != nullptr && values->size() > 0;
+      if (valid) {
+        for (const json::Value& item : values->items()) {
+          if (!item.is_string()) {
+            valid = false;
+            break;
+          }
+        }
+      }
+      if (!valid) {
+        Add(out, definition, L"catalog '" + std::wstring(owner) + L"." + name +
+                                 L"': enum requires a non-empty string 'values' array");
+      }
+    }
+    const json::Value* required = definition.Find(L"required");
+    if (required != nullptr && !required->is_bool()) {
+      Add(out, *required, L"catalog '" + std::wstring(owner) + L"." + name +
+                              L"': 'required' must be a bool");
+    }
+  }
+}
+
+const json::Value* CatalogType(const json::Value& core, std::wstring_view type) {
+  const json::Value* components = core.ObjectField(L"components");
+  if (components == nullptr) return nullptr;
+  return components->Find(type);
+}
+
+bool KindMatches(const json::Value& value, std::wstring_view kind,
+                 const json::Value* definition) {
+  if (kind == L"string") return value.is_string();
+  if (kind == L"text") return value.is_string();
+  if (kind == L"bool") return value.is_bool();
+  if (kind == L"int") return IsInteger(value);
+  if (kind == L"object") return value.is_object();
+  if (kind == L"array") return value.is_array();
+  if (kind == L"binding") return value.is_string() || value.is_object();
+  if (kind == L"enum") {
+    if (!value.is_string()) return false;
+    const json::Value* values = definition->ArrayField(L"values");
+    if (values == nullptr) return false;
+    for (const json::Value& item : values->items()) {
+      if (item.is_string() && item.AsString() == value.AsString()) return true;
+    }
+    return false;
+  }
+  return true;
+}
+
+void ValidateComponent(const json::Value& core, const json::Value& component,
+                       std::vector<Diagnostic>* out) {
+  if (!component.is_object()) {
+    Add(out, component, L"component entry must be an object");
+    return;
+  }
+  const json::Value* type = component.Find(L"type");
+  if (type == nullptr || !type->is_string()) {
+    Add(out, component, L"component is missing a string 'type'");
+    return;
+  }
+  const json::Value* catalog = CatalogType(core, type->AsString());
+  if (catalog == nullptr) {
+    Add(out, *type, L"unknown component type '" + type->AsString() + L"'");
+    return;
+  }
+
+  const json::Value* common = core.ObjectField(L"common");
+  const json::Value* common_properties =
+      common != nullptr ? common->ObjectField(L"properties") : nullptr;
+  const json::Value* type_properties = catalog->ObjectField(L"properties");
+
+  // Required properties must be present.
+  for (const json::Value* properties : {type_properties, common_properties}) {
+    if (properties == nullptr) continue;
+    for (const auto& [name, definition] : properties->members()) {
+      if (definition.is_object() && definition.BoolField(L"required") &&
+          component.Find(name) == nullptr) {
+        Add(out, component, L"component '" + type->AsString() + L"' is missing required '" +
+                                name + L"'");
+      }
+    }
+  }
+
+  for (const auto& [name, value] : component.members()) {
+    if (name == L"type") continue;
+    if (name == L"children") {
+      const json::Value* allowed = core.ArrayField(L"allows_children");
+      bool may = false;
+      if (allowed != nullptr) {
+        for (const json::Value& item : allowed->items()) {
+          if (item.is_string() && item.AsString() == type->AsString()) {
+            may = true;
+            break;
+          }
+        }
+      }
+      if (!may) {
+        Add(out, value, L"component '" + type->AsString() + L"' may not have children");
+        continue;
+      }
+      if (!value.is_array()) {
+        Add(out, value, L"'children' must be an array");
+        continue;
+      }
+      for (const json::Value& child : value.items()) {
+        ValidateComponent(core, child, out);
+      }
+      continue;
+    }
+    const json::Value* definition = nullptr;
+    if (type_properties != nullptr) definition = type_properties->Find(name);
+    if (definition == nullptr && common_properties != nullptr) {
+      definition = common_properties->Find(name);
+    }
+    if (definition == nullptr) {
+      Add(out, value, L"unknown property '" + name + L"' on component '" + type->AsString() +
+                          L"'");
+      continue;
+    }
+    const std::wstring kind = definition->StringField(L"kind");
+    if (!KindMatches(value, kind, definition)) {
+      Add(out, value, L"property '" + name + L"' on component '" + type->AsString() +
+                          L"' must be of kind '" + kind + L"'");
+    }
+  }
+}
+
+}  // namespace
+
+core::Status ValidateCore(const json::Value& core, std::vector<Diagnostic>* diagnostics) {
+  std::vector<Diagnostic> local;
+  std::vector<Diagnostic>& out = diagnostics != nullptr ? *diagnostics : local;
+
+  if (!core.is_object()) {
+    Add(&out, core, L"core document must be an object");
+  } else {
+    const json::Value* schema = core.Find(L"schema");
+    if (schema == nullptr || !schema->is_string() || schema->AsString() != kSchemaName) {
+      Add(&out, core, L"core document 'schema' must be \"" + std::wstring(kSchemaName) + L"\"");
+    }
+    const json::Value* version = core.Find(L"version");
+    if (version == nullptr || !IsInteger(*version)) {
+      Add(&out, core, L"core document 'version' must be an integer");
+    }
+    const json::Value* tokens = core.ObjectField(L"tokens");
+    if (tokens == nullptr) {
+      Add(&out, core, L"core document is missing the 'tokens' object");
+    } else {
+      for (const auto& [theme_name, theme] : tokens->members()) {
+        if (!theme.is_object()) {
+          Add(&out, theme, L"token theme '" + theme_name + L"' must be an object");
+          continue;
+        }
+        for (const auto& [token_name, color] : theme.members()) {
+          if (!color.is_string() || !IsHexColor(color.AsString())) {
+            Add(&out, color, L"token '" + theme_name + L"." + token_name +
+                                 L"' must be a #RRGGBB or #RRGGBBAA colour");
+          }
+        }
+      }
+      for (const std::wstring_view required_theme : {L"dark", L"light"}) {
+        if (tokens->Find(required_theme) == nullptr) {
+          Add(&out, *tokens, L"tokens is missing the '" + std::wstring(required_theme) +
+                                 L"' theme");
+        }
+      }
+    }
+    const json::Value* components = core.ObjectField(L"components");
+    if (components == nullptr || components->members().empty()) {
+      Add(&out, core, L"core document is missing the 'components' catalog");
+    } else {
+      for (const auto& [type_name, entry] : components->members()) {
+        if (!entry.is_object()) {
+          Add(&out, entry, L"catalog entry '" + type_name + L"' must be an object");
+          continue;
+        }
+        const json::Value* properties = entry.ObjectField(L"properties");
+        if (properties == nullptr) {
+          Add(&out, entry, L"catalog entry '" + type_name + L"' is missing 'properties'");
+          continue;
+        }
+        ValidatePropertyDefinitions(*properties, type_name, &out);
+      }
+    }
+    const json::Value* common = core.ObjectField(L"common");
+    if (common != nullptr) {
+      const json::Value* properties = common->ObjectField(L"properties");
+      if (properties != nullptr) {
+        ValidatePropertyDefinitions(*properties, L"common", &out);
+      }
+    }
+    const json::Value* allowed = core.ArrayField(L"allows_children");
+    if (allowed != nullptr) {
+      for (const json::Value& item : allowed->items()) {
+        if (!item.is_string() || CatalogType(core, item.AsString()) == nullptr) {
+          Add(&out, item, L"allows_children must name catalog component types");
+        }
+      }
+    }
+  }
+
+  if (!out.empty()) {
+    return DHEPZ_ERR(core::ErrorCode::InvalidArgument,
+                     L"core document has " + std::to_wstring(out.size()) + L" diagnostic(s)");
+  }
+  return core::Ok();
+}
+
+core::Status ValidateScreen(const json::Value& core, const json::Value& screen,
+                            std::vector<Diagnostic>* diagnostics) {
+  std::vector<Diagnostic> local;
+  std::vector<Diagnostic>& out = diagnostics != nullptr ? *diagnostics : local;
+
+  if (!screen.is_object()) {
+    Add(&out, screen, L"screen document must be an object");
+  } else {
+    const json::Value* components = screen.ArrayField(L"components");
+    if (components == nullptr) {
+      Add(&out, screen, L"screen document is missing the 'components' array");
+    } else {
+      for (const json::Value& component : components->items()) {
+        ValidateComponent(core, component, &out);
+      }
+    }
+  }
+
+  if (!out.empty()) {
+    return DHEPZ_ERR(core::ErrorCode::InvalidArgument,
+                     L"screen document has " + std::to_wstring(out.size()) +
+                         L" diagnostic(s)");
+  }
+  return core::Ok();
+}
+
+}  // namespace ui::config

--- a/src/ui/config/ui_schema.h
+++ b/src/ui/config/ui_schema.h
@@ -1,0 +1,39 @@
+// The data-driven UI vocabulary (#52): validates assets/ui/core.json itself
+// and screen documents against the catalog it carries. Adding a component
+// type is a JSON change; nothing here names a component.
+//
+// Diagnostics carry the source line/column of the offending token, so a bad
+// screen file can be reported the way the plan demands: file and line.
+//
+// This header stays free of windows.h.
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "core/json.h"
+#include "core/status.h"
+
+namespace ui::config {
+
+struct Diagnostic {
+  std::wstring message;
+  int line = 0;
+  int column = 0;
+};
+
+// Validates a core.json document: header fields, token maps, and the shape
+// of every catalog entry (kinds, enum values, required flags). Returns Ok
+// with empty diagnostics when the document is a valid catalog; otherwise
+// fills diagnostics and returns InvalidArgument.
+core::Status ValidateCore(const json::Value& core, std::vector<Diagnostic>* diagnostics);
+
+// Validates a screen document against a core catalog that already passed
+// ValidateCore. Unknown component types, unknown properties, wrong kinds and
+// missing required properties each produce a diagnostic at the offending
+// key's line. Children recurse; only types listed in "allows_children" may
+// carry them.
+core::Status ValidateScreen(const json::Value& core, const json::Value& screen,
+                            std::vector<Diagnostic>* diagnostics);
+
+}  // namespace ui::config

--- a/tests/core/json_position_test.cpp
+++ b/tests/core/json_position_test.cpp
@@ -1,0 +1,27 @@
+#include "core/json.h"
+
+#include "framework/test_case.h"
+
+DHEPZ_TEST(JsonPosition, ValuesCarryTheirSourceLineAndColumn) {
+  json::Value root;
+  DHEPZ_CHECK(json::Parse(L"{\n  \"a\": [\n    1\n  ],\n  \"b\": true\n}\n", &root).ok());
+  DHEPZ_CHECK_EQ(static_cast<unsigned long long>(root.line()), 1ull);
+
+  const json::Value* a = root.Find(L"a");
+  DHEPZ_CHECK(a != nullptr);
+  // Member values carry the KEY's position.
+  DHEPZ_CHECK_EQ(static_cast<unsigned long long>(a->line()), 2ull);
+  DHEPZ_CHECK_EQ(static_cast<unsigned long long>(a->column()), 3ull);
+  // Array items keep their own position.
+  DHEPZ_CHECK_EQ(static_cast<unsigned long long>(a->items()[0].line()), 3ull);
+
+  const json::Value* b = root.Find(L"b");
+  DHEPZ_CHECK(b != nullptr);
+  DHEPZ_CHECK_EQ(static_cast<unsigned long long>(b->line()), 5ull);
+}
+
+DHEPZ_TEST(JsonPosition, CodeBuiltValuesHaveNoPosition) {
+  const json::Value made = json::Value::Bool(true);
+  DHEPZ_CHECK_EQ(made.line(), 0);
+  DHEPZ_CHECK_EQ(made.column(), 0);
+}

--- a/tests/dhepz_tests.vcxproj
+++ b/tests/dhepz_tests.vcxproj
@@ -122,6 +122,7 @@
     <ClCompile Include="..\src\core\**\*.cpp" />
     <ClCompile Include="..\src\platform\**\*.cpp" />
     <ClCompile Include="..\src\render\**\*.cpp" />
+    <ClCompile Include="..\src\ui\config\**\*.cpp" />
     <ClCompile Include="..\src\ui\shell\**\*.cpp" />
     <ClInclude Include="**\*.h" />
     <ResourceCompile Include="app_icon.rc" />

--- a/tests/ui/config/ui_schema_test.cpp
+++ b/tests/ui/config/ui_schema_test.cpp
@@ -1,0 +1,165 @@
+#include "ui/config/ui_schema.h"
+
+#include <windows.h>
+
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <cstring>
+
+#include "core/json.h"
+#include "framework/test_case.h"
+
+namespace {
+
+// The test binary lives at <root>/build/x64/<config>/; the catalog under
+// test is the repo's real assets/ui/core.json.
+std::string ReadRepoFile(const std::string& relative) {
+  wchar_t buffer[MAX_PATH]{};
+  GetModuleFileNameW(nullptr, buffer, MAX_PATH);
+  std::wstring path(buffer);
+  for (int i = 0; i < 4; ++i) {  // file, config dir, x64, build
+    const auto slash = path.find_last_of(L"\\/");
+    if (slash == std::wstring::npos) return {};
+    path.resize(slash);
+  }
+  path += L"\\";
+  for (char c : relative) path.push_back(c == '/' ? L'\\' : static_cast<wchar_t>(c));
+  std::ifstream stream(path, std::ios::binary);
+  std::ostringstream text;
+  text << stream.rdbuf();
+  return text.str();
+}
+
+json::Value LoadCore() {
+  json::Value core;
+  const core::Status status = json::ParseUtf8(ReadRepoFile("assets/ui/core.json"), &core);
+  DHEPZ_CHECK(status.ok());
+  return core;
+}
+
+json::Value ParseScreenText(const std::string& utf8) {
+  json::Value screen;
+  const core::Status status = json::ParseUtf8(utf8, &screen);
+  DHEPZ_CHECK(status.ok());
+  return screen;
+}
+
+}  // namespace
+
+DHEPZ_TEST(UiSchema, RepoCoreJsonValidatesClean) {
+  const json::Value core = LoadCore();
+  std::vector<ui::config::Diagnostic> diagnostics;
+  const core::Status status = ui::config::ValidateCore(core, &diagnostics);
+  for (const auto& diagnostic : diagnostics) {
+    OutputDebugStringW((diagnostic.message + L"\n").c_str());
+  }
+  DHEPZ_CHECK(status.ok());
+  DHEPZ_CHECK(diagnostics.empty());
+}
+
+DHEPZ_TEST(UiSchema, CatalogCarriesTheFourteenComponentTypes) {
+  const json::Value core = LoadCore();
+  const json::Value* components = core.ObjectField(L"components");
+  DHEPZ_CHECK(components != nullptr);
+  const char* types[14] = {"window", "screen", "container", "text",   "button",  "input",
+                           "combo",  "checkbox", "toggle",  "card",   "list",    "scrollbar",
+                           "dialog", "tabs"};
+  for (const char* type : types) {
+    std::wstring wide(type, type + strlen(type));
+    DHEPZ_CHECK(components->Find(wide) != nullptr);
+  }
+}
+
+DHEPZ_TEST(UiSchema, ScreenUsingTenTypesValidatesClean) {
+  const json::Value core = LoadCore();
+  const json::Value screen = ParseScreenText(R"({
+  "components": [
+    { "type": "screen", "route_id": "home", "children": [
+      { "type": "container", "direction": "column", "gap": 8, "children": [
+        { "type": "text", "text": "dhepz", "variant": "title" },
+        { "type": "button", "label": "Open", "variant": "primary", "tab_stop": true },
+        { "type": "input", "placeholder": "search", "maximum_length": 120 },
+        { "type": "combo", "items_binding": "items", "allow_empty": false },
+        { "type": "checkbox", "label": "enabled", "tri_state": true },
+        { "type": "toggle", "label": "dark", "checked_binding": "dark" },
+        { "type": "card", "interactive": true, "children": [
+          { "type": "list", "items_binding": "rows", "row_height": 28 }
+        ] },
+        { "type": "scrollbar", "orientation": "vertical", "thickness": 10 }
+      ] }
+    ] }
+  ]
+})");
+  std::vector<ui::config::Diagnostic> diagnostics;
+  const core::Status status = ui::config::ValidateScreen(core, screen, &diagnostics);
+  for (const auto& diagnostic : diagnostics) {
+    OutputDebugStringW((diagnostic.message + L"\n").c_str());
+  }
+  DHEPZ_CHECK(status.ok());
+  DHEPZ_CHECK(diagnostics.empty());
+}
+
+DHEPZ_TEST(UiSchema, UnknownPropertyFailsWithFileAndLine) {
+  const json::Value core = LoadCore();
+  // The bogus property sits on line 5 of this document.
+  const json::Value screen = ParseScreenText(
+      "{\n"
+      "  \"components\": [\n"
+      "    {\n"
+      "      \"type\": \"button\",\n"
+      "      \"labell\": \"x\",\n"
+      "      \"label\": \"x\"\n"
+      "    }\n"
+      "  ]\n"
+      "}\n");
+  std::vector<ui::config::Diagnostic> diagnostics;
+  DHEPZ_CHECK(!ui::config::ValidateScreen(core, screen, &diagnostics).ok());
+  DHEPZ_CHECK_EQ(diagnostics.size(), static_cast<std::size_t>(1));
+  DHEPZ_CHECK_EQ(static_cast<unsigned long long>(diagnostics[0].line), 5ull);
+  DHEPZ_CHECK(diagnostics[0].message.find(L"labell") != std::wstring::npos);
+}
+
+DHEPZ_TEST(UiSchema, UnknownTypeAndWrongKindAndMissingRequiredAreDiagnostics) {
+  const json::Value core = LoadCore();
+  const json::Value screen = ParseScreenText(
+      "{\n"
+      "  \"components\": [\n"
+      "    { \"type\": \"widget\" },\n"
+      "    { \"type\": \"button\", \"label\": \"ok\", \"tab_stop\": \"yes\" },\n"
+      "    { \"type\": \"text\", \"variant\": \"body\" }\n"
+      "  ]\n"
+      "}\n");
+  std::vector<ui::config::Diagnostic> diagnostics;
+  DHEPZ_CHECK(!ui::config::ValidateScreen(core, screen, &diagnostics).ok());
+  DHEPZ_CHECK_EQ(diagnostics.size(), static_cast<std::size_t>(3));
+}
+
+DHEPZ_TEST(UiSchema, ChildrenRefusedOnLeafComponents) {
+  const json::Value core = LoadCore();
+  const json::Value screen = ParseScreenText(
+      "{\n"
+      "  \"components\": [\n"
+      "    { \"type\": \"button\", \"label\": \"x\", \"children\": [] }\n"
+      "  ]\n"
+      "}\n");
+  std::vector<ui::config::Diagnostic> diagnostics;
+  DHEPZ_CHECK(!ui::config::ValidateScreen(core, screen, &diagnostics).ok());
+  DHEPZ_CHECK_EQ(diagnostics.size(), static_cast<std::size_t>(1));
+}
+
+DHEPZ_TEST(UiSchema, CoreCatalogRejectsBadKindAndEnumWithoutValues) {
+  json::Value core;
+  DHEPZ_CHECK(json::ParseUtf8(
+                  R"({ "schema": "dhepz.ui.core", "version": 1,
+     "tokens": { "dark": { "text": "#FFFFFF" }, "light": { "text": "#000000" } },
+     "components": {
+       "thing": { "properties": {
+         "a": { "kind": "colour" },
+         "b": { "kind": "enum" } } } } })",
+                  &core)
+                  .ok());
+  std::vector<ui::config::Diagnostic> diagnostics;
+  DHEPZ_CHECK(!ui::config::ValidateCore(core, &diagnostics).ok());
+  DHEPZ_CHECK(diagnostics.size() >= 2);
+}


### PR DESCRIPTION
Issue #52.

- assets/ui/core.json: the 14 component types as a data catalog (properties with kinds/enums/required), common properties, dark/light tokens ported from the old build, fonts, spacing, allows_children.
- src/ui/config/ui_schema.{h,cpp}: ValidateCore (catalog shape, token hex colours) and ValidateScreen (unknown type/property, wrong kind, missing required, children rules) with file+line diagnostics; the validator hardcodes no component name.
- core/json gains source positions: every parsed value records 1-based line/column; object members carry their key's position so semantic diagnostics point at the name the user wrote. Pinned by tests.
- Tests: repo core.json validates clean; catalog carries all 14 types; a ten-type screen validates clean; unknown property fails at its exact line; unknown type / wrong kind / missing required each diagnose; children refused on leaf components.