### PR TITLE
feat(ui): two-tier config with corrupt-override quarantine (#58)

### DIFF
--- a/src/ui/config/config_store.cpp
+++ b/src/ui/config/config_store.cpp
@@ -1,0 +1,80 @@
+#include "ui/config/config_store.h"
+
+#include <windows.h>
+
+#include "platform/files.h"
+
+namespace ui::config {
+
+ConfigStore::ConfigStore(std::wstring core_text, std::vector<ScreenSource> embedded,
+                         std::wstring override_path)
+    : core_text_(std::move(core_text)),
+      embedded_(std::move(embedded)),
+      override_path_(std::move(override_path)) {}
+
+bool ConfigStore::ReadOverrideText(std::wstring* text) {
+  return files::ReadText(override_path_, text).ok();
+}
+
+void ConfigStore::QuarantineOverride() {
+  // NTFS rename is atomic: a reader can never observe a half-moved file.
+  MoveFileExW(override_path_.c_str(), (override_path_ + L".quarantine").c_str(),
+              MOVEFILE_REPLACE_EXISTING);
+}
+
+core::Status ConfigStore::ResolveWith(const std::vector<ScreenSource>& sources,
+                                      std::unique_ptr<ResolvedUiDocument>* out,
+                                      std::vector<Diagnostic>* diags) {
+  json::Value core;
+  const core::Status parsed = json::Parse(core_text_, &core);
+  if (!parsed.ok()) {
+    diags->push_back({L"core: " + parsed.Message(), 0, 0});
+    return parsed;
+  }
+  return ResolveDocument(core, sources, diags, out);
+}
+
+core::Status ConfigStore::Load() {
+  std::vector<ScreenSource> sources = embedded_;
+  std::wstring override_text;
+  if (ReadOverrideText(&override_text)) {
+    sources.push_back({L"override", override_text});
+    std::vector<Diagnostic> attempt;
+    std::unique_ptr<ResolvedUiDocument> merged;
+    if (ResolveWith(sources, &merged, &attempt).ok()) {
+      document_ = std::move(merged);
+      diagnostics_.insert(diagnostics_.end(), attempt.begin(), attempt.end());
+      return core::Ok();
+    }
+    // Corrupt or invalid override at bootstrap: fall back to embedded and
+    // move the file aside so the next start begins clean.
+    diagnostics_.insert(diagnostics_.end(), attempt.begin(), attempt.end());
+    diagnostics_.push_back(
+        {L"override: corrupt override quarantined; embedded config in use", 0, 0});
+    QuarantineOverride();
+  }
+  std::vector<Diagnostic> embedded_diags;
+  const core::Status status = ResolveWith(embedded_, &document_, &embedded_diags);
+  diagnostics_.insert(diagnostics_.end(), embedded_diags.begin(), embedded_diags.end());
+  return status;
+}
+
+core::Status ConfigStore::Reload() {
+  std::wstring override_text;
+  std::vector<ScreenSource> sources = embedded_;
+  if (ReadOverrideText(&override_text)) {
+    sources.push_back({L"override", override_text});
+  }
+  std::vector<Diagnostic> attempt;
+  std::unique_ptr<ResolvedUiDocument> next;
+  const core::Status status = ResolveWith(sources, &next, &attempt);
+  if (!status.ok()) {
+    // Hot reload never takes the app down: the live document stays active.
+    diagnostics_.insert(diagnostics_.end(), attempt.begin(), attempt.end());
+    return status;
+  }
+  document_ = std::move(next);
+  return core::Ok();
+}
+
+}  // namespace ui::config

--- a/src/ui/config/config_store.h
+++ b/src/ui/config/config_store.h
@@ -1,0 +1,57 @@
+// Two-tier config resolution with corrupt-override quarantine (#58).
+//
+//   bootstrap:  corrupt override -> embedded config used, diagnostic
+//               published, corrupt file renamed aside (.quarantine)
+//   hot reload: corrupt override -> the live document stays active and a
+//               diagnostic is recorded; nothing swaps, nothing crashes
+//   recovery:   a valid override placed at the path is picked up on the
+//               next reload
+//
+// Truncated or partial writes are just parse errors to this reader, so a
+// half-written override can never surface as a half-resolved document;
+// writers (the future ui-editor) use files::WriteTextAtomic.
+#pragma once
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "core/status.h"
+#include "ui/config/resolved_ui_document.h"
+
+namespace ui::config {
+
+class ConfigStore final {
+ public:
+  // `core_text` and `embedded` are the shipped tier; `override_path` is the
+  // user tier (one screens document).
+  ConfigStore(std::wstring core_text, std::vector<ScreenSource> embedded,
+              std::wstring override_path);
+
+  // Bootstrap. Never fails the process: a corrupt override degrades to the
+  // embedded tier and records diagnostics.
+  core::Status Load();
+
+  // Hot reload. A corrupt or unresolvable override keeps the live document
+  // active and records a diagnostic; a valid one swaps atomically.
+  core::Status Reload();
+
+  const ResolvedUiDocument* document() const { return document_.get(); }
+  // Cumulative diagnostics, oldest first; source names identify the tier.
+  const std::vector<Diagnostic>& diagnostics() const { return diagnostics_; }
+
+ private:
+  bool ReadOverrideText(std::wstring* text);
+  void QuarantineOverride();
+  core::Status ResolveWith(const std::vector<ScreenSource>& sources,
+                           std::unique_ptr<ResolvedUiDocument>* out,
+                           std::vector<Diagnostic>* diags);
+
+  std::wstring core_text_;
+  std::vector<ScreenSource> embedded_;
+  std::wstring override_path_;
+  std::unique_ptr<ResolvedUiDocument> document_;
+  std::vector<Diagnostic> diagnostics_;
+};
+
+}  // namespace ui::config

--- a/tests/ui/config/config_store_test.cpp
+++ b/tests/ui/config/config_store_test.cpp
@@ -1,0 +1,133 @@
+#include "ui/config/config_store.h"
+
+#include <windows.h>
+
+#include <fstream>
+#include <string>
+
+#include "framework/test_case.h"
+
+namespace {
+
+std::wstring W(const char* utf8) {
+  std::wstring wide;
+  for (const char* p = utf8; *p != '\0'; ++p) {
+    wide.push_back(static_cast<wchar_t>(static_cast<unsigned char>(*p)));
+  }
+  return wide;
+}
+
+void WriteFile(const std::wstring& path, const std::string& utf8) {
+  std::ofstream stream(path, std::ios::binary | std::ios::trunc);
+  stream << utf8;
+}
+
+bool Exists(const std::wstring& path) {
+  return GetFileAttributesW(path.c_str()) != INVALID_FILE_ATTRIBUTES;
+}
+
+const char* kCore = R"({
+  "schema": "dhepz.ui.core",
+  "version": 1,
+  "tokens": { "dark": { "text": "#FFFFFF" }, "light": { "text": "#000000" } },
+  "allows_children": ["screen"],
+  "components": {
+    "screen": { "properties": { "route_id": { "kind": "string", "required": true },
+                                "tab_label": { "kind": "string" } } },
+    "text": { "properties": { "text": { "kind": "text", "required": true } } }
+  }
+})";
+
+const char* kEmbedded = R"({
+  "components": [
+    { "type": "screen", "route_id": "home", "tab_label": "Embedded", "children": [
+      { "type": "text", "text": "e" } ] }
+  ]
+})";
+
+const char* kOverride = R"({
+  "components": [
+    { "type": "screen", "route_id": "home", "tab_label": "Override", "children": [
+      { "type": "text", "text": "o" } ] }
+  ]
+})";
+
+const char* kOverride2 = R"({
+  "components": [
+    { "type": "screen", "route_id": "home", "tab_label": "Fixed", "children": [
+      { "type": "text", "text": "f" } ] }
+  ]
+})";
+
+std::wstring TempOverridePath() {
+  wchar_t buffer[MAX_PATH]{};
+  GetTempPathW(MAX_PATH, buffer);
+  std::wstring dir = std::wstring(buffer) + L"dhepz-q-" +
+                     std::to_wstring(GetCurrentProcessId());
+  CreateDirectoryW(dir.c_str(), nullptr);
+  return dir + L"\\override.json";
+}
+
+ui::config::ConfigStore MakeStore(const std::wstring& override_path) {
+  return ui::config::ConfigStore(W(kCore), {{L"embedded", W(kEmbedded)}}, override_path);
+}
+
+}  // namespace
+
+DHEPZ_TEST(ConfigStore, ValidOverrideAtStartupMerges) {
+  const std::wstring path = TempOverridePath();
+  WriteFile(path, kOverride);
+  ui::config::ConfigStore store = MakeStore(path);
+  DHEPZ_CHECK(store.Load().ok());
+  DHEPZ_CHECK(store.document() != nullptr);
+  DHEPZ_CHECK_EQ(store.document()->FindRoute(L"home")->tab_label, std::wstring(L"Override"));
+}
+
+DHEPZ_TEST(ConfigStore, CorruptAtBootstrapFallsBackAndQuarantines) {
+  const std::wstring path = TempOverridePath();
+  WriteFile(path, "{ this is not json");
+  ui::config::ConfigStore store = MakeStore(path);
+  DHEPZ_CHECK(store.Load().ok());
+  DHEPZ_CHECK_EQ(store.document()->FindRoute(L"home")->tab_label, std::wstring(L"Embedded"));
+  DHEPZ_CHECK(!store.diagnostics().empty());
+  DHEPZ_CHECK_FALSE(Exists(path));             // moved aside
+  DHEPZ_CHECK(Exists(path + L".quarantine"));  // preserved for the user
+}
+
+DHEPZ_TEST(ConfigStore, TruncatedOverrideIsCorruptNotCrash) {
+  const std::wstring path = TempOverridePath();
+  const std::string full(kOverride);
+  WriteFile(path, full.substr(0, full.size() / 2));  // a partial write
+  ui::config::ConfigStore store = MakeStore(path);
+  DHEPZ_CHECK(store.Load().ok());
+  DHEPZ_CHECK_EQ(store.document()->FindRoute(L"home")->tab_label, std::wstring(L"Embedded"));
+}
+
+DHEPZ_TEST(ConfigStore, CorruptDuringReloadKeepsTheLiveDocument) {
+  const std::wstring path = TempOverridePath();
+  WriteFile(path, kOverride);
+  ui::config::ConfigStore store = MakeStore(path);
+  DHEPZ_CHECK(store.Load().ok());
+  DHEPZ_CHECK_EQ(store.document()->FindRoute(L"home")->tab_label, std::wstring(L"Override"));
+
+  WriteFile(path, "{ truncated");
+  const std::size_t before = store.diagnostics().size();
+  DHEPZ_CHECK(!store.Reload().ok());
+  // Live document untouched, diagnostic recorded, file NOT quarantined so
+  // the user can fix it in place.
+  DHEPZ_CHECK_EQ(store.document()->FindRoute(L"home")->tab_label, std::wstring(L"Override"));
+  DHEPZ_CHECK(store.diagnostics().size() > before);
+  DHEPZ_CHECK(Exists(path));
+}
+
+DHEPZ_TEST(ConfigStore, RecoveryOnNextReloadWithValidOverride) {
+  const std::wstring path = TempOverridePath();
+  WriteFile(path, "{ broken");
+  ui::config::ConfigStore store = MakeStore(path);
+  DHEPZ_CHECK(store.Load().ok());
+  DHEPZ_CHECK_EQ(store.document()->FindRoute(L"home")->tab_label, std::wstring(L"Embedded"));
+
+  WriteFile(path, kOverride2);
+  DHEPZ_CHECK(store.Reload().ok());
+  DHEPZ_CHECK_EQ(store.document()->FindRoute(L"home")->tab_label, std::wstring(L"Fixed"));
+}


### PR DESCRIPTION
Issue #58. ConfigStore: embedded < override merge via the #53 resolver. Bootstrap corrupt override -> embedded + diagnostics + atomic quarantine rename. Hot reload corrupt -> live document kept, diagnostic recorded, file left for the user to fix. Recovery proven: valid override picked up on next reload. Truncated override treated as corrupt, never a crash or a half-resolved document. Tests cover all four criteria plus the startup-merge happy path.