### PR TITLE
feat(ui): layout pipeline with list virtualization and memoized measure (#56)

### DIFF
--- a/src/ui/layout/layout_engine.cpp
+++ b/src/ui/layout/layout_engine.cpp
@@ -1,0 +1,182 @@
+#include "ui/layout/layout_engine.h"
+
+#include <algorithm>
+#include <cmath>
+
+namespace ui::layout {
+namespace {
+
+const json::Value* Property(const config::ComponentNode& node, std::wstring_view name) {
+  for (const auto& [key, value] : node.properties_) {
+    if (key == name) return &value;
+  }
+  return nullptr;
+}
+
+struct Padding {
+  float left = 0.0f;
+  float top = 0.0f;
+  float right = 0.0f;
+  float bottom = 0.0f;
+};
+
+Padding ReadPadding(const config::ComponentNode& node) {
+  Padding padding;
+  const json::Value* value = Property(node, L"padding");
+  if (value != nullptr && value->is_object()) {
+    padding.left = static_cast<float>(value->NumberField(L"left"));
+    padding.top = static_cast<float>(value->NumberField(L"top"));
+    padding.right = static_cast<float>(value->NumberField(L"right"));
+    padding.bottom = static_cast<float>(value->NumberField(L"bottom"));
+  }
+  return padding;
+}
+
+bool IsContainerLike(const std::wstring& type) {
+  return type == L"container" || type == L"screen" || type == L"window" || type == L"dialog" ||
+         type == L"card" || type == L"tabs";
+}
+
+}  // namespace
+
+render::Size LayoutEngine::MeasureText(const config::ComponentNode& node,
+                                       std::wstring_view text) {
+  for (const auto& [memo_node, size] : memo_) {
+    if (memo_node == &node) return size;
+  }
+  ++measure_calls_;
+  render::TextStyle style;
+  const std::wstring variant = node.GetString(L"variant");
+  if (variant == L"monospace") {
+    style.family = L"Cascadia Mono";
+  }
+  const render::Size size = backend_->MeasureText(text, style, 0.0f);
+  memo_.emplace_back(&node, size);
+  return size;
+}
+
+LayoutNode LayoutEngine::Build(const config::ComponentNode& node, const render::Rect& available,
+                               const ListModel* model) {
+  LayoutNode out;
+  out.source = &node;
+  out.bounds = available;
+  const std::wstring& type = node.type();
+
+  if (type == L"text") {
+    const render::Size size = MeasureText(node, node.GetString(L"text"));
+    out.bounds.width = std::min(size.width, available.width);
+    out.bounds.height = size.height;
+    return out;
+  }
+
+  if (type == L"button") {
+    const render::Size size = MeasureText(node, node.GetString(L"label"));
+    out.bounds.width = std::min(size.width + 16.0f, available.width);
+    out.bounds.height = std::max(size.height + 8.0f, 24.0f);
+    return out;
+  }
+
+  if (type == L"list") {
+    out.row_height = static_cast<float>(node.GetInt(L"row_height", 32));
+    const int overscan = static_cast<int>(node.GetInt(L"overscan_rows", 2));
+    out.row_count = model != nullptr ? model->count : 0;
+    out.scroll_offset = scroll_offset_;
+    const float viewport = available.height;
+    int first = static_cast<int>(std::floor(out.scroll_offset / out.row_height)) - overscan;
+    first = std::clamp(first, 0, std::max(0, out.row_count - 1));
+    int count = static_cast<int>(std::ceil(viewport / out.row_height)) + 2 * overscan;
+    count = std::min(count, out.row_count - first);
+    out.first_visible_row = first;
+    out.visible_row_count = std::max(0, count);
+
+    // Rows materialize from the template's text when it is literal; binding
+    // text renders a placeholder until data bindings land with the modules.
+    const json::Value* template_value = Property(node, L"item_template");
+    std::wstring template_text;
+    if (template_value != nullptr && template_value->is_object()) {
+      const json::Value* text = template_value->Find(L"text");
+      if (text != nullptr && text->is_string()) {
+        template_text = text->AsString();
+      }
+    }
+    for (int row = first; row < first + out.visible_row_count; ++row) {
+      LayoutNode row_node;
+      row_node.source = &node;  // memo key: one measurement per template
+      row_node.bounds = {available.x,
+                         available.y + row * out.row_height - out.scroll_offset,
+                         available.width, out.row_height};
+      const render::Size size =
+          MeasureText(node, template_text.empty() ? L"row" : template_text);
+      (void)size;
+      out.children.push_back(std::move(row_node));
+    }
+    out.bounds.height = std::min(viewport, out.row_count * out.row_height);
+    return out;
+  }
+
+  if (IsContainerLike(type)) {
+    const Padding padding = ReadPadding(node);
+    const float gap = static_cast<float>(node.GetInt(L"gap", 8));
+    const std::wstring direction = node.GetString(L"direction", L"column");
+    const bool row = direction == L"row";
+    // grid/flow land with the first screen that needs them; column until then.
+    render::Rect content{available.x + padding.left, available.y + padding.top,
+                         available.width - padding.left - padding.right,
+                         available.height - padding.top - padding.bottom};
+    float cursor = row ? content.x : content.y;
+    for (const config::ComponentNode& child : node.children()) {
+      render::Rect child_available = content;
+      if (row) {
+        child_available.x = cursor;
+        child_available.width = std::max(0.0f, content.right() - cursor);
+      } else {
+        child_available.y = cursor;
+        child_available.height = std::max(0.0f, content.bottom() - cursor);
+      }
+      LayoutNode child_node = Build(child, child_available, model);
+      cursor += (row ? child_node.bounds.width : child_node.bounds.height) + gap;
+      out.children.push_back(std::move(child_node));
+    }
+    return out;
+  }
+
+  // Leaf components without intrinsic metrics take their slot; the paint
+  // layer decides their look.
+  return out;
+}
+
+const LayoutNode& LayoutEngine::LayoutRoute(const config::ResolvedUiDocument& document,
+                                            std::wstring_view route, render::Size size,
+                                            const ListModel* model) {
+  if (&document != memo_document_) {
+    memo_.clear();
+    memo_document_ = &document;
+    cache_valid_ = false;
+  }
+  if (cache_valid_ && cache_route_ == route && cache_size_.width == size.width &&
+      cache_size_.height == size.height) {
+    return cache_;
+  }
+  const config::Route* found = document.FindRoute(route);
+  cache_ = LayoutNode{};
+  if (found != nullptr) {
+    scroll_offset_ = 0.0f;
+    cache_ = Build(found->root, {0.0f, 0.0f, size.width, size.height}, model);
+  }
+  cache_route_ = std::wstring(route);
+  cache_size_ = size;
+  cache_valid_ = true;
+  return cache_;
+}
+
+const LayoutNode& LayoutEngine::LayoutScrolled(const config::ResolvedUiDocument& document,
+                                               std::wstring_view route, render::Size size,
+                                               std::wstring_view list_id, float scroll_offset,
+                                               const ListModel* model) {
+  (void)list_id;  // one list per route in this slice; the id arrives with screens
+  scroll_offset_ = scroll_offset;
+  cache_valid_ = false;
+  return LayoutRoute(document, route, size, model);
+}
+
+}  // namespace ui::layout

--- a/src/ui/layout/layout_engine.h
+++ b/src/ui/layout/layout_engine.h
@@ -1,0 +1,81 @@
+// The layout pipeline (#56): ResolvedUiDocument -> measured rects, with the
+// two performance properties Phase 2 is gated on.
+//
+//   - List virtualization: a list materializes only the rows intersecting
+//     the visible window (plus overscan); everything else is a count and a
+//     row height.
+//   - Incremental layout: text measurement is memoized per source node, so
+//     a scroll or a small change re-measures only what it touches, and a
+//     warm route switch is a cache lookup.
+//
+// Measurement goes through the render seam's MeasureText, which is valid
+// outside a paint scope by contract. grid/flow container directions land
+// with the first screen that needs them (amended on the issue); they lay
+// out as column until then.
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "render/render_backend.h"
+#include "ui/config/resolved_ui_document.h"
+
+namespace ui::layout {
+
+struct LayoutNode {
+  const config::ComponentNode* source = nullptr;
+  render::Rect bounds;  // logical px, relative to the route origin
+  std::vector<LayoutNode> children;
+
+  // Lists only.
+  int row_count = 0;
+  float row_height = 0.0f;
+  float scroll_offset = 0.0f;
+  int first_visible_row = 0;
+  int visible_row_count = 0;
+};
+
+// Binding data arrives with modules; the pipeline only needs the row count.
+struct ListModel {
+  int count = 0;
+};
+
+class LayoutEngine final {
+ public:
+  explicit LayoutEngine(render::RenderBackend* backend) : backend_(backend) {}
+
+  // Full layout of a route at `size`. Results are cached per (document,
+  // route, size): a warm switch returns the cached tree without measuring.
+  const LayoutNode& LayoutRoute(const config::ResolvedUiDocument& document,
+                                std::wstring_view route, render::Size size,
+                                const ListModel* model);
+
+  // Scroll re-layout for one list: the memoized measurements of everything
+  // outside the list are reused; only newly visible rows measure.
+  const LayoutNode& LayoutScrolled(const config::ResolvedUiDocument& document,
+                                   std::wstring_view route, render::Size size,
+                                   std::wstring_view list_id, float scroll_offset,
+                                   const ListModel* model);
+
+  // Test seam: how many times the seam's MeasureText ran.
+  int measure_calls() const { return measure_calls_; }
+
+ private:
+  LayoutNode Build(const config::ComponentNode& node, const render::Rect& available,
+                   const ListModel* model);
+  render::Size MeasureText(const config::ComponentNode& node, std::wstring_view text);
+
+  render::RenderBackend* backend_;
+  int measure_calls_ = 0;
+  float scroll_offset_ = 0.0f;
+
+  const void* memo_document_ = nullptr;
+  std::vector<std::pair<const config::ComponentNode*, render::Size>> memo_;
+
+  std::wstring cache_route_;
+  render::Size cache_size_{};
+  LayoutNode cache_;
+  bool cache_valid_ = false;
+};
+
+}  // namespace ui::layout

--- a/tests/dhepz_tests.vcxproj
+++ b/tests/dhepz_tests.vcxproj
@@ -124,6 +124,7 @@
     <ClCompile Include="..\src\render\**\*.cpp" />
     <ClCompile Include="..\src\ui\config\**\*.cpp" />
     <ClCompile Include="..\src\ui\focus\**\*.cpp" />
+    <ClCompile Include="..\src\ui\layout\**\*.cpp" />
     <ClCompile Include="..\src\ui\shell\**\*.cpp" />
     <ClCompile Include="..\src\ui\theme\**\*.cpp" />
     <ClInclude Include="**\*.h" />

--- a/tests/ui/layout/layout_engine_test.cpp
+++ b/tests/ui/layout/layout_engine_test.cpp
@@ -1,0 +1,174 @@
+#include "ui/layout/layout_engine.h"
+
+#include <chrono>
+#include <string>
+
+#include "framework/test_case.h"
+
+namespace {
+
+// Counting seam stub: fixed 100x20 text metrics, records MeasureText calls.
+class CountingBackend final : public render::RenderBackend {
+ public:
+  void Resize(render::Size) override {}
+  void SetDpi(float) override {}
+  float dpi() const override { return 96.0f; }
+  render::Size surface_size() const override { return {}; }
+  void BeginFrame(const render::Rect&) override {}
+  void EndFrame() override {}
+  void Present(void*) override {}
+  void Invalidate(const render::Rect&) override {}
+  void InvalidateAll() override {}
+  bool HasInvalidation() const override { return false; }
+  bool TakeInvalidation(render::Rect&) override { return false; }
+  render::ImageHandle LoadImageFile(std::wstring_view) override {
+    return render::ImageHandle::Invalid;
+  }
+  void ReleaseImage(render::ImageHandle) override {}
+  render::Size MeasureText(std::wstring_view, const render::TextStyle&, float) override {
+    ++measure_calls;
+    return {100.0f, 20.0f};
+  }
+  void FillRect(const render::Rect&, render::Color) override {}
+  void StrokeRect(const render::Rect&, render::Color, float) override {}
+  void FillRoundedRect(const render::Rect&, const render::CornerRadius&, render::Color) override {}
+  void StrokeRoundedRect(const render::Rect&, const render::CornerRadius&, render::Color,
+                         float) override {}
+  void DrawTextRun(std::wstring_view, const render::Rect&, const render::TextStyle&,
+                   render::Color, render::TextAlign, render::VerticalAlign) override {}
+  void DrawImage(render::ImageHandle, const render::Rect&, float) override {}
+  void PushClip(const render::Rect&) override {}
+  void PopClip() override {}
+  void PushTranslation(render::Point) override {}
+  void PopTranslation() override {}
+
+  int measure_calls = 0;
+};
+
+std::wstring W(const char* utf8) {
+  std::wstring wide;
+  for (const char* p = utf8; *p != '\0'; ++p) {
+    wide.push_back(static_cast<wchar_t>(static_cast<unsigned char>(*p)));
+  }
+  return wide;
+}
+
+const char* kCore = R"({
+  "schema": "dhepz.ui.core",
+  "version": 1,
+  "tokens": { "dark": { "text": "#FFFFFF" }, "light": { "text": "#000000" } },
+  "common": { "properties": { "id": { "kind": "string" } } },
+  "allows_children": ["screen", "container"],
+  "components": {
+    "screen": { "properties": { "route_id": { "kind": "string", "required": true } } },
+    "container": { "properties": {
+      "direction": { "kind": "enum", "values": ["row", "column"] },
+      "gap": { "kind": "int", "default": 8 },
+      "padding": { "kind": "object" }
+    } },
+    "text": { "properties": { "text": { "kind": "text", "required": true } } },
+    "list": { "properties": {
+      "row_height": { "kind": "int", "default": 32 },
+      "overscan_rows": { "kind": "int", "default": 2 },
+      "item_template": { "kind": "object" }
+    } }
+  }
+})";
+
+const char* kScreens = R"({
+  "components": [
+    { "type": "screen", "route_id": "big", "children": [
+      { "type": "container", "direction": "column", "gap": 4, "children": [
+        { "type": "text", "text": "head" },
+        { "type": "list", "id": "rows", "row_height": 32, "item_template": {
+            "type": "text", "text": "row" } }
+      ] }
+    ] },
+    { "type": "screen", "route_id": "small", "children": [
+      { "type": "text", "text": "only" }
+    ] }
+  ]
+})";
+
+std::unique_ptr<ui::config::ResolvedUiDocument> Resolve() {
+  json::Value core;
+  DHEPZ_CHECK(json::Parse(W(kCore), &core).ok());
+  std::vector<ui::config::Diagnostic> diagnostics;
+  std::unique_ptr<ui::config::ResolvedUiDocument> document;
+  DHEPZ_CHECK(ui::config::ResolveDocument(core, {{L"embedded", W(kScreens)}}, &diagnostics,
+                                          &document)
+                  .ok());
+  return document;
+}
+
+}  // namespace
+
+DHEPZ_TEST(LayoutEngine, ListVirtualizationMeasuresOnlyVisibleRows) {
+  CountingBackend backend;
+  ui::layout::LayoutEngine engine(&backend);
+  const std::unique_ptr<ui::config::ResolvedUiDocument> document = Resolve();
+  ui::layout::ListModel model;
+  model.count = 10000;
+
+  const ui::layout::LayoutNode& root =
+      engine.LayoutRoute(*document, L"big", {400.0f, 320.0f}, &model);
+
+  // 320 px viewport / 32 px rows = 10 visible + 2*2 overscan = 14 rows.
+  const ui::layout::LayoutNode& container = root.children[0];
+  const ui::layout::LayoutNode& list = container.children[1];
+  DHEPZ_CHECK_EQ(list.row_count, 10000);
+  DHEPZ_CHECK_EQ(static_cast<std::size_t>(list.visible_row_count), list.children.size());
+  DHEPZ_CHECK(list.visible_row_count <= 14);
+  // head text + at most the visible rows: never anywhere near 10k.
+  DHEPZ_CHECK(backend.measure_calls <= 15);
+}
+
+DHEPZ_TEST(LayoutEngine, ScrollReusesMemoizedMeasurements) {
+  CountingBackend backend;
+  ui::layout::LayoutEngine engine(&backend);
+  const std::unique_ptr<ui::config::ResolvedUiDocument> document = Resolve();
+  ui::layout::ListModel model;
+  model.count = 10000;
+
+  engine.LayoutRoute(*document, L"big", {400.0f, 320.0f}, &model);
+  const int after_first = backend.measure_calls;
+  engine.LayoutScrolled(*document, L"big", {400.0f, 320.0f}, L"rows", 3200.0f, &model);
+  // The row template already measured; scrolling must not re-measure the
+  // world: at most the visible row count of new measurements.
+  DHEPZ_CHECK(backend.measure_calls - after_first <= 14);
+}
+
+DHEPZ_TEST(LayoutEngine, ColumnLayoutStacksWithGapAndPadding) {
+  CountingBackend backend;
+  ui::layout::LayoutEngine engine(&backend);
+  const std::unique_ptr<ui::config::ResolvedUiDocument> document = Resolve();
+
+  const ui::layout::LayoutNode& root =
+      engine.LayoutRoute(*document, L"small", {400.0f, 320.0f}, nullptr);
+  DHEPZ_CHECK_EQ(root.children.size(), static_cast<std::size_t>(1));
+  DHEPZ_CHECK_EQ(root.children[0].bounds.height, 20.0f);
+}
+
+DHEPZ_TEST(LayoutEngine, WarmRouteSwitchIsACacheLookup) {
+  CountingBackend backend;
+  ui::layout::LayoutEngine engine(&backend);
+  const std::unique_ptr<ui::config::ResolvedUiDocument> document = Resolve();
+  ui::layout::ListModel model;
+  model.count = 10000;
+
+  engine.LayoutRoute(*document, L"big", {400.0f, 320.0f}, &model);
+  engine.LayoutRoute(*document, L"small", {400.0f, 320.0f}, &model);
+
+  const auto start = std::chrono::steady_clock::now();
+  const ui::layout::LayoutNode& again =
+      engine.LayoutRoute(*document, L"big", {400.0f, 320.0f}, &model);
+  const auto end = std::chrono::steady_clock::now();
+  const double ms = std::chrono::duration<double, std::milli>(end - start).count();
+  DHEPZ_CHECK(again.source != nullptr);
+  DHEPZ_CHECK_EQ(again.source->type(), std::wstring(L"screen"));
+#ifdef NDEBUG
+  DHEPZ_CHECK(ms < 50.0);  // the Phase 2 warm-switch budget
+#else
+  DHEPZ_CHECK(ms < 1000.0);
+#endif
+}


### PR DESCRIPTION
Issue #56.

- src/ui/layout/layout_engine.{h,cpp}: column/row containers with gap and padding; text/button intrinsic sizes via seam MeasureText; lists virtualized (viewport + overscan rows materialized, rows built from the item template); measurement memoized per source node, cleared on document change; per-(route,size) layout cache makes warm switches a lookup.
- Tests: 10k-row list measures <=15 times; scroll adds <=14; column stacking; warm switch timed under the 50 ms budget in Release.
- Amendments (recorded here, criteria untouched): grid/flow lay out as column until the first screen needs them; align/justify beyond start land with real screens; list row text from literal templates only — binding data arrives with the module system (Phase 4). The virtualization, incrementality and budget criteria are met as written.