### PR TITLE
feat(ui): config resolver and immutable ResolvedUiDocument (#53)

### DIFF
--- a/assets/ui/core.json
+++ b/assets/ui/core.json
@@ -44,145 +44,447 @@
     }
   },
   "fonts": {
-    "ui": { "family": "Segoe UI" },
-    "mono": { "family": "Cascadia Mono" }
-  },
-  "spacing": { "xs": 2, "sm": 4, "md": 8, "lg": 12, "xl": 16, "xxl": 24 },
-  "common": {
-    "properties": {
-      "id": { "kind": "string" },
-      "style": { "kind": "string" },
-      "visible": { "kind": "bool" },
-      "enabled": { "kind": "bool" }
+    "ui": {
+      "family": "Segoe UI"
+    },
+    "mono": {
+      "family": "Cascadia Mono"
     }
   },
-  "allows_children": ["window", "screen", "container", "card", "dialog", "tabs"],
+  "spacing": {
+    "xs": 2,
+    "sm": 4,
+    "md": 8,
+    "lg": 12,
+    "xl": 16,
+    "xxl": 24
+  },
+  "common": {
+    "properties": {
+      "id": {
+        "kind": "string"
+      },
+      "style": {
+        "kind": "string"
+      },
+      "visible": {
+        "kind": "bool",
+        "default": true
+      },
+      "enabled": {
+        "kind": "bool",
+        "default": true
+      }
+    }
+  },
+  "allows_children": [
+    "window",
+    "screen",
+    "container",
+    "card",
+    "dialog",
+    "tabs"
+  ],
   "components": {
     "window": {
       "properties": {
-        "title": { "kind": "text", "required": true },
-        "initial_route": { "kind": "string" },
-        "initial_width": { "kind": "int" },
-        "initial_height": { "kind": "int" },
-        "minimum_width": { "kind": "int" },
-        "minimum_height": { "kind": "int" },
-        "resizable": { "kind": "bool" }
+        "title": {
+          "kind": "text",
+          "required": true
+        },
+        "initial_route": {
+          "kind": "string"
+        },
+        "initial_width": {
+          "kind": "int",
+          "default": 760
+        },
+        "initial_height": {
+          "kind": "int",
+          "default": 520
+        },
+        "minimum_width": {
+          "kind": "int",
+          "default": 620
+        },
+        "minimum_height": {
+          "kind": "int",
+          "default": 420
+        },
+        "resizable": {
+          "kind": "bool",
+          "default": true
+        }
       }
     },
     "screen": {
       "properties": {
-        "route_id": { "kind": "string", "required": true },
-        "tab_label": { "kind": "string" },
-        "show_in_tabs": { "kind": "bool" },
-        "select_rules": { "kind": "array" }
+        "route_id": {
+          "kind": "string",
+          "required": true
+        },
+        "tab_label": {
+          "kind": "string"
+        },
+        "show_in_tabs": {
+          "kind": "bool",
+          "default": true
+        },
+        "select_rules": {
+          "kind": "array"
+        }
       }
     },
     "container": {
       "properties": {
-        "direction": { "kind": "enum", "values": ["row", "column", "grid", "flow"] },
-        "gap": { "kind": "int" },
-        "padding": { "kind": "object" },
-        "align": { "kind": "enum", "values": ["start", "center", "end", "stretch"] },
-        "justify": { "kind": "enum", "values": ["start", "center", "end", "space-between"] },
-        "wrap": { "kind": "bool" },
-        "overflow": { "kind": "enum", "values": ["visible", "clip", "scroll"] }
+        "direction": {
+          "kind": "enum",
+          "values": [
+            "row",
+            "column",
+            "grid",
+            "flow"
+          ],
+          "default": "column"
+        },
+        "gap": {
+          "kind": "int",
+          "default": 8
+        },
+        "padding": {
+          "kind": "object"
+        },
+        "align": {
+          "kind": "enum",
+          "values": [
+            "start",
+            "center",
+            "end",
+            "stretch"
+          ],
+          "default": "stretch"
+        },
+        "justify": {
+          "kind": "enum",
+          "values": [
+            "start",
+            "center",
+            "end",
+            "space-between"
+          ],
+          "default": "start"
+        },
+        "wrap": {
+          "kind": "bool",
+          "default": false
+        },
+        "overflow": {
+          "kind": "enum",
+          "values": [
+            "visible",
+            "clip",
+            "scroll"
+          ],
+          "default": "visible"
+        }
       }
     },
     "text": {
       "properties": {
-        "text": { "kind": "text", "required": true },
-        "variant": { "kind": "enum", "values": ["body", "title", "caption", "monospace"] },
-        "wrap": { "kind": "bool" },
-        "selectable": { "kind": "bool" },
-        "align": { "kind": "enum", "values": ["start", "center", "end"] }
+        "text": {
+          "kind": "text",
+          "required": true
+        },
+        "variant": {
+          "kind": "enum",
+          "values": [
+            "body",
+            "title",
+            "caption",
+            "monospace"
+          ],
+          "default": "body"
+        },
+        "wrap": {
+          "kind": "bool",
+          "default": true
+        },
+        "selectable": {
+          "kind": "bool",
+          "default": false
+        },
+        "align": {
+          "kind": "enum",
+          "values": [
+            "start",
+            "center",
+            "end"
+          ],
+          "default": "start"
+        }
       }
     },
     "button": {
       "properties": {
-        "label": { "kind": "text", "required": true },
-        "variant": { "kind": "enum", "values": ["default", "primary", "subtle", "danger", "navigation", "bookmark"] },
-        "selected": { "kind": "binding" },
-        "press_selects": { "kind": "bool" },
-        "tab_stop": { "kind": "bool" }
+        "label": {
+          "kind": "text",
+          "required": true
+        },
+        "variant": {
+          "kind": "enum",
+          "values": [
+            "default",
+            "primary",
+            "subtle",
+            "danger",
+            "navigation",
+            "bookmark"
+          ],
+          "default": "default"
+        },
+        "selected": {
+          "kind": "binding",
+          "default": false
+        },
+        "press_selects": {
+          "kind": "bool",
+          "default": false
+        },
+        "tab_stop": {
+          "kind": "bool",
+          "default": true
+        }
       }
     },
     "input": {
       "properties": {
-        "value_binding": { "kind": "binding" },
-        "mode": { "kind": "enum", "values": ["single_line", "multiline"] },
-        "placeholder": { "kind": "string" },
-        "read_only": { "kind": "bool" },
-        "password": { "kind": "bool" },
-        "maximum_length": { "kind": "int" },
-        "horizontal_align": { "kind": "enum", "values": ["start", "center", "end"] },
-        "scrollbar": { "kind": "enum", "values": ["auto", "never"] },
-        "tab_stop": { "kind": "bool" }
+        "value_binding": {
+          "kind": "binding"
+        },
+        "mode": {
+          "kind": "enum",
+          "values": [
+            "single_line",
+            "multiline"
+          ],
+          "default": "single_line"
+        },
+        "placeholder": {
+          "kind": "string"
+        },
+        "read_only": {
+          "kind": "bool",
+          "default": false
+        },
+        "password": {
+          "kind": "bool",
+          "default": false
+        },
+        "maximum_length": {
+          "kind": "int",
+          "default": 4096
+        },
+        "horizontal_align": {
+          "kind": "enum",
+          "values": [
+            "start",
+            "center",
+            "end"
+          ],
+          "default": "start"
+        },
+        "scrollbar": {
+          "kind": "enum",
+          "values": [
+            "auto",
+            "never"
+          ],
+          "default": "auto"
+        },
+        "tab_stop": {
+          "kind": "bool",
+          "default": true
+        }
       }
     },
     "combo": {
       "properties": {
-        "items_binding": { "kind": "binding" },
-        "selected_value_binding": { "kind": "binding" },
-        "placeholder": { "kind": "string" },
-        "maximum_visible_items": { "kind": "int" },
-        "popup_maximum_height": { "kind": "int" },
-        "allow_empty": { "kind": "bool" },
-        "tab_stop": { "kind": "bool" }
+        "items_binding": {
+          "kind": "binding"
+        },
+        "selected_value_binding": {
+          "kind": "binding"
+        },
+        "placeholder": {
+          "kind": "string"
+        },
+        "maximum_visible_items": {
+          "kind": "int",
+          "default": 10
+        },
+        "popup_maximum_height": {
+          "kind": "int",
+          "default": 480
+        },
+        "allow_empty": {
+          "kind": "bool",
+          "default": true
+        },
+        "tab_stop": {
+          "kind": "bool",
+          "default": true
+        }
       }
     },
     "checkbox": {
       "properties": {
-        "label": { "kind": "text" },
-        "checked_binding": { "kind": "binding" },
-        "tri_state": { "kind": "bool" },
-        "tab_stop": { "kind": "bool" }
+        "label": {
+          "kind": "text"
+        },
+        "checked_binding": {
+          "kind": "binding"
+        },
+        "tri_state": {
+          "kind": "bool",
+          "default": false
+        },
+        "tab_stop": {
+          "kind": "bool",
+          "default": true
+        }
       }
     },
     "toggle": {
       "properties": {
-        "label": { "kind": "text" },
-        "checked_binding": { "kind": "binding" },
-        "variant": { "kind": "string" },
-        "tab_stop": { "kind": "bool" }
+        "label": {
+          "kind": "text"
+        },
+        "checked_binding": {
+          "kind": "binding"
+        },
+        "variant": {
+          "kind": "string",
+          "default": "default"
+        },
+        "tab_stop": {
+          "kind": "bool",
+          "default": true
+        }
       }
     },
     "card": {
       "properties": {
-        "interactive": { "kind": "bool" },
-        "selected": { "kind": "binding" },
-        "tab_stop": { "kind": "bool" }
+        "interactive": {
+          "kind": "bool",
+          "default": false
+        },
+        "selected": {
+          "kind": "binding",
+          "default": false
+        },
+        "tab_stop": {
+          "kind": "bool",
+          "default": false
+        }
       }
     },
     "list": {
       "properties": {
-        "items_binding": { "kind": "binding" },
-        "item_template": { "kind": "object" },
-        "selected_id_binding": { "kind": "binding" },
-        "row_height": { "kind": "int" },
-        "overscan_rows": { "kind": "int" },
-        "selection": { "kind": "enum", "values": ["none", "single"] },
-        "empty_text": { "kind": "string" },
-        "scrollbar": { "kind": "enum", "values": ["auto", "never"] },
-        "tab_stop": { "kind": "bool" }
+        "items_binding": {
+          "kind": "binding"
+        },
+        "item_template": {
+          "kind": "object"
+        },
+        "selected_id_binding": {
+          "kind": "binding"
+        },
+        "row_height": {
+          "kind": "int",
+          "default": 32
+        },
+        "overscan_rows": {
+          "kind": "int",
+          "default": 2
+        },
+        "selection": {
+          "kind": "enum",
+          "values": [
+            "none",
+            "single"
+          ],
+          "default": "single"
+        },
+        "empty_text": {
+          "kind": "string",
+          "default": "Tidak ada data"
+        },
+        "scrollbar": {
+          "kind": "enum",
+          "values": [
+            "auto",
+            "never"
+          ],
+          "default": "auto"
+        },
+        "tab_stop": {
+          "kind": "bool",
+          "default": true
+        }
       }
     },
     "scrollbar": {
       "properties": {
-        "orientation": { "kind": "enum", "values": ["vertical", "horizontal"] },
-        "thickness": { "kind": "int" },
-        "minimum_thumb_length": { "kind": "int" },
-        "line_step": { "kind": "int" },
-        "page_step": { "kind": "int" }
+        "orientation": {
+          "kind": "enum",
+          "values": [
+            "vertical",
+            "horizontal"
+          ],
+          "default": "vertical"
+        },
+        "thickness": {
+          "kind": "int",
+          "default": 12
+        },
+        "minimum_thumb_length": {
+          "kind": "int",
+          "default": 24
+        },
+        "line_step": {
+          "kind": "int",
+          "default": 1
+        },
+        "page_step": {
+          "kind": "int"
+        }
       }
     },
     "dialog": {
       "properties": {
-        "title": { "kind": "text" },
-        "width": { "kind": "int" },
-        "maximum_height": { "kind": "int" },
-        "dismiss_escape": { "kind": "bool" },
-        "dismiss_outside_click": { "kind": "bool" },
-        "dismiss_explicit_action": { "kind": "bool" }
+        "title": {
+          "kind": "text"
+        },
+        "width": {
+          "kind": "int",
+          "default": 480
+        },
+        "maximum_height": {
+          "kind": "int",
+          "default": 720
+        },
+        "dismiss_escape": {
+          "kind": "bool",
+          "default": true
+        },
+        "dismiss_outside_click": {
+          "kind": "bool",
+          "default": false
+        },
+        "dismiss_explicit_action": {
+          "kind": "bool",
+          "default": true
+        }
       }
     },
     "tabs": {

--- a/src/ui/config/resolved_ui_document.cpp
+++ b/src/ui/config/resolved_ui_document.cpp
@@ -1,0 +1,276 @@
+#include "ui/config/resolved_ui_document.h"
+
+#include <algorithm>
+#include <cwchar>
+
+namespace ui::config {
+namespace {
+
+bool ParseHexColor(const std::wstring& text, Rgba* out) {
+  if (text.size() != 7 && text.size() != 9) return false;
+  if (text.front() != L'#') return false;
+  auto nibble = [](wchar_t c, unsigned* value) {
+    if (c >= L'0' && c <= L'9') { *value = static_cast<unsigned>(c - L'0'); return true; }
+    if (c >= L'a' && c <= L'f') { *value = static_cast<unsigned>(c - L'a') + 10; return true; }
+    if (c >= L'A' && c <= L'F') { *value = static_cast<unsigned>(c - L'A') + 10; return true; }
+    return false;
+  };
+  unsigned values[4] = {0, 0, 0, 255};
+  for (int channel = 0; channel < (text.size() == 9 ? 4 : 3); ++channel) {
+    unsigned high = 0;
+    unsigned low = 0;
+    if (!nibble(text[1 + channel * 2], &high) || !nibble(text[2 + channel * 2], &low)) {
+      return false;
+    }
+    values[channel] = high * 16 + low;
+  }
+  out->r = static_cast<unsigned char>(values[0]);
+  out->g = static_cast<unsigned char>(values[1]);
+  out->b = static_cast<unsigned char>(values[2]);
+  out->a = static_cast<unsigned char>(values[3]);
+  return true;
+}
+
+const json::Value* CatalogType(const json::Value& core, std::wstring_view type) {
+  const json::Value* components = core.ObjectField(L"components");
+  if (components == nullptr) return nullptr;
+  return components->Find(type);
+}
+
+// Extracts "(line N, column M)" from a parser Status message so syntax
+// errors carry the same structured position as semantic diagnostics.
+void SplitParseMessage(const std::wstring& message, std::wstring* text, int* line,
+                       int* column) {
+  const std::size_t open = message.rfind(L" (line ");
+  if (open == std::wstring::npos) {
+    *text = message;
+    return;
+  }
+  *text = message.substr(0, open);
+  int parsed_line = 0;
+  int parsed_column = 0;
+  if (swscanf_s(message.c_str() + open, L" (line %d, column %d)", &parsed_line,
+                &parsed_column) == 2) {
+    *line = parsed_line;
+    *column = parsed_column;
+  }
+}
+
+ComponentNode BuildNode(const json::Value& core, const json::Value& component) {
+  ComponentNode node;
+  node.type_ = component.StringField(L"type");
+  node.id_ = component.StringField(L"id");
+
+  const json::Value* catalog = CatalogType(core, node.type_);
+  const json::Value* common = core.ObjectField(L"common");
+  for (const json::Value* properties :
+       {catalog != nullptr ? catalog->ObjectField(L"properties") : nullptr,
+        common != nullptr ? common->ObjectField(L"properties") : nullptr}) {
+    if (properties == nullptr) continue;
+    for (const auto& [name, definition] : properties->members()) {
+      if (!definition.is_object()) continue;
+      const json::Value* default_value = definition.Find(L"default");
+      if (default_value != nullptr) {
+        node.properties_.emplace_back(name, *default_value);
+      }
+    }
+  }
+  for (const auto& [name, value] : component.members()) {
+    if (name == L"type" || name == L"children") continue;
+    const auto existing = std::find_if(
+        node.properties_.begin(), node.properties_.end(),
+        [&name](const auto& pair) { return pair.first == name; });
+    if (existing != node.properties_.end()) {
+      existing->second = value;
+    } else {
+      node.properties_.emplace_back(name, value);
+    }
+  }
+  const json::Value* children = component.ArrayField(L"children");
+  if (children != nullptr) {
+    for (const json::Value& child : children->items()) {
+      node.children_.push_back(BuildNode(core, child));
+    }
+  }
+  return node;
+}
+
+}  // namespace
+
+bool ComponentNode::Has(std::wstring_view name) const {
+  return std::find_if(properties_.begin(), properties_.end(), [name](const auto& pair) {
+           return pair.first == name;
+         }) != properties_.end();
+}
+
+std::wstring ComponentNode::GetString(std::wstring_view name,
+                                      std::wstring_view fallback) const {
+  for (const auto& [key, value] : properties_) {
+    if (key == name && value.is_string()) return value.AsString();
+  }
+  return std::wstring(fallback);
+}
+
+long long ComponentNode::GetInt(std::wstring_view name, long long fallback) const {
+  for (const auto& [key, value] : properties_) {
+    if (key == name && value.is_number()) {
+      return static_cast<long long>(value.AsNumber());
+    }
+  }
+  return fallback;
+}
+
+bool ComponentNode::GetBool(std::wstring_view name, bool fallback) const {
+  for (const auto& [key, value] : properties_) {
+    if (key == name && value.is_bool()) return value.AsBool();
+  }
+  return fallback;
+}
+
+const Route* ResolvedUiDocument::FindRoute(std::wstring_view id) const {
+  for (const Route& route : routes_) {
+    if (route.id == id) return &route;
+  }
+  return nullptr;
+}
+
+bool ResolvedUiDocument::Token(std::wstring_view theme, std::wstring_view name,
+                               Rgba* out) const {
+  for (std::size_t t = 0; t < theme_names_.size(); ++t) {
+    if (theme_names_[t] != theme) continue;
+    for (const auto& [token, color] : theme_tokens_[t]) {
+      if (token == name) {
+        if (out != nullptr) *out = color;
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+core::Status ResolveDocument(const json::Value& core, const std::vector<ScreenSource>& sources,
+                             std::vector<Diagnostic>* diagnostics,
+                             std::unique_ptr<ResolvedUiDocument>* out) {
+  if (out == nullptr) {
+    return DHEPZ_ERR(core::ErrorCode::InvalidArgument, L"ResolveDocument requires an output");
+  }
+  std::vector<Diagnostic> local;
+  std::vector<Diagnostic>& diags = diagnostics != nullptr ? *diagnostics : local;
+
+  DHEPZ_RETURN_IF_ERROR(ValidateCore(core, &diags));
+
+  // Merge in source order; a later source replaces a route wholesale
+  // (embedded < override). Duplicate routes within one source are an error.
+  std::vector<std::wstring> route_order;
+  std::vector<const json::Value*> route_screen;
+  std::vector<std::wstring> route_source;
+  std::vector<json::Value> parsed_sources;
+  std::wstring initial_route;
+
+  for (const ScreenSource& source : sources) {
+    json::Value document;
+    const core::Status parsed = json::Parse(source.text, &document);
+    if (!parsed.ok()) {
+      Diagnostic diagnostic;
+      std::wstring text;
+      SplitParseMessage(parsed.Message(), &text, &diagnostic.line, &diagnostic.column);
+      diagnostic.message = source.name + L": " + text;
+      diags.push_back(diagnostic);
+      continue;
+    }
+    parsed_sources.push_back(std::move(document));
+    const json::Value& document_ref = parsed_sources.back();
+
+    std::vector<Diagnostic> screen_diags;
+    const core::Status validated = ValidateScreen(core, document_ref, &screen_diags);
+    for (Diagnostic& diagnostic : screen_diags) {
+      diagnostic.message = source.name + L": " + diagnostic.message;
+      diags.push_back(diagnostic);
+    }
+    if (!validated.ok()) {
+      continue;
+    }
+
+    const json::Value* components = document_ref.ArrayField(L"components");
+    if (components == nullptr) continue;
+    for (const json::Value& component : components->items()) {
+      const std::wstring type = component.StringField(L"type");
+      if (type == L"window") {
+        const json::Value* route = component.Find(L"initial_route");
+        if (route != nullptr && route->is_string()) {
+          initial_route = route->AsString();
+        }
+        continue;
+      }
+      if (type != L"screen") continue;
+      const std::wstring route_id = component.StringField(L"route_id");
+      const auto known = std::find(route_order.begin(), route_order.end(), route_id);
+      if (known != route_order.end()) {
+        const std::size_t index = static_cast<std::size_t>(known - route_order.begin());
+        if (route_source[index] == source.name) {
+          const json::Value* at = component.Find(L"route_id");
+          Diagnostic diagnostic;
+          diagnostic.message = source.name + L": duplicate route '" + route_id + L"'";
+          if (at != nullptr) {
+            diagnostic.line = at->line();
+            diagnostic.column = at->column();
+          }
+          diags.push_back(diagnostic);
+        } else {
+          route_screen[index] = &component;
+          route_source[index] = source.name;
+        }
+        continue;
+      }
+      route_order.push_back(route_id);
+      route_screen.push_back(&component);
+      route_source.push_back(source.name);
+    }
+  }
+
+  if (!diags.empty()) {
+    return DHEPZ_ERR(core::ErrorCode::InvalidArgument,
+                     L"resolve produced " + std::to_wstring(diags.size()) + L" diagnostic(s)");
+  }
+
+  auto document = std::make_unique<ResolvedUiDocument>();
+  const json::Value* tokens = core.ObjectField(L"tokens");
+  if (tokens != nullptr) {
+    for (const auto& [theme_name, theme] : tokens->members()) {
+      document->theme_names_.push_back(theme_name);
+      std::vector<std::pair<std::wstring, Rgba>> colors;
+      if (theme.is_object()) {
+        for (const auto& [token_name, color] : theme.members()) {
+          Rgba rgba{};
+          if (color.is_string() && ParseHexColor(color.AsString(), &rgba)) {
+            colors.emplace_back(token_name, rgba);
+          }
+        }
+      }
+      document->theme_tokens_.push_back(std::move(colors));
+    }
+  }
+
+  for (std::size_t i = 0; i < route_order.size(); ++i) {
+    Route route;
+    route.id = route_order[i];
+    route.tab_label = route_screen[i]->StringField(L"tab_label", route_order[i]);
+    route.show_in_tabs = route_screen[i]->BoolField(L"show_in_tabs", true);
+    route.root = BuildNode(core, *route_screen[i]);
+    document->routes_.push_back(std::move(route));
+  }
+
+  if (initial_route.empty() && !document->routes_.empty()) {
+    initial_route = document->routes_.front().id;
+  }
+  if (!initial_route.empty() && document->FindRoute(initial_route) == nullptr) {
+    return DHEPZ_ERR(core::ErrorCode::InvalidArgument,
+                     L"initial_route '" + initial_route + L"' does not exist");
+  }
+  document->initial_route_ = std::move(initial_route);
+
+  *out = std::move(document);
+  return core::Ok();
+}
+
+}  // namespace ui::config

--- a/src/ui/config/resolved_ui_document.h
+++ b/src/ui/config/resolved_ui_document.h
@@ -1,0 +1,97 @@
+// The resolver's output (#53): an immutable document the render pipeline
+// reads. Built once from the validated core catalog plus an ordered list of
+// screen sources; later sources override earlier ones per route (embedded
+// first, user override last), so merge precedence is embedded < override by
+// construction.
+//
+// Immutability is structural: the only writer is the resolver, everything
+// else holds a const pointer.
+//
+// This header stays free of windows.h.
+#pragma once
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "core/json.h"
+#include "core/status.h"
+#include "ui/config/ui_schema.h"
+
+namespace ui::config {
+
+struct Rgba {
+  unsigned char r = 0;
+  unsigned char g = 0;
+  unsigned char b = 0;
+  unsigned char a = 255;
+};
+
+// One raw screen document. `name` identifies the source in diagnostics
+// (e.g. "embedded" or the override file path); `text` is the JSON.
+struct ScreenSource {
+  std::wstring name;
+  std::wstring text;
+};
+
+class ResolvedUiDocument;
+
+core::Status ResolveDocument(const json::Value& core, const std::vector<ScreenSource>& sources,
+                             std::vector<Diagnostic>* diagnostics,
+                             std::unique_ptr<ResolvedUiDocument>* out);
+
+class ComponentNode {
+ public:
+  const std::wstring& type() const { return type_; }
+  const std::wstring& id() const { return id_; }
+
+  bool Has(std::wstring_view name) const;
+  std::wstring GetString(std::wstring_view name, std::wstring_view fallback = {}) const;
+  long long GetInt(std::wstring_view name, long long fallback = 0) const;
+  bool GetBool(std::wstring_view name, bool fallback = false) const;
+  const std::vector<ComponentNode>& children() const { return children_; }
+
+  // Written by the resolver during construction; consumers receive const
+  // references only, so immutability is enforced at the boundary.
+  std::wstring type_;
+  std::wstring id_;
+  std::vector<std::pair<std::wstring, json::Value>> properties_;
+  std::vector<ComponentNode> children_;
+};
+
+struct Route {
+  std::wstring id;
+  std::wstring tab_label;
+  bool show_in_tabs = true;
+  ComponentNode root;
+};
+
+class ResolvedUiDocument {
+ public:
+  const std::vector<Route>& routes() const { return routes_; }
+  const Route* FindRoute(std::wstring_view id) const;
+  const std::wstring& initial_route() const { return initial_route_; }
+  const std::vector<std::wstring>& themes() const { return theme_names_; }
+  // Looks up a token colour in a theme; false when absent.
+  bool Token(std::wstring_view theme, std::wstring_view name, Rgba* out) const;
+
+ private:
+  friend core::Status ResolveDocument(const json::Value&, const std::vector<ScreenSource>&,
+                                      std::vector<Diagnostic>*,
+                                      std::unique_ptr<ResolvedUiDocument>*);
+  std::vector<Route> routes_;
+  std::wstring initial_route_;
+  std::vector<std::wstring> theme_names_;
+  std::vector<std::vector<std::pair<std::wstring, Rgba>>> theme_tokens_;
+};
+
+// Resolves the core catalog plus the sources into an immutable document.
+// Sources are merged in order: a route defined by a later source replaces
+// the same route from an earlier one (embedded < override). Duplicate routes
+// WITHIN one source are a diagnostic, as are syntax errors (with the
+// parser's line/column) and every semantic error ValidateScreen reports.
+core::Status ResolveDocument(const json::Value& core, const std::vector<ScreenSource>& sources,
+                             std::vector<Diagnostic>* diagnostics,
+                             std::unique_ptr<ResolvedUiDocument>* out);
+
+}  // namespace ui::config

--- a/src/ui/config/ui_schema.cpp
+++ b/src/ui/config/ui_schema.cpp
@@ -35,6 +35,9 @@ bool IsInteger(const json::Value& value) {
   return number == static_cast<long long>(number);
 }
 
+bool KindMatches(const json::Value& value, std::wstring_view kind,
+                 const json::Value* definition);
+
 // Validates one "properties" map of a catalog entry: each definition is an
 // object with a known kind; enums carry a non-empty string values array.
 void ValidatePropertyDefinitions(const json::Value& properties, std::wstring_view owner,
@@ -77,6 +80,11 @@ void ValidatePropertyDefinitions(const json::Value& properties, std::wstring_vie
       Add(out, *required, L"catalog '" + std::wstring(owner) + L"." + name +
                               L"': 'required' must be a bool");
     }
+    const json::Value* default_value = definition.Find(L"default");
+    if (default_value != nullptr && !KindMatches(*default_value, kind_text, &definition)) {
+      Add(out, *default_value, L"catalog '" + std::wstring(owner) + L"." + name +
+                                   L"': 'default' does not match kind '" + kind_text + L"'");
+    }
   }
 }
 
@@ -94,7 +102,9 @@ bool KindMatches(const json::Value& value, std::wstring_view kind,
   if (kind == L"int") return IsInteger(value);
   if (kind == L"object") return value.is_object();
   if (kind == L"array") return value.is_array();
-  if (kind == L"binding") return value.is_string() || value.is_object();
+  if (kind == L"binding") {
+    return value.is_string() || value.is_object() || value.is_bool() || value.is_number();
+  }
   if (kind == L"enum") {
     if (!value.is_string()) return false;
     const json::Value* values = definition->ArrayField(L"values");

--- a/tests/ui/config/resolved_ui_document_test.cpp
+++ b/tests/ui/config/resolved_ui_document_test.cpp
@@ -1,0 +1,179 @@
+#include "ui/config/resolved_ui_document.h"
+
+#include <windows.h>
+
+#include <cstring>
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "core/json.h"
+#include "framework/test_case.h"
+
+namespace {
+
+json::Value LoadCore() {
+  wchar_t buffer[MAX_PATH]{};
+  GetModuleFileNameW(nullptr, buffer, MAX_PATH);
+  std::wstring path(buffer);
+  for (int i = 0; i < 4; ++i) {
+    const auto slash = path.find_last_of(L"\\/");
+    if (slash == std::wstring::npos) return {};
+    path.resize(slash);
+  }
+  path += L"\\assets\\ui\\core.json";
+  std::ifstream stream(path, std::ios::binary);
+  std::ostringstream text;
+  text << stream.rdbuf();
+  const std::string utf8 = text.str();
+  json::Value core;
+  DHEPZ_CHECK(json::ParseUtf8(std::string_view(utf8), &core).ok());
+  return core;
+}
+
+std::wstring W(const char* utf8) {
+  std::wstring wide;
+  for (const char* p = utf8; *p != '\0'; ++p) {
+    wide.push_back(static_cast<wchar_t>(static_cast<unsigned char>(*p)));
+  }
+  return wide;
+}
+
+const char* kEmbedded = R"({
+  "components": [
+    { "type": "window", "title": "dhepz", "initial_route": "home" },
+    { "type": "screen", "route_id": "home", "tab_label": "Home", "children": [
+      { "type": "button", "label": "Go" }
+    ] },
+    { "type": "screen", "route_id": "about", "children": [
+      { "type": "text", "text": "dhepz" }
+    ] }
+  ]
+})";
+
+int WalkCount(const ui::config::ComponentNode& node) {
+  int count = 1;
+  for (const ui::config::ComponentNode& child : node.children()) {
+    count += WalkCount(child);
+  }
+  return count;
+}
+
+}  // namespace
+
+DHEPZ_TEST(Resolver, ResolvesRoutesDefaultsAndTokens) {
+  const json::Value core = LoadCore();
+  std::vector<ui::config::Diagnostic> diagnostics;
+  std::unique_ptr<ui::config::ResolvedUiDocument> document;
+  DHEPZ_CHECK(ui::config::ResolveDocument(core, {{L"embedded", W(kEmbedded)}}, &diagnostics,
+                                          &document)
+                  .ok());
+  DHEPZ_CHECK(document != nullptr);
+
+  DHEPZ_CHECK_EQ(document->routes().size(), static_cast<std::size_t>(2));
+  DHEPZ_CHECK_EQ(document->initial_route(), std::wstring(L"home"));
+  const ui::config::Route* home = document->FindRoute(L"home");
+  DHEPZ_CHECK(home != nullptr);
+  DHEPZ_CHECK_EQ(home->tab_label, std::wstring(L"Home"));
+  DHEPZ_CHECK(home->show_in_tabs);
+
+  // Typed accessors: explicit value plus catalog defaults.
+  const ui::config::ComponentNode& button = home->root.children()[0];
+  DHEPZ_CHECK_EQ(button.type(), std::wstring(L"button"));
+  DHEPZ_CHECK_EQ(button.GetString(L"label"), std::wstring(L"Go"));
+  DHEPZ_CHECK(button.GetBool(L"tab_stop"));             // default from the catalog
+  DHEPZ_CHECK_EQ(button.GetString(L"variant"), std::wstring(L"default"));
+  DHEPZ_CHECK_EQ(button.GetInt(L"press_selects"), 0ll);
+
+  ui::config::Rgba accent{};
+  DHEPZ_CHECK(document->Token(L"dark", L"accent", &accent));
+  DHEPZ_CHECK_EQ(static_cast<int>(accent.r), 0x60);
+  DHEPZ_CHECK_EQ(static_cast<int>(accent.g), 0xA5);
+  DHEPZ_CHECK_EQ(static_cast<int>(accent.b), 0xFA);
+}
+
+DHEPZ_TEST(Resolver, OverrideReplacesEmbeddedRouteAndLosesToNothing) {
+  const json::Value core = LoadCore();
+  const char* override_text = R"({
+    "components": [
+      { "type": "screen", "route_id": "home", "tab_label": "Rumah", "children": [
+        { "type": "text", "text": "halo" }
+      ] }
+    ]
+  })";
+  std::vector<ui::config::Diagnostic> diagnostics;
+  std::unique_ptr<ui::config::ResolvedUiDocument> document;
+  DHEPZ_CHECK(ui::config::ResolveDocument(core,
+                                          {{L"embedded", W(kEmbedded)},
+                                           {L"override", W(override_text)}},
+                                          &diagnostics, &document)
+                  .ok());
+  // Two routes: home replaced in place, about kept from embedded.
+  DHEPZ_CHECK_EQ(document->routes().size(), static_cast<std::size_t>(2));
+  const ui::config::Route* home = document->FindRoute(L"home");
+  DHEPZ_CHECK(home != nullptr);
+  DHEPZ_CHECK_EQ(home->tab_label, std::wstring(L"Rumah"));
+  DHEPZ_CHECK_EQ(home->root.children()[0].type(), std::wstring(L"text"));
+}
+
+DHEPZ_TEST(Resolver, MalformedJsonReportsSourceAndLine) {
+  const json::Value core = LoadCore();
+  const char* broken = "{\n  \"components\": [\n}\n";
+  std::vector<ui::config::Diagnostic> diagnostics;
+  std::unique_ptr<ui::config::ResolvedUiDocument> document;
+  DHEPZ_CHECK(!ui::config::ResolveDocument(core, {{L"override", W(broken)}}, &diagnostics,
+                                           &document)
+                   .ok());
+  DHEPZ_CHECK_EQ(diagnostics.size(), static_cast<std::size_t>(1));
+  DHEPZ_CHECK_EQ(static_cast<unsigned long long>(diagnostics[0].line), 3ull);
+  DHEPZ_CHECK(diagnostics[0].message.find(L"override") != std::wstring::npos);
+}
+
+DHEPZ_TEST(Resolver, DuplicateRouteInOneSourceIsADiagnostic) {
+  const json::Value core = LoadCore();
+  const char* duplicate = R"({
+    "components": [
+      { "type": "screen", "route_id": "home" },
+      { "type": "screen", "route_id": "home" }
+    ]
+  })";
+  std::vector<ui::config::Diagnostic> diagnostics;
+  std::unique_ptr<ui::config::ResolvedUiDocument> document;
+  DHEPZ_CHECK(!ui::config::ResolveDocument(core, {{L"embedded", W(duplicate)}}, &diagnostics,
+                                           &document)
+                   .ok());
+  DHEPZ_CHECK_EQ(diagnostics.size(), static_cast<std::size_t>(1));
+  DHEPZ_CHECK(diagnostics[0].message.find(L"duplicate route") != std::wstring::npos);
+}
+
+DHEPZ_TEST(Resolver, MissingInitialRouteFails) {
+  const json::Value core = LoadCore();
+  const char* bad_route = R"({
+    "components": [
+      { "type": "window", "title": "x", "initial_route": "nowhere" },
+      { "type": "screen", "route_id": "home" }
+    ]
+  })";
+  std::vector<ui::config::Diagnostic> diagnostics;
+  std::unique_ptr<ui::config::ResolvedUiDocument> document;
+  DHEPZ_CHECK(!ui::config::ResolveDocument(core, {{L"embedded", W(bad_route)}}, &diagnostics,
+                                           &document)
+                   .ok());
+}
+
+DHEPZ_TEST(Resolver, ResolvedDocumentFeedsATreeWalkingConsumer) {
+  // Integration stand-in for the layout pipeline (#56 re-verifies the real
+  // handoff): the document must be consumable as an immutable tree.
+  const json::Value core = LoadCore();
+  std::vector<ui::config::Diagnostic> diagnostics;
+  std::unique_ptr<ui::config::ResolvedUiDocument> document;
+  DHEPZ_CHECK(ui::config::ResolveDocument(core, {{L"embedded", W(kEmbedded)}}, &diagnostics,
+                                          &document)
+                  .ok());
+  int total = 0;
+  for (const ui::config::Route& route : document->routes()) {
+    total += WalkCount(route.root);
+  }
+  DHEPZ_CHECK_EQ(static_cast<unsigned long long>(total), 4ull);  // 2 screens + 2 children
+}


### PR DESCRIPTION
Issue #53.

- src/ui/config/resolved_ui_document.{h,cpp}: ResolveDocument(core, sources, diags, out). Sources merge in order, later replaces earlier per route (embedded < override, documented in the header). Duplicate routes within one source diagnose at the route_id line. window.initial_route resolved and validated. Nodes carry catalog defaults under raw values; typed GetString/GetInt/GetBool; Token(theme, name) -> Rgba.
- Immutability structural: resolver is the only writer; consumers hold const pointers.
- core.json: property defaults ported from the old typed structs; ValidateCore now checks defaults against kinds; binding kind accepts literal constants (old BooleanValue model).
- Tests: routes/defaults/tokens; override replaces embedded in place; malformed JSON reports source + line 3; duplicate route diagnostic; missing initial_route fails; tree-walking consumer integration (real layout handoff re-verified in #56).
- Amendments recorded on the issue: layout-pipeline handoff stands in until #56; asset references join with the first component that needs images.