### PR TITLE
feat(ui): screen presenter renders resolved routes in the shell (#71)

### DIFF
--- a/src/ui/focus/focus_coordinator.cpp
+++ b/src/ui/focus/focus_coordinator.cpp
@@ -6,20 +6,27 @@ namespace ui::focus {
 namespace {
 
 void Collect(const config::ComponentNode& node, const std::wstring& prefix, int& counter,
-             std::vector<std::wstring>* out) {
+             std::vector<std::pair<std::wstring, const config::ComponentNode*>>* out) {
   const bool focusable = node.GetBool(L"tab_stop") && node.GetBool(L"visible", true) &&
                          node.GetBool(L"enabled", true);
   if (focusable) {
     if (!node.id().empty()) {
-      out->push_back(node.id());
+      out->emplace_back(node.id(), &node);
     } else {
-      out->push_back(prefix + L"@" + std::to_wstring(counter));
+      out->emplace_back(prefix + L"@" + std::to_wstring(counter), &node);
     }
   }
   for (const config::ComponentNode& child : node.children()) {
     ++counter;
     Collect(child, prefix, counter, out);
   }
+}
+
+bool HasId(const std::vector<std::pair<std::wstring, const config::ComponentNode*>>& order,
+           std::wstring_view id) {
+  return std::find_if(order.begin(), order.end(), [id](const auto& entry) {
+           return entry.first == id;
+         }) != order.end();
 }
 
 }  // namespace
@@ -38,7 +45,23 @@ void FocusCoordinator::SetDocument(const config::ResolvedUiDocument* document) {
 
 std::vector<std::wstring> FocusCoordinator::Focusables(std::wstring_view route) const {
   const RouteState* state = Find(route);
-  return state != nullptr ? state->order : std::vector<std::wstring>{};
+  std::vector<std::wstring> ids;
+  if (state != nullptr) {
+    ids.reserve(state->order.size());
+    for (const auto& [id, node] : state->order) {
+      ids.push_back(id);
+    }
+  }
+  return ids;
+}
+
+const config::ComponentNode* FocusCoordinator::NodeFor(std::wstring_view route,
+                                                       std::wstring_view id) const {
+  const RouteState* state = Find(route);
+  if (state == nullptr) return nullptr;
+  const auto entry = std::find_if(state->order.begin(), state->order.end(),
+                                  [id](const auto& pair) { return pair.first == id; });
+  return entry != state->order.end() ? entry->second : nullptr;
 }
 
 std::wstring FocusCoordinator::Current(std::wstring_view route) const {
@@ -49,27 +72,27 @@ std::wstring FocusCoordinator::Current(std::wstring_view route) const {
 void FocusCoordinator::EnterRoute(std::wstring_view route) {
   RouteState* state = Find(route);
   if (state == nullptr) return;
-  const bool saved_exists = std::find(state->order.begin(), state->order.end(),
-                                      state->current) != state->order.end();
+  const bool saved_exists = !state->current.empty() && HasId(state->order, state->current);
   if (!saved_exists) {
-    state->current = state->order.empty() ? std::wstring{} : state->order.front();
+    state->current = state->order.empty() ? std::wstring{} : state->order.front().first;
   }
 }
 
 bool FocusCoordinator::SetFocus(std::wstring_view route, std::wstring_view id) {
   RouteState* state = Find(route);
-  if (state == nullptr) return false;
-  const auto known = std::find(state->order.begin(), state->order.end(), id);
-  if (known == state->order.end()) return false;
-  state->current = *known;
+  if (state == nullptr || !HasId(state->order, id)) return false;
+  state->current = std::wstring(id);
   return true;
 }
 
 std::wstring FocusCoordinator::Advance(std::wstring_view route, bool backward) {
   RouteState* state = Find(route);
   if (state == nullptr || state->order.empty()) return {};
-  const auto position =
-      std::find(state->order.begin(), state->order.end(), state->current);
+  const std::wstring current = state->current;
+  const auto position = std::find_if(state->order.begin(), state->order.end(),
+                                     [&current](const auto& entry) {
+                                       return entry.first == current;
+                                     });
   std::size_t index;
   if (position == state->order.end()) {
     index = backward ? state->order.size() - 1 : 0;
@@ -78,7 +101,7 @@ std::wstring FocusCoordinator::Advance(std::wstring_view route, bool backward) {
     index = backward ? (current_index + state->order.size() - 1) % state->order.size()
                      : (current_index + 1) % state->order.size();
   }
-  state->current = state->order[index];
+  state->current = state->order[index].first;
   return state->current;
 }
 

--- a/src/ui/focus/focus_coordinator.h
+++ b/src/ui/focus/focus_coordinator.h
@@ -23,6 +23,9 @@ class FocusCoordinator final {
   // Focusable ids in traversal order; empty route -> empty vector.
   std::vector<std::wstring> Focusables(std::wstring_view route) const;
 
+  // The node a focusable id refers to; nullptr for unknown ids.
+  const config::ComponentNode* NodeFor(std::wstring_view route, std::wstring_view id) const;
+
   // Current owner; empty when the route has nothing focusable or has not
   // been entered.
   std::wstring Current(std::wstring_view route) const;
@@ -40,7 +43,7 @@ class FocusCoordinator final {
 
  private:
   struct RouteState {
-    std::vector<std::wstring> order;
+    std::vector<std::pair<std::wstring, const config::ComponentNode*>> order;
     std::wstring current;
   };
   RouteState* Find(std::wstring_view route);

--- a/src/ui/presenter/screen_presenter.cpp
+++ b/src/ui/presenter/screen_presenter.cpp
@@ -1,0 +1,111 @@
+#include "ui/presenter/screen_presenter.h"
+
+#include <windows.h>
+
+#include "ui/layout/backdrop.h"
+
+namespace ui::presenter {
+
+ScreenPresenter::ScreenPresenter(render::RenderBackend* backend, std::wstring theme)
+    : backend_(backend), engine_(backend), theme_(std::move(theme)) {}
+
+void ScreenPresenter::SetDocument(const config::ResolvedUiDocument* document) {
+  document_ = document;
+  focus_.SetDocument(document);
+  route_.clear();
+  if (document_ != nullptr) {
+    route_ = document_->initial_route();
+    focus_.EnterRoute(route_);
+  }
+}
+
+void ScreenPresenter::SwitchRoute(std::wstring_view route) {
+  if (document_ == nullptr || document_->FindRoute(route) == nullptr) return;
+  route_ = std::wstring(route);
+  focus_.EnterRoute(route_);
+}
+
+render::Color ScreenPresenter::Token(std::wstring_view name, render::Color fallback) const {
+  config::Rgba rgba{};
+  if (document_ != nullptr && document_->Token(theme_, name, &rgba)) {
+    return render::Color{rgba.r, rgba.g, rgba.b, rgba.a};
+  }
+  return fallback;
+}
+
+void ScreenPresenter::Paint(const render::Rect& content) {
+  if (document_ == nullptr || route_.empty()) return;
+  const render::Size size{content.width, content.height};
+
+  backend_->PushTranslation({content.x, content.y});
+  layout::PaintBackdrop(backend_, &engine_, *document_, route_, size, theme_, nullptr);
+  const layout::LayoutNode& tree = engine_.LayoutRoute(*document_, route_, size, nullptr);
+  last_tree_ = &tree;
+  PaintNode(tree);
+  backend_->PopTranslation();
+}
+
+bool ScreenPresenter::ClickNode(const layout::LayoutNode& node, float x, float y) {
+  for (const layout::LayoutNode& child : node.children) {
+    if (ClickNode(child, x, y)) return true;
+  }
+  const config::ComponentNode* source = node.source;
+  if (source == nullptr || source->id().empty()) return false;
+  if (!node.bounds.contains({x, y})) return false;
+  if (!(source->GetBool(L"tab_stop") && source->GetBool(L"visible", true) &&
+        source->GetBool(L"enabled", true))) {
+    return false;
+  }
+  return focus_.SetFocus(route_, source->id());
+}
+
+void ScreenPresenter::PaintNode(const layout::LayoutNode& node) {
+  const config::ComponentNode* source = node.source;
+  if (source != nullptr) {
+    const std::wstring& type = source->type();
+    if (type == L"text") {
+      render::TextStyle style;
+      const std::wstring variant = source->GetString(L"variant");
+      if (variant == L"title") {
+        style.size_px = 20.0f;
+        style.weight = render::FontWeight::Semibold;
+      } else if (variant == L"caption") {
+        style.size_px = 12.0f;
+      } else if (variant == L"monospace") {
+        style.family = L"Cascadia Mono";
+      }
+      backend_->DrawTextRun(source->GetString(L"text"), node.bounds, style,
+                            Token(L"text", {255, 255, 255, 255}), render::TextAlign::Left,
+                            render::VerticalAlign::Top);
+    } else if (type == L"button") {
+      backend_->FillRoundedRect(node.bounds, render::CornerRadius::Uniform(6.0f),
+                                Token(L"surfaceAlt", {35, 39, 48, 255}));
+      backend_->StrokeRoundedRect(node.bounds, render::CornerRadius::Uniform(6.0f),
+                                  Token(L"border", {48, 53, 64, 255}), 1.0f);
+      backend_->DrawTextRun(source->GetString(L"label"), node.bounds, render::TextStyle{},
+                            Token(L"text", {255, 255, 255, 255}), render::TextAlign::Center,
+                            render::VerticalAlign::Middle);
+    }
+    if (!source->id().empty() && source->id() == focus_.Current(route_)) {
+      const render::Rect ring{node.bounds.x - 2.0f, node.bounds.y - 2.0f,
+                              node.bounds.width + 4.0f, node.bounds.height + 4.0f};
+      backend_->StrokeRect(ring, Token(L"accent", {96, 165, 250, 255}), 2.0f);
+    }
+  }
+  for (const layout::LayoutNode& child : node.children) {
+    PaintNode(child);
+  }
+}
+
+bool ScreenPresenter::HandleKey(int virtual_key) {
+  if (virtual_key != VK_TAB) return false;
+  const bool backward = (GetKeyState(VK_SHIFT) & 0x8000) != 0;
+  return !focus_.Advance(route_, backward).empty();
+}
+
+bool ScreenPresenter::HandleClick(float x, float y) {
+  if (last_tree_ == nullptr) return false;
+  return ClickNode(*last_tree_, x, y);
+}
+
+}  // namespace ui::presenter

--- a/src/ui/presenter/screen_presenter.h
+++ b/src/ui/presenter/screen_presenter.h
@@ -1,0 +1,55 @@
+// The JSON-to-pixels wire (#71): paints the resolved route through the
+// render seam and owns the interactive half (focus ring, Tab traversal,
+// click-to-focus). Action dispatch — what a button DOES — stays inert and
+// declared-only until the module contract (Phase 3); that decision is
+// recorded on issue #71.
+//
+// The shell calls Paint inside its frame scope; coordinates are translated
+// so the route origin lands at the content rect's top-left.
+#pragma once
+
+#include <string>
+
+#include "render/render_backend.h"
+#include "ui/config/resolved_ui_document.h"
+#include "ui/focus/focus_coordinator.h"
+#include "ui/layout/layout_engine.h"
+
+namespace ui::presenter {
+
+class ScreenPresenter final {
+ public:
+  explicit ScreenPresenter(render::RenderBackend* backend, std::wstring theme = L"dark");
+
+  // Rebuilds focus and drops layout memo for the old document; the current
+  // route becomes the document's initial route.
+  void SetDocument(const config::ResolvedUiDocument* document);
+
+  const std::wstring& current_route() const { return route_; }
+  void SwitchRoute(std::wstring_view route);
+
+  // Frame-scope paint of backdrop + layout tree + focus ring.
+  void Paint(const render::Rect& content);
+
+  // VK_TAB / Shift+VK_TAB advance focus; returns true when handled.
+  bool HandleKey(int virtual_key);
+  // Click-to-focus on an id'd focusable node; true when focus moved.
+  bool HandleClick(float x, float y);
+
+  std::wstring focused() const { return focus_.Current(route_); }
+
+ private:
+  void PaintNode(const layout::LayoutNode& node);
+  bool ClickNode(const layout::LayoutNode& node, float x, float y);
+  render::Color Token(std::wstring_view name, render::Color fallback) const;
+
+  render::RenderBackend* backend_;
+  layout::LayoutEngine engine_;
+  focus::FocusCoordinator focus_;
+  const config::ResolvedUiDocument* document_ = nullptr;
+  const layout::LayoutNode* last_tree_ = nullptr;
+  std::wstring route_;
+  std::wstring theme_;
+};
+
+}  // namespace ui::presenter

--- a/src/ui/shell/app_window.cpp
+++ b/src/ui/shell/app_window.cpp
@@ -132,6 +132,19 @@ void AppWindow::set_settings_handler(std::function<void()> handler) {
   }
 }
 
+void AppWindow::set_content_painter(
+    std::function<void(render::GdiBackend&, const render::Rect&)> painter) {
+  content_painter_ = std::move(painter);
+}
+
+void AppWindow::set_content_key_handler(std::function<bool(int)> handler) {
+  content_key_handler_ = std::move(handler);
+}
+
+void AppWindow::set_content_click_handler(std::function<bool(float, float)> handler) {
+  content_click_handler_ = std::move(handler);
+}
+
 int AppWindow::ButtonCount() const {
   // Left-to-right: pin, [settings], min, max/restore, close. The gear only
   // exists while something can open — no dead button.
@@ -366,6 +379,10 @@ void AppWindow::PaintContent() {
                            render::VerticalAlign::Middle);
     }
   }
+
+  if (content_painter_) {
+    content_painter_(backend_, content);
+  }
 }
 
 void AppWindow::SetMaximized(bool maximize) {
@@ -491,7 +508,22 @@ long long AppWindow::HandleMessage(void* window_handle, unsigned int message,
       return 0;
     case WM_LBUTTONUP: {
       const int button = ButtonAt(GET_X_LPARAM(lparam), GET_Y_LPARAM(lparam));
-      if (button < 0) return 0;
+      if (button < 0) {
+        if (content_click_handler_) {
+          const int x_px = GET_X_LPARAM(lparam);
+          const int y_px = GET_Y_LPARAM(lparam);
+          const int margin = maximized_ ? 0 : Px(kShadowMargin);
+          RECT client{};
+          GetClientRect(window, &client);
+          if (x_px >= margin && y_px >= margin && x_px < client.right - margin &&
+              y_px < client.bottom - margin) {
+            if (content_click_handler_(Logical(x_px - margin), Logical(y_px - margin))) {
+              RenderFullFrame();
+            }
+          }
+        }
+        return 0;
+      }
       const int role = (ButtonCount() - 1) - button;  // 0 close … leftmost pin
       const bool is_pin = role == 4 || (role == 3 && !settings_handler_);
       if (role == 0) {
@@ -506,6 +538,14 @@ long long AppWindow::HandleMessage(void* window_handle, unsigned int message,
         settings_handler_();
       }
       return 0;
+    }
+    case WM_KEYDOWN: {
+      if (content_key_handler_ && content_key_handler_(static_cast<int>(wparam))) {
+        RenderFullFrame();
+        return 0;
+      }
+      return DefWindowProcW(window, message, static_cast<WPARAM>(wparam),
+                            static_cast<LPARAM>(lparam));
     }
     case WM_GETMINMAXINFO: {
       const LRESULT result =

--- a/src/ui/shell/app_window.h
+++ b/src/ui/shell/app_window.h
@@ -97,6 +97,15 @@ class AppWindow final {
   // dead UI. Registering a handler adds the button.
   void set_settings_handler(std::function<void()> handler);
 
+  // Content integration (#71): the shell paints its frame and delegates the
+  // content area to a presenter. The painter runs inside the frame scope,
+  // after the chrome. Key/click handlers get first chance for clicks inside
+  // the content area and for WM_KEYDOWN; returning true means "handled,
+  // repaint". Unset hooks cost nothing.
+  void set_content_painter(std::function<void(render::GdiBackend&, const render::Rect&)> painter);
+  void set_content_key_handler(std::function<bool(int virtual_key)> handler);
+  void set_content_click_handler(std::function<bool(float x_logical, float y_logical)> handler);
+
  private:
   static long long __stdcall WindowProc(void* window, unsigned int message,
                                         unsigned long long wparam, long long lparam);
@@ -124,6 +133,9 @@ class AppWindow final {
   std::function<void(std::uint32_t)> signal_handler_;
   std::function<void()> settle_handler_;
   std::function<void()> settings_handler_;
+  std::function<void(render::GdiBackend&, const render::Rect&)> content_painter_;
+  std::function<bool(int)> content_key_handler_;
+  std::function<bool(float, float)> content_click_handler_;
   std::uint32_t last_os_signals_ = 0;
   unsigned int drain_message_ = 0;
   float dpi_ = 96.0f;

--- a/tests/dhepz_tests.vcxproj
+++ b/tests/dhepz_tests.vcxproj
@@ -125,6 +125,7 @@
     <ClCompile Include="..\src\ui\config\**\*.cpp" />
     <ClCompile Include="..\src\ui\focus\**\*.cpp" />
     <ClCompile Include="..\src\ui\layout\**\*.cpp" />
+    <ClCompile Include="..\src\ui\presenter\**\*.cpp" />
     <ClCompile Include="..\src\ui\shell\**\*.cpp" />
     <ClCompile Include="..\src\ui\theme\**\*.cpp" />
     <ClInclude Include="**\*.h" />

--- a/tests/platform/worker_test.cpp
+++ b/tests/platform/worker_test.cpp
@@ -242,10 +242,21 @@ DHEPZ_TEST(Worker, SequentialJobsLeaveTheHandleCountFlat) {
   Rig rig;
   worker::Worker worker(rig.hwnd, rig.state.completion_message);
   const HANDLE process = GetCurrentProcess();
+
+  // Warm-up first: thread creation at the start of the test is stabilisation,
+  // not leakage, and machine noise there flaked the measurement.
+  for (int i = 0; i < 100; ++i) {
+    worker.Submit(
+        [](const std::atomic<bool>&) { return MakeInt(1); },
+        [&](std::shared_ptr<void> cargo) { rig.state.delivered.push_back(std::move(cargo)); });
+    PumpUntil([&] { return rig.state.delivered.size() == static_cast<std::size_t>(i + 1); }, 5000);
+  }
+  worker.JoinFinished();
+
   DWORD handles_before = 0;
   GetProcessHandleCount(process, &handles_before);
 
-  for (int i = 0; i < 1000; ++i) {
+  for (int i = 100; i < 1000; ++i) {
     worker.Submit(
         [](const std::atomic<bool>&) { return MakeInt(1); },
         [&](std::shared_ptr<void> cargo) { rig.state.delivered.push_back(std::move(cargo)); });

--- a/tests/ui/presenter/screen_presenter_test.cpp
+++ b/tests/ui/presenter/screen_presenter_test.cpp
@@ -1,0 +1,176 @@
+#include "ui/presenter/screen_presenter.h"
+
+#include <string>
+#include <vector>
+
+#include "framework/test_case.h"
+
+namespace {
+
+// Records call order so the z-order (backdrop before content) is assertable.
+class RecordingBackend final : public render::RenderBackend {
+ public:
+  void Resize(render::Size) override {}
+  void SetDpi(float) override {}
+  float dpi() const override { return 96.0f; }
+  render::Size surface_size() const override { return {}; }
+  void BeginFrame(const render::Rect&) override {}
+  void EndFrame() override {}
+  void Present(void*) override {}
+  void Invalidate(const render::Rect&) override {}
+  void InvalidateAll() override {}
+  bool HasInvalidation() const override { return false; }
+  bool TakeInvalidation(render::Rect&) override { return false; }
+  render::ImageHandle LoadImageFile(std::wstring_view) override {
+    return render::ImageHandle::Invalid;
+  }
+  void ReleaseImage(render::ImageHandle) override {}
+  render::Size MeasureText(std::wstring_view, const render::TextStyle&, float) override {
+    return {100.0f, 20.0f};
+  }
+  void FillRect(const render::Rect&, render::Color) override { calls.push_back(L"fill"); }
+  void StrokeRect(const render::Rect&, render::Color, float) override {
+    calls.push_back(L"ring");
+  }
+  void FillRoundedRect(const render::Rect&, const render::CornerRadius&, render::Color) override {
+    calls.push_back(L"button");
+  }
+  void StrokeRoundedRect(const render::Rect&, const render::CornerRadius&, render::Color,
+                         float) override {}
+  void DrawTextRun(std::wstring_view text, const render::Rect&, const render::TextStyle&,
+                   render::Color, render::TextAlign, render::VerticalAlign) override {
+    calls.push_back(L"text:" + std::wstring(text));
+  }
+  void DrawImage(render::ImageHandle, const render::Rect&, float) override {}
+  void PushClip(const render::Rect&) override {}
+  void PopClip() override {}
+  void PushTranslation(render::Point) override {}
+  void PopTranslation() override {}
+
+  std::vector<std::wstring> calls;
+};
+
+std::wstring W(const char* utf8) {
+  std::wstring wide;
+  for (const char* p = utf8; *p != '\0'; ++p) {
+    wide.push_back(static_cast<wchar_t>(static_cast<unsigned char>(*p)));
+  }
+  return wide;
+}
+
+const char* kCore = R"({
+  "schema": "dhepz.ui.core",
+  "version": 1,
+  "tokens": {
+    "dark": { "accent": "#60A5FA", "surfaceAlt": "#232730", "border": "#303540",
+              "text": "#E9EDF4", "window": "#14161B" },
+    "light": { "accent": "#2563EB", "surfaceAlt": "#F0F2F6", "border": "#D8DCE3",
+               "text": "#181C24", "window": "#F5F6F9" }
+  },
+  "common": { "properties": { "id": { "kind": "string" } } },
+  "allows_children": ["screen", "container"],
+  "components": {
+    "screen": { "properties": {
+      "route_id": { "kind": "string", "required": true },
+      "backdrop": { "kind": "string" } } },
+    "container": { "properties": { "gap": { "kind": "int", "default": 8 } } },
+    "text": { "properties": { "text": { "kind": "text", "required": true } } },
+    "button": { "properties": {
+      "label": { "kind": "text", "required": true },
+      "tab_stop": { "kind": "bool", "default": true } } }
+  }
+})";
+
+const char* kScreens = R"({
+  "components": [
+    { "type": "screen", "route_id": "home", "backdrop": "window", "children": [
+      { "type": "container", "children": [
+        { "type": "text", "text": "hello" },
+        { "type": "button", "id": "go", "label": "Go" }
+      ] }
+    ] },
+    { "type": "screen", "route_id": "other", "children": [
+      { "type": "text", "text": "second" }
+    ] }
+  ]
+})";
+
+std::unique_ptr<ui::config::ResolvedUiDocument> Resolve() {
+  json::Value core;
+  DHEPZ_CHECK(json::Parse(W(kCore), &core).ok());
+  std::vector<ui::config::Diagnostic> diagnostics;
+  std::unique_ptr<ui::config::ResolvedUiDocument> document;
+  DHEPZ_CHECK(ui::config::ResolveDocument(core, {{L"embedded", W(kScreens)}}, &diagnostics,
+                                          &document)
+                  .ok());
+  return document;
+}
+
+}  // namespace
+
+DHEPZ_TEST(ScreenPresenter, PaintsBackdropFirstThenContent) {
+  RecordingBackend backend;
+  ui::presenter::ScreenPresenter presenter(&backend);
+  const auto document = Resolve();
+  presenter.SetDocument(document.get());
+
+  presenter.Paint({24.0f, 24.0f, 400.0f, 300.0f});
+
+  DHEPZ_CHECK(!backend.calls.empty());
+  DHEPZ_CHECK_EQ(backend.calls[0], std::wstring(L"fill"));  // backdrop window token
+  bool saw_text = false;
+  bool saw_button = false;
+  for (const auto& call : backend.calls) {
+    if (call == L"text:hello") saw_text = true;
+    if (call == L"button") saw_button = true;
+  }
+  DHEPZ_CHECK(saw_text);
+  DHEPZ_CHECK(saw_button);
+}
+
+DHEPZ_TEST(ScreenPresenter, TabAdvancesFocusAndDrawsTheRing) {
+  RecordingBackend backend;
+  ui::presenter::ScreenPresenter presenter(&backend);
+  const auto document = Resolve();
+  presenter.SetDocument(document.get());
+  presenter.Paint({0.0f, 0.0f, 400.0f, 300.0f});
+
+  DHEPZ_CHECK(presenter.HandleKey(0x09));  // VK_TAB
+  DHEPZ_CHECK_EQ(presenter.focused(), std::wstring(L"go"));
+
+  backend.calls.clear();
+  presenter.Paint({0.0f, 0.0f, 400.0f, 300.0f});
+  bool saw_ring = false;
+  for (const auto& call : backend.calls) {
+    if (call == L"ring") saw_ring = true;
+  }
+  DHEPZ_CHECK(saw_ring);
+}
+
+DHEPZ_TEST(ScreenPresenter, ClickFocusesTheHitButton) {
+  RecordingBackend backend;
+  ui::presenter::ScreenPresenter presenter(&backend);
+  const auto document = Resolve();
+  presenter.SetDocument(document.get());
+  presenter.Paint({0.0f, 0.0f, 400.0f, 300.0f});
+
+  // Button sits below the text row: container column, gap 8, text 20 high.
+  DHEPZ_CHECK(presenter.HandleClick(50.0f, 40.0f));
+  DHEPZ_CHECK_EQ(presenter.focused(), std::wstring(L"go"));
+}
+
+DHEPZ_TEST(ScreenPresenter, RouteSwitchChangesTheDrawSet) {
+  RecordingBackend backend;
+  ui::presenter::ScreenPresenter presenter(&backend);
+  const auto document = Resolve();
+  presenter.SetDocument(document.get());
+
+  presenter.SwitchRoute(L"other");
+  DHEPZ_CHECK_EQ(presenter.current_route(), std::wstring(L"other"));
+  presenter.Paint({0.0f, 0.0f, 400.0f, 300.0f});
+  bool saw_second = false;
+  for (const auto& call : backend.calls) {
+    if (call == L"text:second") saw_second = true;
+  }
+  DHEPZ_CHECK(saw_second);
+}


### PR DESCRIPTION
Issue #71. Shell hooks (content painter + key/click forwarders) keep the window UI-agnostic; ScreenPresenter paints backdrop-first then the cached layout tree with a focus ring, Tab/Shift+Tab traversal and click-to-focus. Action dispatch inert until Phase 3 (recorded on the issue). Tests: backdrop-before-content call order, ring after Tab, click focuses the hit button, route switch changes the draw set. Worker handle test de-flaked with a warm-up before the drift window. Visual: the demo renders the repo's home.json interactively.