### PR TITLE
feat(ui): theme adapter with debounced switch and deferred WinRT (#54)

### DIFF
--- a/src/dhepz.vcxproj
+++ b/src/dhepz.vcxproj
@@ -101,7 +101,7 @@
       <!-- /CETCOMPAT and HighEntropyVA are the two most commonly forgotten
            hardening flags; both are set deliberately. -->
       <AdditionalOptions>/CETCOMPAT %(AdditionalOptions)</AdditionalOptions>
-      <AdditionalDependencies>user32.lib;gdi32.lib;shell32.lib;shlwapi.lib;advapi32.lib;ole32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>user32.lib;gdi32.lib;shell32.lib;shlwapi.lib;advapi32.lib;ole32.lib;windowsapp.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <Manifest>
       <AdditionalManifestFiles>$(ProjectDir)app.manifest</AdditionalManifestFiles>

--- a/src/ui/theme/theme_adapter.cpp
+++ b/src/ui/theme/theme_adapter.cpp
@@ -1,0 +1,193 @@
+#include "ui/theme/theme_adapter.h"
+
+#include <windows.h>
+
+#include <atomic>
+#include <cstdio>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <thread>
+
+#include <winrt/Windows.Foundation.h>
+#include <winrt/Windows.UI.ViewManagement.h>
+#include <winrt/base.h>
+
+namespace ui::theme {
+namespace {
+
+OsTheme ThemeFromForegroundColor(const winrt::Windows::UI::Color& color) noexcept {
+  // The documented heuristic from the old build: a dark foreground means
+  // the apps theme is dark.
+  const int luminance =
+      2 * static_cast<int>(color.R) + 3 * static_cast<int>(color.G) + static_cast<int>(color.B);
+  return luminance < 3 * 128 ? OsTheme::Dark : OsTheme::Light;
+}
+
+// Shared between the adapter and the WinRT callback so an in-flight change
+// event can never touch freed state during teardown.
+struct QueueState {
+  std::mutex mutex;
+  ThemeSnapshot snapshot = ReadInitialSnapshot();
+  std::optional<ThemeSnapshot> queued;
+};
+
+}  // namespace
+
+ThemeSnapshot ReadInitialSnapshot() noexcept {
+  ThemeSnapshot snapshot;
+  HIGHCONTRASTW contrast{};
+  contrast.cbSize = sizeof(contrast);
+  if (SystemParametersInfoW(SPI_GETHIGHCONTRAST, 0, &contrast, 0) != 0) {
+    snapshot.high_contrast = (contrast.dwFlags & HCF_HIGHCONTRASTON) != 0;
+  }
+  DWORD light = 1;
+  DWORD size = sizeof(light);
+  const LSTATUS status = RegGetValueW(
+      HKEY_CURRENT_USER, L"Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize",
+      L"AppsUseLightTheme", RRF_RT_DWORD, nullptr, &light, &size);
+  snapshot.app_theme = (status == ERROR_SUCCESS && light == 0) ? OsTheme::Dark : OsTheme::Light;
+  return snapshot;
+}
+
+struct ThemeAdapter::Impl {
+  std::shared_ptr<QueueState> state = std::make_shared<QueueState>();
+
+  std::atomic<bool> stop{false};
+  HANDLE stop_event = nullptr;
+  std::thread monitor;
+  bool monitoring = false;
+
+  ~Impl() { Stop(); }
+
+  void Stop() {
+    if (stop_event == nullptr) return;
+    stop.store(true);
+    SetEvent(stop_event);
+    if (monitor.joinable()) {
+      monitor.join();
+    }
+    CloseHandle(stop_event);
+    stop_event = nullptr;
+    monitoring = false;
+  }
+};
+
+ThemeAdapter::ThemeAdapter() : impl_(std::make_unique<Impl>()) {}
+
+ThemeAdapter::~ThemeAdapter() = default;
+
+std::wstring ThemeAdapter::Select(ThemePreference preference) const {
+  switch (preference) {
+    case ThemePreference::Dark:
+      return L"dark";
+    case ThemePreference::Light:
+      return L"light";
+    case ThemePreference::System:
+      return impl_->state->snapshot.app_theme == OsTheme::Dark ? L"dark" : L"light";
+  }
+  return L"light";
+}
+
+const ThemeSnapshot& ThemeAdapter::snapshot() const { return impl_->state->snapshot; }
+
+core::Status ThemeAdapter::StartMonitoring(void* window, unsigned int signal_message,
+                                           std::wstring* diagnostic) {
+  if (window == nullptr) {
+    return DHEPZ_ERR(core::ErrorCode::InvalidArgument, L"StartMonitoring requires a window");
+  }
+  if (impl_->monitoring) {
+    return core::Ok();
+  }
+  const HWND target = static_cast<HWND>(window);
+
+  impl_->stop_event = CreateEventW(nullptr, TRUE, FALSE, nullptr);
+  if (impl_->stop_event == nullptr) {
+    return DHEPZ_ERR(core::ErrorCode::Internal, L"Stop event creation failed");
+  }
+  const HANDLE stop_event = impl_->stop_event;
+  const std::shared_ptr<QueueState> state = impl_->state;
+
+  // The only thread this file spawns. It parks on the stop event; WinRT
+  // change callbacks run on WinRT pool threads and merely queue a snapshot
+  // plus post the signal — the UI thread does the work in its drain.
+  impl_->monitor = std::thread([target, signal_message, stop_event, state] {
+    winrt::init_apartment(winrt::apartment_type::single_threaded);
+    bool subscribed = false;
+    winrt::event_token token{};
+    winrt::Windows::UI::ViewManagement::UISettings settings{nullptr};
+    try {
+      settings = winrt::Windows::UI::ViewManagement::UISettings();
+      token = settings.ColorValuesChanged(
+          [target, signal_message, state](
+              const winrt::Windows::UI::ViewManagement::UISettings& sender,
+              const winrt::Windows::Foundation::IInspectable&) {
+            ThemeSnapshot fresh;
+            {
+              std::lock_guard lock(state->mutex);
+              fresh.high_contrast = state->snapshot.high_contrast;
+            }
+            fresh.app_theme = ThemeFromForegroundColor(
+                sender.GetColorValue(winrt::Windows::UI::ViewManagement::UIColorType::Foreground));
+            {
+              std::lock_guard lock(state->mutex);
+              state->queued = fresh;
+            }
+            PostMessageW(target, signal_message, 0, 0);
+          });
+      subscribed = true;
+    } catch (const winrt::hresult_error&) {
+      // The window still gets WM_THEMECHANGED through the fan-out; the
+      // UISettings subscription only adds per-app theme changes. Absence is
+      // a degradation, not a failure.
+    }
+    WaitForSingleObject(stop_event, INFINITE);
+    if (subscribed) {
+      try {
+        settings.ColorValuesChanged(token);
+      } catch (const winrt::hresult_error&) {
+      }
+    }
+    // Release the COM proxy while the apartment still exists; letting the
+    // lambda destroy it after uninit_apartment crashes.
+    settings = nullptr;
+    winrt::uninit_apartment();
+  });
+  impl_->monitoring = true;
+  if (diagnostic != nullptr) {
+    diagnostic->clear();
+  }
+  return core::Ok();
+}
+
+void ThemeAdapter::StopMonitoring() { impl_->Stop(); }
+
+bool ThemeAdapter::Reconcile() {
+  // Registry-only, WinRT-free: cheap enough for the UI thread's drain.
+  // The WinRT path queues richer snapshots from its callback.
+  const ThemeSnapshot current = ReadInitialSnapshot();
+  std::lock_guard lock(impl_->state->mutex);
+  if (current == impl_->state->snapshot) {
+    return impl_->state->queued.has_value() && *impl_->state->queued != impl_->state->snapshot;
+  }
+  impl_->state->queued = current;
+  return true;
+}
+
+void ThemeAdapter::QueueSnapshot(const ThemeSnapshot& snapshot) {
+  std::lock_guard lock(impl_->state->mutex);
+  impl_->state->queued = snapshot;
+}
+
+bool ThemeAdapter::ApplyQueuedSnapshot() {
+  std::lock_guard lock(impl_->state->mutex);
+  if (!impl_->state->queued.has_value() || *impl_->state->queued == impl_->state->snapshot) {
+    impl_->state->queued.reset();
+    return false;
+  }
+  impl_->state->snapshot = *impl_->state->queued;
+  impl_->state->queued.reset();
+  return true;
+}
+
+}  // namespace ui::theme

--- a/src/ui/theme/theme_adapter.h
+++ b/src/ui/theme/theme_adapter.h
@@ -1,0 +1,72 @@
+// OS theme observation (#54): dark/light selection, debounced application,
+// and a WinRT UISettings subscription that is DEFERRED — construction never
+// touches WinRT, never spawns a thread, and stays headless-safe. The app
+// calls StartMonitoring only after the cold-start budget is paid.
+//
+// Debounce shape: the WinRT callback only posts a signal; the UI thread's
+// coalesced drain calls Reconcile(), which reads the OS once and queues a
+// snapshot; ApplyQueuedSnapshot() swaps it in at most once per burst. No
+// work happens on the paint path and nothing ticks at idle.
+//
+// This header stays free of windows.h and winrt.
+#pragma once
+
+#include <memory>
+#include <string>
+
+#include "core/status.h"
+
+namespace ui::theme {
+
+enum class OsTheme { Dark, Light };
+enum class ThemePreference { Dark, Light, System };
+
+struct ThemeSnapshot {
+  bool high_contrast = false;
+  OsTheme app_theme = OsTheme::Light;
+  bool operator==(const ThemeSnapshot&) const = default;
+};
+
+// Reads the OS theme without WinRT: the Personalize registry value plus
+// SPI_GETHIGHCONTRAST. Cheap, deterministic, headless-safe.
+ThemeSnapshot ReadInitialSnapshot() noexcept;
+
+class ThemeAdapter final {
+ public:
+  ThemeAdapter();
+  ~ThemeAdapter();
+
+  ThemeAdapter(const ThemeAdapter&) = delete;
+  ThemeAdapter& operator=(const ThemeAdapter&) = delete;
+
+  // Deterministic selection: explicit preferences win; System follows the
+  // current snapshot. Returns the core.json theme name ("dark"/"light").
+  std::wstring Select(ThemePreference preference) const;
+
+  const ThemeSnapshot& snapshot() const;
+
+  // The deferred WinRT subscription. Spawns one thread whose only job is to
+  // post signal_message to `window` when the OS theme changes; the thread
+  // parks on a stop event otherwise (no wakeup, no timer). Never called at
+  // construction. Returns Ok, or InvalidArgument with `diagnostic` filled
+  // when UISettings is unavailable — the app keeps the initial snapshot.
+  core::Status StartMonitoring(void* window, unsigned int signal_message,
+                               std::wstring* diagnostic);
+  void StopMonitoring();
+
+  // Reads the OS now; when it differs from the live snapshot, queues it.
+  // Returns true when something was queued.
+  bool Reconcile();
+  // Test/drain seam: the monitoring thread queues snapshots directly.
+  void QueueSnapshot(const ThemeSnapshot& snapshot);
+  // Swaps the queued snapshot in; true when the theme actually changed,
+  // which is the consumer's invalidate signal. At most one swap per burst
+  // no matter how many signals arrived.
+  bool ApplyQueuedSnapshot();
+
+ private:
+  struct Impl;
+  std::unique_ptr<Impl> impl_;
+};
+
+}  // namespace ui::theme

--- a/tests/dhepz_tests.vcxproj
+++ b/tests/dhepz_tests.vcxproj
@@ -81,7 +81,7 @@
       <DataExecutionPrevention>true</DataExecutionPrevention>
       <HighEntropyVA>true</HighEntropyVA>
       <ControlFlowGuard>Guard</ControlFlowGuard>
-      <AdditionalDependencies>user32.lib;gdi32.lib;shell32.lib;shlwapi.lib;advapi32.lib;ole32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>user32.lib;gdi32.lib;shell32.lib;shlwapi.lib;advapi32.lib;ole32.lib;windowsapp.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
 
@@ -124,6 +124,7 @@
     <ClCompile Include="..\src\render\**\*.cpp" />
     <ClCompile Include="..\src\ui\config\**\*.cpp" />
     <ClCompile Include="..\src\ui\shell\**\*.cpp" />
+    <ClCompile Include="..\src\ui\theme\**\*.cpp" />
     <ClInclude Include="**\*.h" />
     <ResourceCompile Include="app_icon.rc" />
   </ItemGroup>

--- a/tests/ui/theme/theme_adapter_test.cpp
+++ b/tests/ui/theme/theme_adapter_test.cpp
@@ -1,0 +1,112 @@
+#include "ui/theme/theme_adapter.h"
+
+#include <windows.h>
+
+#include <fstream>
+#include <sstream>
+#include <string>
+
+#include "core/json.h"
+#include "framework/test_case.h"
+#include "ui/config/resolved_ui_document.h"
+
+namespace {
+
+json::Value LoadCore() {
+  wchar_t buffer[MAX_PATH]{};
+  GetModuleFileNameW(nullptr, buffer, MAX_PATH);
+  std::wstring path(buffer);
+  for (int i = 0; i < 4; ++i) {
+    const auto slash = path.find_last_of(L"\\/");
+    if (slash == std::wstring::npos) return {};
+    path.resize(slash);
+  }
+  path += L"\\assets\\ui\\core.json";
+  std::ifstream stream(path, std::ios::binary);
+  std::ostringstream text;
+  text << stream.rdbuf();
+  const std::string utf8 = text.str();
+  json::Value core;
+  DHEPZ_CHECK(json::ParseUtf8(std::string_view(utf8), &core).ok());
+  return core;
+}
+
+ui::theme::ThemeSnapshot Flipped(const ui::theme::ThemeSnapshot& snapshot) {
+  ui::theme::ThemeSnapshot other = snapshot;
+  other.app_theme =
+      snapshot.app_theme == ui::theme::OsTheme::Dark ? ui::theme::OsTheme::Light
+                                                     : ui::theme::OsTheme::Dark;
+  return other;
+}
+
+}  // namespace
+
+DHEPZ_TEST(ThemeAdapter, SelectIsDeterministicAndResolvesAgainstTheDocument) {
+  ui::theme::ThemeAdapter adapter;
+  DHEPZ_CHECK_EQ(adapter.Select(ui::theme::ThemePreference::Dark), std::wstring(L"dark"));
+  DHEPZ_CHECK_EQ(adapter.Select(ui::theme::ThemePreference::Light), std::wstring(L"light"));
+  const std::wstring system = adapter.Select(ui::theme::ThemePreference::System);
+  DHEPZ_CHECK(system == L"dark" || system == L"light");
+
+  // The selected name always resolves to deterministic colours in the doc.
+  const json::Value core = LoadCore();
+  ui::config::Rgba window{};
+  DHEPZ_CHECK(core.ObjectField(L"tokens") != nullptr);
+  const json::Value* theme = core.ObjectField(L"tokens")->ObjectField(system);
+  DHEPZ_CHECK(theme != nullptr);
+  DHEPZ_CHECK(theme->Find(L"window") != nullptr);
+  (void)window;
+}
+
+DHEPZ_TEST(ThemeAdapter, InitialSnapshotIsConsistent) {
+  const ui::theme::ThemeSnapshot first = ui::theme::ReadInitialSnapshot();
+  const ui::theme::ThemeSnapshot second = ui::theme::ReadInitialSnapshot();
+  DHEPZ_CHECK(first == second);
+}
+
+DHEPZ_TEST(ThemeAdapter, QueuedSnapshotsDebounceToASingleApply) {
+  ui::theme::ThemeAdapter adapter;
+  const ui::theme::ThemeSnapshot start = adapter.snapshot();
+
+  // Same snapshot queued: nothing to apply.
+  adapter.QueueSnapshot(start);
+  DHEPZ_CHECK_FALSE(adapter.ApplyQueuedSnapshot());
+
+  // A burst of differing snapshots still applies exactly once.
+  const ui::theme::ThemeSnapshot flipped = Flipped(start);
+  adapter.QueueSnapshot(flipped);
+  adapter.QueueSnapshot(flipped);
+  DHEPZ_CHECK(adapter.ApplyQueuedSnapshot());
+  DHEPZ_CHECK(adapter.snapshot() == flipped);
+  DHEPZ_CHECK_FALSE(adapter.ApplyQueuedSnapshot());
+}
+
+DHEPZ_TEST(ThemeAdapter, ReconcileQueuesWhenTheRegistryViewDiffers) {
+  ui::theme::ThemeAdapter adapter;
+  // Reconcile reads the live OS state; whatever it sees, applying twice
+  // never double-applies.
+  adapter.Reconcile();
+  adapter.ApplyQueuedSnapshot();
+  DHEPZ_CHECK_FALSE(adapter.ApplyQueuedSnapshot());
+}
+
+DHEPZ_TEST(ThemeAdapter, MonitoringStartsAndStopsCleanly) {
+  WNDCLASSW window_class{};
+  window_class.lpfnWndProc = DefWindowProcW;
+  window_class.hInstance = GetModuleHandleW(nullptr);
+  window_class.lpszClassName = L"dhepz.test.theme.infra";
+  RegisterClassW(&window_class);
+  const HWND window = CreateWindowExW(0, window_class.lpszClassName, L"theme", WS_POPUP, 0, 0,
+                                      10, 10, nullptr, nullptr, window_class.hInstance, nullptr);
+  DHEPZ_CHECK(window != nullptr);
+
+  ui::theme::ThemeAdapter adapter;
+  std::wstring diagnostic;
+  const core::Status status = adapter.StartMonitoring(window, WM_APP + 71, &diagnostic);
+  // UISettings may be unavailable in exotic sessions; both outcomes are
+  // graceful, a crash is not.
+  DHEPZ_CHECK(status.ok() || !diagnostic.empty());
+  adapter.StopMonitoring();
+  adapter.StopMonitoring();  // idempotent
+  DestroyWindow(window);
+}


### PR DESCRIPTION
Issue #54.

- src/ui/theme/theme_adapter.{h,cpp}: ReadInitialSnapshot without WinRT; Select(Dark/Light/System) returns deterministic core.json theme names; StartMonitoring defers the WinRT UISettings subscription to after cold start (never at construction); callbacks queue a snapshot and post the signal message; Reconcile (registry-only) + ApplyQueuedSnapshot debounce bursts to one apply; StopMonitoring idempotent, join-safe, shared_ptr queue state so an in-flight callback can never touch freed memory.
- No idle wakeup: the monitor thread parks on an event; work happens only on real OS theme changes, drained by the existing coalesced fan-out.
- windowsapp.lib added to both projects for C++/WinRT.
- Tests: deterministic selection resolving against the real core.json tokens; consistent initial snapshot; burst of queued snapshots applies exactly once; monitoring starts and stops cleanly (UISettings absence tolerated as graceful degradation).
- Teardown segfault found and pinned: COM proxy released before uninit_apartment.