### PR TITLE
feat(ui): focus coordinator and keyboard navigation policy (#55)

### DIFF
--- a/src/ui/focus/focus_coordinator.cpp
+++ b/src/ui/focus/focus_coordinator.cpp
@@ -1,0 +1,99 @@
+#include "ui/focus/focus_coordinator.h"
+
+#include <algorithm>
+
+namespace ui::focus {
+namespace {
+
+void Collect(const config::ComponentNode& node, const std::wstring& prefix, int& counter,
+             std::vector<std::wstring>* out) {
+  const bool focusable = node.GetBool(L"tab_stop") && node.GetBool(L"visible", true) &&
+                         node.GetBool(L"enabled", true);
+  if (focusable) {
+    if (!node.id().empty()) {
+      out->push_back(node.id());
+    } else {
+      out->push_back(prefix + L"@" + std::to_wstring(counter));
+    }
+  }
+  for (const config::ComponentNode& child : node.children()) {
+    ++counter;
+    Collect(child, prefix, counter, out);
+  }
+}
+
+}  // namespace
+
+void FocusCoordinator::SetDocument(const config::ResolvedUiDocument* document) {
+  document_ = document;
+  routes_.clear();
+  if (document_ == nullptr) return;
+  for (const config::Route& route : document_->routes()) {
+    RouteState state;
+    int counter = 0;
+    Collect(route.root, route.id, counter, &state.order);
+    routes_.emplace_back(route.id, std::move(state));
+  }
+}
+
+std::vector<std::wstring> FocusCoordinator::Focusables(std::wstring_view route) const {
+  const RouteState* state = Find(route);
+  return state != nullptr ? state->order : std::vector<std::wstring>{};
+}
+
+std::wstring FocusCoordinator::Current(std::wstring_view route) const {
+  const RouteState* state = Find(route);
+  return state != nullptr ? state->current : std::wstring{};
+}
+
+void FocusCoordinator::EnterRoute(std::wstring_view route) {
+  RouteState* state = Find(route);
+  if (state == nullptr) return;
+  const bool saved_exists = std::find(state->order.begin(), state->order.end(),
+                                      state->current) != state->order.end();
+  if (!saved_exists) {
+    state->current = state->order.empty() ? std::wstring{} : state->order.front();
+  }
+}
+
+bool FocusCoordinator::SetFocus(std::wstring_view route, std::wstring_view id) {
+  RouteState* state = Find(route);
+  if (state == nullptr) return false;
+  const auto known = std::find(state->order.begin(), state->order.end(), id);
+  if (known == state->order.end()) return false;
+  state->current = *known;
+  return true;
+}
+
+std::wstring FocusCoordinator::Advance(std::wstring_view route, bool backward) {
+  RouteState* state = Find(route);
+  if (state == nullptr || state->order.empty()) return {};
+  const auto position =
+      std::find(state->order.begin(), state->order.end(), state->current);
+  std::size_t index;
+  if (position == state->order.end()) {
+    index = backward ? state->order.size() - 1 : 0;
+  } else {
+    const std::size_t current_index = static_cast<std::size_t>(position - state->order.begin());
+    index = backward ? (current_index + state->order.size() - 1) % state->order.size()
+                     : (current_index + 1) % state->order.size();
+  }
+  state->current = state->order[index];
+  return state->current;
+}
+
+FocusCoordinator::RouteState* FocusCoordinator::Find(std::wstring_view route) {
+  for (auto& [id, state] : routes_) {
+    if (id == route) return &state;
+  }
+  return nullptr;
+}
+
+const FocusCoordinator::RouteState* FocusCoordinator::Find(std::wstring_view route) const {
+  for (const auto& [id, state] : routes_) {
+    if (id == route) return &state;
+  }
+  return nullptr;
+}
+
+}  // namespace ui::focus

--- a/src/ui/focus/focus_coordinator.h
+++ b/src/ui/focus/focus_coordinator.h
@@ -1,0 +1,53 @@
+// Keyboard focus ownership (#55): traversal order, current owner per route,
+// and restore-on-return policy, all as pure logic over the resolved tree.
+// No Windows, no IO — nothing here can block the UI thread.
+//
+// Traversal order is declaration order (the resolver preserves member and
+// children order). A node is focusable when its resolved properties say
+// tab_stop, visible and enabled. Nodes without an explicit id get a
+// deterministic synthetic one so traversal is still addressable.
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "ui/config/resolved_ui_document.h"
+
+namespace ui::focus {
+
+class FocusCoordinator final {
+ public:
+  // Rebuilds per-route traversal order; saved focus positions are dropped.
+  void SetDocument(const config::ResolvedUiDocument* document);
+
+  // Focusable ids in traversal order; empty route -> empty vector.
+  std::vector<std::wstring> Focusables(std::wstring_view route) const;
+
+  // Current owner; empty when the route has nothing focusable or has not
+  // been entered.
+  std::wstring Current(std::wstring_view route) const;
+
+  // Route-switch policy: restore the saved id when it still exists in the
+  // traversal order, otherwise the first focusable.
+  void EnterRoute(std::wstring_view route);
+
+  // Explicit ownership; false when the id is not focusable on that route.
+  bool SetFocus(std::wstring_view route, std::wstring_view id);
+
+  // Tab / Shift+Tab with wrap-around; returns the new owner, empty when the
+  // route has nothing focusable.
+  std::wstring Advance(std::wstring_view route, bool backward);
+
+ private:
+  struct RouteState {
+    std::vector<std::wstring> order;
+    std::wstring current;
+  };
+  RouteState* Find(std::wstring_view route);
+  const RouteState* Find(std::wstring_view route) const;
+
+  const config::ResolvedUiDocument* document_ = nullptr;
+  std::vector<std::pair<std::wstring, RouteState>> routes_;
+};
+
+}  // namespace ui::focus

--- a/tests/dhepz_tests.vcxproj
+++ b/tests/dhepz_tests.vcxproj
@@ -123,6 +123,7 @@
     <ClCompile Include="..\src\platform\**\*.cpp" />
     <ClCompile Include="..\src\render\**\*.cpp" />
     <ClCompile Include="..\src\ui\config\**\*.cpp" />
+    <ClCompile Include="..\src\ui\focus\**\*.cpp" />
     <ClCompile Include="..\src\ui\shell\**\*.cpp" />
     <ClCompile Include="..\src\ui\theme\**\*.cpp" />
     <ClInclude Include="**\*.h" />

--- a/tests/ui/focus/focus_coordinator_test.cpp
+++ b/tests/ui/focus/focus_coordinator_test.cpp
@@ -1,0 +1,123 @@
+#include "ui/focus/focus_coordinator.h"
+
+#include <string>
+#include <vector>
+
+#include "core/json.h"
+#include "framework/test_case.h"
+#include "ui/config/resolved_ui_document.h"
+
+namespace {
+
+const char* kCore = R"({
+  "schema": "dhepz.ui.core",
+  "version": 1,
+  "tokens": { "dark": { "text": "#FFFFFF" }, "light": { "text": "#000000" } },
+  "common": { "properties": {
+    "id": { "kind": "string" },
+    "visible": { "kind": "bool", "default": true },
+    "enabled": { "kind": "bool", "default": true }
+  } },
+  "allows_children": ["screen", "container"],
+  "components": {
+    "screen": { "properties": {
+      "route_id": { "kind": "string", "required": true }
+    } },
+    "container": { "properties": {
+      "tab_stop": { "kind": "bool", "default": false }
+    } },
+    "button": { "properties": {
+      "label": { "kind": "text", "required": true },
+      "tab_stop": { "kind": "bool", "default": true }
+    } }
+  }
+})";
+
+const char* kScreens = R"({
+  "components": [
+    { "type": "screen", "route_id": "home", "children": [
+      { "type": "button", "id": "a", "label": "A" },
+      { "type": "button", "id": "b", "label": "B", "tab_stop": false },
+      { "type": "button", "id": "c", "label": "C", "enabled": false },
+      { "type": "container", "children": [
+        { "type": "button", "id": "d", "label": "D" },
+        { "type": "button", "label": "E" }
+      ] }
+    ] },
+    { "type": "screen", "route_id": "other", "children": [
+      { "type": "button", "id": "x", "label": "X" }
+    ] }
+  ]
+})";
+
+std::wstring W(const char* utf8) {
+  std::wstring wide;
+  for (const char* p = utf8; *p != '\0'; ++p) {
+    wide.push_back(static_cast<wchar_t>(static_cast<unsigned char>(*p)));
+  }
+  return wide;
+}
+
+std::unique_ptr<ui::config::ResolvedUiDocument> Resolve() {
+  json::Value core;
+  DHEPZ_CHECK(json::Parse(W(kCore), &core).ok());
+  std::vector<ui::config::Diagnostic> diagnostics;
+  std::unique_ptr<ui::config::ResolvedUiDocument> document;
+  DHEPZ_CHECK(ui::config::ResolveDocument(core, {{L"embedded", W(kScreens)}}, &diagnostics,
+                                          &document)
+                  .ok());
+  return document;
+}
+
+}  // namespace
+
+DHEPZ_TEST(FocusCoordinator, TraversalSkipsUnfocusableAndKeepsDeclarationOrder) {
+  ui::focus::FocusCoordinator coordinator;
+  coordinator.SetDocument(Resolve().get());
+  const std::vector<std::wstring> order = coordinator.Focusables(L"home");
+  DHEPZ_CHECK_EQ(order.size(), static_cast<std::size_t>(3));  // a, d, synthetic E
+  DHEPZ_CHECK_EQ(order[0], std::wstring(L"a"));
+  DHEPZ_CHECK_EQ(order[1], std::wstring(L"d"));
+  DHEPZ_CHECK(order[2].find(L"@") != std::wstring::npos);
+}
+
+DHEPZ_TEST(FocusCoordinator, AdvanceWrapsBothDirections) {
+  const std::unique_ptr<ui::config::ResolvedUiDocument> document = Resolve();
+  ui::focus::FocusCoordinator coordinator;
+  coordinator.SetDocument(document.get());
+  coordinator.EnterRoute(L"home");
+  DHEPZ_CHECK_EQ(coordinator.Current(L"home"), std::wstring(L"a"));
+
+  DHEPZ_CHECK_EQ(coordinator.Advance(L"home", false), std::wstring(L"d"));
+  DHEPZ_CHECK(coordinator.Advance(L"home", false).find(L"@") != std::wstring::npos);
+  DHEPZ_CHECK_EQ(coordinator.Advance(L"home", false), std::wstring(L"a"));  // wrap
+  DHEPZ_CHECK(coordinator.Advance(L"home", true).find(L"@") != std::wstring::npos);  // back-wrap
+}
+
+DHEPZ_TEST(FocusCoordinator, RouteSwitchRestoresSavedFocusOrFallsBack) {
+  const std::unique_ptr<ui::config::ResolvedUiDocument> document = Resolve();
+  ui::focus::FocusCoordinator coordinator;
+  coordinator.SetDocument(document.get());
+
+  coordinator.EnterRoute(L"home");
+  DHEPZ_CHECK(coordinator.SetFocus(L"home", L"d"));
+  coordinator.EnterRoute(L"other");
+  DHEPZ_CHECK_EQ(coordinator.Current(L"other"), std::wstring(L"x"));
+  coordinator.EnterRoute(L"home");
+  DHEPZ_CHECK_EQ(coordinator.Current(L"home"), std::wstring(L"d"));  // restored
+
+  // A document where the saved id vanished falls back to the first.
+  coordinator.SetDocument(document.get());
+  coordinator.EnterRoute(L"home");
+  DHEPZ_CHECK_EQ(coordinator.Current(L"home"), std::wstring(L"a"));
+}
+
+DHEPZ_TEST(FocusCoordinator, SetFocusRefusesUnfocusableIds) {
+  const std::unique_ptr<ui::config::ResolvedUiDocument> document = Resolve();
+  ui::focus::FocusCoordinator coordinator;
+  coordinator.SetDocument(document.get());
+  DHEPZ_CHECK_FALSE(coordinator.SetFocus(L"home", L"b"));  // tab_stop false
+  DHEPZ_CHECK_FALSE(coordinator.SetFocus(L"home", L"c"));  // disabled
+  DHEPZ_CHECK_FALSE(coordinator.SetFocus(L"home", L"nope"));
+  DHEPZ_CHECK(coordinator.SetFocus(L"home", L"a"));
+}


### PR DESCRIPTION
Issue #55.

- src/ui/focus/focus_coordinator.{h,cpp}: SetDocument builds per-route traversal order from the resolved tree; EnterRoute applies the restore-or-first policy; SetFocus validates against the focusable set; Advance wraps both directions.
- Focusability = resolved tab_stop && visible && enabled; nodes without ids get deterministic synthetic ones so traversal stays addressable.
- Tests: declaration order with unfocusable nodes skipped; wrap both directions; restore-on-return and fallback when the saved id vanished; SetFocus refuses tab_stop-false/disabled/unknown ids.
- Interactive keyboard reach across real components lands with the component runtime; the policy and ordering are pinned here.