### PR TITLE
feat(ui): backdrop layers with z-order and transparent-fill rule (#62)

### DIFF
--- a/assets/ui/core.json
+++ b/assets/ui/core.json
@@ -132,6 +132,9 @@
         },
         "select_rules": {
           "kind": "array"
+        },
+        "backdrop": {
+          "kind": "string"
         }
       }
     },

--- a/src/ui/config/resolved_ui_document.cpp
+++ b/src/ui/config/resolved_ui_document.cpp
@@ -256,8 +256,30 @@ core::Status ResolveDocument(const json::Value& core, const std::vector<ScreenSo
     route.id = route_order[i];
     route.tab_label = route_screen[i]->StringField(L"tab_label", route_order[i]);
     route.show_in_tabs = route_screen[i]->BoolField(L"show_in_tabs", true);
+    const json::Value* backdrop = route_screen[i]->Find(L"backdrop");
+    if (backdrop != nullptr && backdrop->is_string() && !backdrop->AsString().empty()) {
+      const std::wstring& value = backdrop->AsString();
+      if (value.rfind(L"screen:", 0) == 0) {
+        route.backdrop_kind = Route::BackdropKind::Screen;
+        route.backdrop_value = value.substr(7);
+      } else {
+        const json::Value* dark = tokens != nullptr ? tokens->Find(L"dark") : nullptr;
+        const bool is_token =
+            dark != nullptr && dark->is_object() && dark->Find(value) != nullptr;
+        route.backdrop_kind = is_token ? Route::BackdropKind::Color : Route::BackdropKind::Image;
+        route.backdrop_value = value;
+      }
+    }
     route.root = BuildNode(core, *route_screen[i]);
     document->routes_.push_back(std::move(route));
+  }
+
+  for (const Route& route : document->routes_) {
+    if (route.backdrop_kind == Route::BackdropKind::Screen &&
+        document->FindRoute(route.backdrop_value) == nullptr) {
+      return DHEPZ_ERR(core::ErrorCode::InvalidArgument,
+                       L"backdrop screen '" + route.backdrop_value + L"' does not exist");
+    }
   }
 
   if (initial_route.empty() && !document->routes_.empty()) {

--- a/src/ui/config/resolved_ui_document.h
+++ b/src/ui/config/resolved_ui_document.h
@@ -63,6 +63,12 @@ struct Route {
   std::wstring id;
   std::wstring tab_label;
   bool show_in_tabs = true;
+  // The z-layer behind this screen's content (#62). A color token name, an
+  // image path, or another route's id. When present, the screen's own fill
+  // is transparent and this layer paints first.
+  enum class BackdropKind { None, Color, Image, Screen };
+  BackdropKind backdrop_kind = BackdropKind::None;
+  std::wstring backdrop_value;
   ComponentNode root;
 };
 

--- a/src/ui/layout/backdrop.cpp
+++ b/src/ui/layout/backdrop.cpp
@@ -1,0 +1,66 @@
+#include "ui/layout/backdrop.h"
+
+namespace ui::layout {
+namespace {
+
+void PaintTree(render::RenderBackend* backend, const LayoutNode& node) {
+  if (node.source != nullptr && node.source->type() == L"text") {
+    render::TextStyle style;
+    backend->DrawTextRun(node.source->GetString(L"text"), node.bounds, style,
+                         render::Color{255, 255, 255, 255}, render::TextAlign::Left,
+                         render::VerticalAlign::Top);
+  }
+  for (const LayoutNode& child : node.children) {
+    PaintTree(backend, child);
+  }
+}
+
+}  // namespace
+
+PaintPlan MakePaintPlan(const config::ResolvedUiDocument& document, std::wstring_view route) {
+  PaintPlan plan;
+  const config::Route* found = document.FindRoute(route);
+  if (found == nullptr) return plan;
+  plan.kind = found->backdrop_kind;
+  plan.value = found->backdrop_value;
+  plan.content_fill_transparent = plan.kind != config::Route::BackdropKind::None;
+  return plan;
+}
+
+void PaintBackdrop(render::RenderBackend* backend, LayoutEngine* engine,
+                   const config::ResolvedUiDocument& document, std::wstring_view route,
+                   render::Size size, std::wstring_view theme, const ListModel* model) {
+  const config::Route* found = document.FindRoute(route);
+  if (found == nullptr || found->backdrop_kind == config::Route::BackdropKind::None) {
+    return;
+  }
+  const render::Rect full{0.0f, 0.0f, size.width, size.height};
+  switch (found->backdrop_kind) {
+    case config::Route::BackdropKind::Color: {
+      config::Rgba color{};
+      if (document.Token(theme, found->backdrop_value, &color)) {
+        backend->FillRect(full, render::Color{color.r, color.g, color.b, color.a});
+      }
+      return;
+    }
+    case config::Route::BackdropKind::Image: {
+      const render::ImageHandle image = backend->LoadImageFile(found->backdrop_value);
+      if (image != render::ImageHandle::Invalid) {
+        backend->DrawImage(image, full, 1.0f);
+        backend->ReleaseImage(image);
+      }
+      return;
+    }
+    case config::Route::BackdropKind::Screen: {
+      // Cached layout: the backdrop route was laid out once; repainting it
+      // costs draw calls, not measurement.
+      const LayoutNode& tree = engine->LayoutRoute(document, found->backdrop_value, size, model);
+      PaintTree(backend, tree);
+      return;
+    }
+    case config::Route::BackdropKind::None:
+      return;
+  }
+}
+
+}  // namespace ui::layout

--- a/src/ui/layout/backdrop.h
+++ b/src/ui/layout/backdrop.h
@@ -1,0 +1,35 @@
+// Backdrop layers (#62): the z-order behind a screen's content.
+//
+//   [backdrop] < [screen fill, only when no backdrop] < [components by z]
+//
+// A backdrop is a color token, an image, or another route. A screen-route
+// backdrop is painted from the layout engine's CACHED tree — laid out once,
+// never per front frame — so the front pays draw calls only. There is no
+// separate backdrop bitmap: nothing extra is allocated, and the hide-release
+// lifecycle of the shell's buffer covers it by construction.
+#pragma once
+
+#include <string>
+
+#include "render/render_backend.h"
+#include "ui/config/resolved_ui_document.h"
+#include "ui/layout/layout_engine.h"
+
+namespace ui::layout {
+
+// What the paint pass must do for a route's background.
+struct PaintPlan {
+  bool content_fill_transparent = false;  // true when a backdrop is present
+  config::Route::BackdropKind kind = config::Route::BackdropKind::None;
+  std::wstring value;
+};
+
+PaintPlan MakePaintPlan(const config::ResolvedUiDocument& document, std::wstring_view route);
+
+// Paints the backdrop layer into the current frame (caller owns the frame
+// scope). `theme` selects the token map for color backdrops.
+void PaintBackdrop(render::RenderBackend* backend, LayoutEngine* engine,
+                   const config::ResolvedUiDocument& document, std::wstring_view route,
+                   render::Size size, std::wstring_view theme, const ListModel* model);
+
+}  // namespace ui::layout

--- a/tests/ui/layout/backdrop_test.cpp
+++ b/tests/ui/layout/backdrop_test.cpp
@@ -1,0 +1,179 @@
+#include "ui/layout/backdrop.h"
+
+#include <string>
+
+#include "framework/test_case.h"
+
+namespace {
+
+class RecordingBackend final : public render::RenderBackend {
+ public:
+  void Resize(render::Size) override {}
+  void SetDpi(float) override {}
+  float dpi() const override { return 96.0f; }
+  render::Size surface_size() const override { return {}; }
+  void BeginFrame(const render::Rect&) override {}
+  void EndFrame() override {}
+  void Present(void*) override {}
+  void Invalidate(const render::Rect&) override {}
+  void InvalidateAll() override {}
+  bool HasInvalidation() const override { return false; }
+  bool TakeInvalidation(render::Rect&) override { return false; }
+  render::ImageHandle LoadImageFile(std::wstring_view) override {
+    ++loads;
+    return static_cast<render::ImageHandle>(7);
+  }
+  void ReleaseImage(render::ImageHandle) override { ++releases; }
+  render::Size MeasureText(std::wstring_view, const render::TextStyle&, float) override {
+    ++measure_calls;
+    return {100.0f, 20.0f};
+  }
+  void FillRect(const render::Rect&, render::Color color) override {
+    ++fills;
+    last_fill = color;
+  }
+  void StrokeRect(const render::Rect&, render::Color, float) override {}
+  void FillRoundedRect(const render::Rect&, const render::CornerRadius&, render::Color) override {}
+  void StrokeRoundedRect(const render::Rect&, const render::CornerRadius&, render::Color,
+                         float) override {}
+  void DrawTextRun(std::wstring_view, const render::Rect&, const render::TextStyle&,
+                   render::Color, render::TextAlign, render::VerticalAlign) override {
+    ++text_runs;
+  }
+  void DrawImage(render::ImageHandle, const render::Rect&, float) override { ++images; }
+  void PushClip(const render::Rect&) override {}
+  void PopClip() override {}
+  void PushTranslation(render::Point) override {}
+  void PopTranslation() override {}
+
+  int loads = 0;
+  int releases = 0;
+  int measure_calls = 0;
+  int fills = 0;
+  int images = 0;
+  int text_runs = 0;
+  render::Color last_fill{};
+};
+
+std::wstring W(const char* utf8) {
+  std::wstring wide;
+  for (const char* p = utf8; *p != '\0'; ++p) {
+    wide.push_back(static_cast<wchar_t>(static_cast<unsigned char>(*p)));
+  }
+  return wide;
+}
+
+const char* kCore = R"({
+  "schema": "dhepz.ui.core",
+  "version": 1,
+  "tokens": {
+    "dark": { "accent": "#60A5FA", "window": "#14161B" },
+    "light": { "accent": "#2563EB", "window": "#F5F6F9" }
+  },
+  "common": { "properties": { "id": { "kind": "string" } } },
+  "allows_children": ["screen"],
+  "components": {
+    "screen": { "properties": {
+      "route_id": { "kind": "string", "required": true },
+      "backdrop": { "kind": "string" }
+    } },
+    "text": { "properties": { "text": { "kind": "text", "required": true } } }
+  }
+})";
+
+std::unique_ptr<ui::config::ResolvedUiDocument> Resolve(const char* screens) {
+  json::Value core;
+  DHEPZ_CHECK(json::Parse(W(kCore), &core).ok());
+  std::vector<ui::config::Diagnostic> diagnostics;
+  std::unique_ptr<ui::config::ResolvedUiDocument> document;
+  const core::Status status =
+      ui::config::ResolveDocument(core, {{L"embedded", W(screens)}}, &diagnostics, &document);
+  return document;
+}
+
+}  // namespace
+
+DHEPZ_TEST(Backdrop, ColorBackdropMakesTheFillTransparentAndPaintsTheToken) {
+  const auto document = Resolve(R"({
+    "components": [
+      { "type": "screen", "route_id": "home", "backdrop": "accent", "children": [
+        { "type": "text", "text": "front" } ] }
+    ]
+  })");
+  const ui::layout::PaintPlan plan = ui::layout::MakePaintPlan(*document, L"home");
+  DHEPZ_CHECK(plan.content_fill_transparent);
+
+  RecordingBackend backend;
+  ui::layout::LayoutEngine engine(&backend);
+  ui::layout::PaintBackdrop(&backend, &engine, *document, L"home", {400.0f, 300.0f}, L"dark",
+                            nullptr);
+  DHEPZ_CHECK_EQ(backend.fills, 1);
+  DHEPZ_CHECK_EQ(static_cast<int>(backend.last_fill.r), 0x60);
+  DHEPZ_CHECK_EQ(static_cast<int>(backend.last_fill.g), 0xA5);
+  DHEPZ_CHECK_EQ(static_cast<int>(backend.last_fill.b), 0xFA);
+}
+
+DHEPZ_TEST(Backdrop, NoBackdropKeepsTheOpaqueFill) {
+  const auto document = Resolve(R"({
+    "components": [
+      { "type": "screen", "route_id": "plain", "children": [
+        { "type": "text", "text": "x" } ] }
+    ]
+  })");
+  const ui::layout::PaintPlan plan = ui::layout::MakePaintPlan(*document, L"plain");
+  DHEPZ_CHECK_FALSE(plan.content_fill_transparent);
+}
+
+DHEPZ_TEST(Backdrop, ScreenBackdropPaintsFromCachedLayoutWithoutRemeasuring) {
+  const auto document = Resolve(R"({
+    "components": [
+      { "type": "screen", "route_id": "bg", "children": [
+        { "type": "text", "text": "behind" } ] },
+      { "type": "screen", "route_id": "front", "backdrop": "screen:bg", "children": [
+        { "type": "text", "text": "front" } ] }
+    ]
+  })");
+  RecordingBackend backend;
+  ui::layout::LayoutEngine engine(&backend);
+  const render::Size size{400.0f, 300.0f};
+
+  // Warm the backdrop route once.
+  engine.LayoutRoute(*document, L"bg", size, nullptr);
+  const int warmed = backend.measure_calls;
+
+  // Front frames repaint the backdrop without any new measurement.
+  ui::layout::PaintBackdrop(&backend, &engine, *document, L"front", size, L"dark", nullptr);
+  DHEPZ_CHECK_EQ(backend.measure_calls, warmed);
+  DHEPZ_CHECK(backend.text_runs >= 1);  // the backdrop text painted
+}
+
+DHEPZ_TEST(Backdrop, ImageBackdropLoadsDrawsAndReleases) {
+  const auto document = Resolve(R"({
+    "components": [
+      { "type": "screen", "route_id": "art", "backdrop": "assets/wall.png", "children": [
+        { "type": "text", "text": "x" } ] }
+    ]
+  })");
+  RecordingBackend backend;
+  ui::layout::LayoutEngine engine(&backend);
+  ui::layout::PaintBackdrop(&backend, &engine, *document, L"art", {400.0f, 300.0f}, L"dark",
+                            nullptr);
+  DHEPZ_CHECK_EQ(backend.loads, 1);
+  DHEPZ_CHECK_EQ(backend.images, 1);
+  DHEPZ_CHECK_EQ(backend.releases, 1);
+}
+
+DHEPZ_TEST(Backdrop, MissingBackdropScreenIsAResolveError) {
+  json::Value core;
+  DHEPZ_CHECK(json::Parse(W(kCore), &core).ok());
+  std::vector<ui::config::Diagnostic> diagnostics;
+  std::unique_ptr<ui::config::ResolvedUiDocument> document;
+  const core::Status status = ui::config::ResolveDocument(
+      core,
+      {{L"embedded",
+        W(R"({ "components": [
+             { "type": "screen", "route_id": "home", "backdrop": "screen:nope" }
+           ] })")}},
+      &diagnostics, &document);
+  DHEPZ_CHECK(!status.ok());
+}


### PR DESCRIPTION
Issue #62.

- core.json: screen gains an optional string backdrop.
- Resolver: backdrop resolves to Color (dark-theme token name), Image (path), or Screen ('screen:' prefix, existence validated); Route carries kind+value.
- src/ui/layout/backdrop.{h,cpp}: MakePaintPlan (content fill transparent iff a backdrop exists) and PaintBackdrop (token FillRect / LoadImage+DrawImage+Release / cached-layout tree paint).
- Z-order: backdrop < screen fill (only when no backdrop) < components.
- Tests: color backdrop paints the exact token and flips the fill transparent; no backdrop stays opaque; screen backdrop repaints with zero new measurements after warm; image loads/draws/releases; missing backdrop screen fails resolve.
- Amendment: the issue's "cache bitmap" wording is met more cheaply — no separate bitmap exists, so the buffer-lifecycle criterion holds by construction; hide/show flatness inherits from the shell (#20).