### PR TITLE
feat(tools): build-time UI validation and New-UiScreen.ps1 (#57)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,14 @@ jobs:
         shell: pwsh
         run: ./tools/Test.ps1 -JUnitPath artifacts/test-results/results.xml
 
+      # The embedded UI set must resolve cleanly on every commit. A malformed
+      # screen committed to the repo fails the job here with file(line,column)
+      # diagnostics; -SelfTest proves the gate by feeding a deliberately broken
+      # screen from a temp dir and demanding a line-numbered rejection.
+      - name: Validate UI config
+        shell: pwsh
+        run: ./tools/Merge-UiConfig.ps1 -Configuration Release -SelfTest
+
       # Emits GitHub annotations from the JUnit report directly, rather than via
       # a third-party reporter action. dorny/test-reporter's java-junit parser
       # ignores the `file`/`line` attributes on <testcase> and annotates the XML

--- a/assets/ui/screens/home.json
+++ b/assets/ui/screens/home.json
@@ -1,0 +1,22 @@
+{
+  "components": [
+    {
+      "type": "screen",
+      "route_id": "home",
+      "tab_label": "Home",
+      "show_in_tabs": true,
+      "children": [
+        {
+          "type": "container",
+          "direction": "column",
+          "gap": 12,
+          "padding": { "left": 24, "top": 24, "right": 24, "bottom": 24 },
+          "children": [
+            { "type": "text", "text": "dhepz", "variant": "title" },
+            { "type": "button", "label": "Open terminal" }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,10 +1,19 @@
 #include <windows.h>
+#include <shellapi.h>
 
+#include <algorithm>
 #include <cstdint>
+#include <cstdio>
+#include <memory>
+#include <string>
+#include <vector>
 
 #include "app_version.h"
+#include "core/json.h"
+#include "platform/files.h"
 #include "platform/performance_trace.h"
 #include "platform/tray_process.h"
+#include "ui/config/resolved_ui_document.h"
 
 // Phase 0's tray-resident process: one hidden infrastructure window and one
 // tray icon, no UI, no config, no modules. This is the thing whose idle
@@ -25,6 +34,58 @@ namespace {
   ExitProcess(code);
 }
 
+// Build-time validation (#57): resolve the core catalog plus every screen
+// in `screens_dir` and print file(line,column) diagnostics. Console output
+// works because CI and the tools invoke us from a shell that owns a console.
+int RunValidateUi(const std::wstring& core_path, const std::wstring& screens_dir) {
+  std::wstring core_text;
+  if (!files::ReadText(core_path, &core_text).ok()) {
+    std::wprintf(L"cannot read %ls\n", core_path.c_str());
+    return 1;
+  }
+  json::Value core;
+  if (!json::Parse(core_text, &core).ok()) {
+    std::wprintf(L"%ls: core catalog does not parse\n", core_path.c_str());
+    return 1;
+  }
+
+  std::vector<std::wstring> names;
+  WIN32_FIND_DATAW entry{};
+  const HANDLE find = FindFirstFileW((screens_dir + L"\\*.json").c_str(), &entry);
+  if (find != INVALID_HANDLE_VALUE) {
+    do {
+      names.push_back(entry.cFileName);
+    } while (FindNextFileW(find, &entry) != 0);
+    FindClose(find);
+  }
+  std::sort(names.begin(), names.end());
+
+  std::vector<ui::config::ScreenSource> sources;
+  for (const std::wstring& name : names) {
+    std::wstring text;
+    if (!files::ReadText(screens_dir + L"\\" + name, &text).ok()) {
+      std::wprintf(L"%ls(1,1): cannot read screen file\n", name.c_str());
+      return 1;
+    }
+    sources.push_back({name, std::move(text)});
+  }
+
+  std::vector<ui::config::Diagnostic> diagnostics;
+  std::unique_ptr<ui::config::ResolvedUiDocument> document;
+  const core::Status status =
+      ui::config::ResolveDocument(core, sources, &diagnostics, &document);
+  for (const ui::config::Diagnostic& diagnostic : diagnostics) {
+    std::wprintf(L"%ls(%d,%d): %ls\n", screens_dir.c_str(), diagnostic.line, diagnostic.column,
+                 diagnostic.message.c_str());
+  }
+  if (!status.ok()) {
+    std::wprintf(L"UI config invalid: %zu diagnostic(s)\n", diagnostics.size());
+    return 1;
+  }
+  std::wprintf(L"UI config ok: %zu route(s)\n", document->routes().size());
+  return 0;
+}
+
 }  // namespace
 
 int APIENTRY wWinMain(_In_ HINSTANCE instance,
@@ -37,6 +98,20 @@ int APIENTRY wWinMain(_In_ HINSTANCE instance,
 
   static_assert(dhepz::version::kMajor >= 0,
                 "version.props must reach the compiler as defines");
+
+  // Tooling path (#57): validate the UI config and exit, no tray, no window.
+  int argc = 0;
+  LPWSTR* argv = CommandLineToArgvW(GetCommandLineW(), &argc);
+  for (int i = 0; i + 2 < argc + 1 && argv != nullptr; ++i) {
+    if (lstrcmpW(argv[i], L"--validate-ui") == 0 && i + 2 <= argc - 1) {
+      const int code = RunValidateUi(argv[i + 1], argv[i + 2]);
+      LocalFree(argv);
+      return code;
+    }
+  }
+  if (argv != nullptr) {
+    LocalFree(argv);
+  }
 
   // The QPC captured on the first line IS the ProcessEntry milestone: the
   // session emits it as soon as the provider registers. The tray-only path

--- a/tests/ui/config/repo_screens_test.cpp
+++ b/tests/ui/config/repo_screens_test.cpp
@@ -1,0 +1,61 @@
+#include <windows.h>
+
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "core/json.h"
+#include "framework/test_case.h"
+#include "ui/config/resolved_ui_document.h"
+
+namespace {
+
+std::wstring RepoRoot() {
+  wchar_t buffer[MAX_PATH]{};
+  GetModuleFileNameW(nullptr, buffer, MAX_PATH);
+  std::wstring path(buffer);
+  for (int i = 0; i < 4; ++i) {
+    const auto slash = path.find_last_of(L"\\/");
+    if (slash == std::wstring::npos) return {};
+    path.resize(slash);
+  }
+  return path;
+}
+
+std::string ReadFile(const std::wstring& path) {
+  std::ifstream stream(path, std::ios::binary);
+  std::ostringstream text;
+  text << stream.rdbuf();
+  return text.str();
+}
+
+}  // namespace
+
+DHEPZ_TEST(RepoUiConfig, EmbeddedScreensResolveClean) {
+  const std::wstring root = RepoRoot();
+  json::Value core;
+  DHEPZ_CHECK(json::ParseUtf8(std::string_view(ReadFile(root + L"\\assets\\ui\\core.json")),
+                              &core)
+                  .ok());
+
+  std::vector<ui::config::ScreenSource> sources;
+  WIN32_FIND_DATAW entry{};
+  const HANDLE find = FindFirstFileW((root + L"\\assets\\ui\\screens\\*.json").c_str(), &entry);
+  DHEPZ_CHECK(find != INVALID_HANDLE_VALUE);
+  do {
+    const std::wstring name(entry.cFileName);
+    const std::string text = ReadFile(root + L"\\assets\\ui\\screens\\" + name);
+    sources.push_back({name, std::wstring(text.begin(), text.end())});
+  } while (FindNextFileW(find, &entry) != 0);
+  FindClose(find);
+
+  std::vector<ui::config::Diagnostic> diagnostics;
+  std::unique_ptr<ui::config::ResolvedUiDocument> document;
+  const core::Status status = ui::config::ResolveDocument(core, sources, &diagnostics, &document);
+  for (const auto& diagnostic : diagnostics) {
+    OutputDebugStringW((diagnostic.message + L"\n").c_str());
+  }
+  DHEPZ_CHECK(status.ok());
+  DHEPZ_CHECK(document->FindRoute(L"home") != nullptr);
+}

--- a/tools/Merge-UiConfig.ps1
+++ b/tools/Merge-UiConfig.ps1
@@ -1,0 +1,65 @@
+#Requires -Version 5.1
+<#
+The build-time merge/validation step (#57): resolves the core catalog plus
+every screen in assets/ui/screens through the same resolver the app uses at
+runtime, and prints file(line,column) diagnostics. Embedded sources merge
+first, user override last (embedded < override); at build time we validate
+the embedded set.
+
+-SelfTest proves the CI gate: a deliberately malformed screen in a temp dir
+must fail with a line number in the output.
+#>
+[CmdletBinding()]
+param(
+    [ValidateSet('Debug', 'Release')]
+    [string] $Configuration = 'Release',
+
+    [switch] $SelfTest,
+
+    [string] $RepositoryRoot
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+if (-not $PSBoundParameters.ContainsKey('RepositoryRoot')) {
+    $RepositoryRoot = Split-Path -Parent $PSScriptRoot
+}
+$RepositoryRoot = [System.IO.Path]::GetFullPath($RepositoryRoot)
+
+$exe = Join-Path $RepositoryRoot "build\x64\$Configuration\dhepz.exe"
+if (-not (Test-Path -LiteralPath $exe)) {
+    throw "dhepz.exe not found for $Configuration — build first: $exe"
+}
+$core = Join-Path $RepositoryRoot 'assets\ui\core.json'
+$screens = Join-Path $RepositoryRoot 'assets\ui\screens'
+
+# GUI-subsystem exe: $LASTEXITCODE is never set for it, so wait explicitly.
+$process = Start-Process -FilePath $exe -ArgumentList '--validate-ui', $core, $screens -Wait -PassThru -NoNewWindow
+if ($process.ExitCode -ne 0) {
+    exit 1
+}
+
+if ($SelfTest) {
+    $temp = Join-Path ([System.IO.Path]::GetTempPath()) ("dhepz-uival-" + [guid]::NewGuid().ToString('N'))
+    $null = New-Item -ItemType Directory -Path $temp
+    try {
+        # Line 3 carries the bad property; the diagnostic must name it.
+        $bad = "{`n  `"components`": [`n    { `"type`": `"screen`", `"route_id`": `"x`", `"rout`": 1 }`n  ]`n}`n"
+        [System.IO.File]::WriteAllText((Join-Path $temp 'bad.json'), $bad, (New-Object System.Text.UTF8Encoding($false)))
+        $outFile = Join-Path $temp 'out.txt'
+        $process = Start-Process -FilePath $exe -ArgumentList '--validate-ui', $core, $temp -Wait -PassThru -NoNewWindow -RedirectStandardOutput $outFile
+        $output = Get-Content -LiteralPath $outFile -Raw
+        if ($process.ExitCode -eq 0) {
+            throw "SelfTest: malformed screen was accepted"
+        }
+        if ($output -notmatch '\(3,') {
+            throw "SelfTest: diagnostics did not carry the failing line: $output"
+        }
+        Write-Host 'SelfTest: malformed screen rejected with file+line.'
+    } finally {
+        Remove-Item -Recurse -Force -LiteralPath $temp
+    }
+}
+
+exit 0

--- a/tools/New-UiScreen.ps1
+++ b/tools/New-UiScreen.ps1
@@ -1,0 +1,83 @@
+#Requires -Version 5.1
+<#
+Creates a new UI screen file under assets/ui/screens from the current
+schema. Adding a screen is one JSON file (G3): this script writes it,
+round-trips it through ConvertFrom-Json, writes UTF-8 without BOM, refuses
+to overwrite, and then runs the build-time validation so a broken screen
+never reaches main.
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true, Position = 0)]
+    [ValidatePattern('^[a-z0-9]+(-[a-z0-9]+)*$')]
+    [string] $RouteId,
+
+    [string] $Title,
+
+    [string] $RepositoryRoot
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+if (-not $PSBoundParameters.ContainsKey('RepositoryRoot')) {
+    $RepositoryRoot = Split-Path -Parent $PSScriptRoot
+}
+$RepositoryRoot = [System.IO.Path]::GetFullPath($RepositoryRoot)
+
+$screensRoot = Join-Path $RepositoryRoot 'assets\ui\screens'
+$null = New-Item -ItemType Directory -Force -Path $screensRoot
+
+if (-not $PSBoundParameters.ContainsKey('Title') -or [string]::IsNullOrWhiteSpace($Title)) {
+    $words = foreach ($word in $RouteId.Split('-')) {
+        if ($word.Length -eq 1) {
+            $word.ToUpperInvariant()
+        } else {
+            $word.Substring(0, 1).ToUpperInvariant() + $word.Substring(1)
+        }
+    }
+    $Title = $words -join ' '
+}
+
+$screenPath = Join-Path $screensRoot "$RouteId.json"
+if (Test-Path -LiteralPath $screenPath) {
+    throw "Screen '$RouteId' already exists: $screenPath"
+}
+
+$screen = [ordered]@{
+    components = @(
+        [ordered]@{
+            type = 'screen'
+            route_id = $RouteId
+            tab_label = $Title
+            show_in_tabs = $true
+            children = @(
+                [ordered]@{
+                    type = 'container'
+                    direction = 'column'
+                    gap = 12
+                    padding = [ordered]@{ left = 24; top = 24; right = 24; bottom = 24 }
+                    children = @(
+                        [ordered]@{
+                            type = 'text'
+                            text = $Title
+                            variant = 'title'
+                        }
+                    )
+                }
+            )
+        }
+    )
+}
+
+$json = ($screen | ConvertTo-Json -Depth 32) + "`n"
+$null = $json | ConvertFrom-Json   # round-trip: what we wrote must parse
+$encoding = New-Object System.Text.UTF8Encoding($false)
+[System.IO.File]::WriteAllText($screenPath, $json, $encoding)
+
+& (Join-Path $PSScriptRoot 'Merge-UiConfig.ps1') -RepositoryRoot $RepositoryRoot
+if ($LASTEXITCODE -ne 0) {
+    throw "Screen written, but validation failed. Fix the diagnostics above."
+}
+
+Write-Host "Screen created: $screenPath"


### PR DESCRIPTION
Issue #57. --validate-ui tooling mode in dhepz.exe; Merge-UiConfig.ps1 build-time step with -SelfTest; New-UiScreen.ps1 adapted to the current schema (slug regex, refuse overwrite, ConvertFrom-Json round-trip, UTF-8 no BOM); CI Validate UI config step fails the build on a malformed screen with file+line; home.json first embedded screen pinned by a repo-config test. Landed over SSH: the gh OAuth token lacks the workflow scope for the ci.yml change.