### PR TITLE
fix(ui): layout outside the paint scope; Prepare/Paint split (#59)

### DIFF
--- a/src/ui/layout/backdrop.cpp
+++ b/src/ui/layout/backdrop.cpp
@@ -27,6 +27,10 @@ PaintPlan MakePaintPlan(const config::ResolvedUiDocument& document, std::wstring
   return plan;
 }
 
+void PaintBackdropTree(render::RenderBackend* backend, const LayoutNode& tree) {
+  PaintTree(backend, tree);
+}
+
 void PaintBackdrop(render::RenderBackend* backend, LayoutEngine* engine,
                    const config::ResolvedUiDocument& document, std::wstring_view route,
                    render::Size size, std::wstring_view theme, const ListModel* model) {

--- a/src/ui/layout/backdrop.h
+++ b/src/ui/layout/backdrop.h
@@ -32,4 +32,8 @@ void PaintBackdrop(render::RenderBackend* backend, LayoutEngine* engine,
                    const config::ResolvedUiDocument& document, std::wstring_view route,
                    render::Size size, std::wstring_view theme, const ListModel* model);
 
+// Draw-only variant for a screen backdrop: paints `tree` (laid out by the
+// caller outside the frame scope). No measurement happens here.
+void PaintBackdropTree(render::RenderBackend* backend, const LayoutNode& tree);
+
 }  // namespace ui::layout

--- a/src/ui/presenter/screen_presenter.cpp
+++ b/src/ui/presenter/screen_presenter.cpp
@@ -33,15 +33,50 @@ render::Color ScreenPresenter::Token(std::wstring_view name, render::Color fallb
   return fallback;
 }
 
-void ScreenPresenter::Paint(const render::Rect& content) {
+void ScreenPresenter::Prepare(const render::Rect& content) {
   if (document_ == nullptr || route_.empty()) return;
   const render::Size size{content.width, content.height};
+  const config::Route* route = document_->FindRoute(route_);
+  backdrop_tree_ = nullptr;
+  if (route != nullptr &&
+      route->backdrop_kind == config::Route::BackdropKind::Screen) {
+    backdrop_tree_ =
+        &engine_.LayoutRoute(*document_, route->backdrop_value, size, nullptr);
+  }
+  last_tree_ = &engine_.LayoutRoute(*document_, route_, size, nullptr);
+  plan_ = layout::MakePaintPlan(*document_, route_);
+}
+
+void ScreenPresenter::Paint(const render::Rect& content) {
+  if (document_ == nullptr || last_tree_ == nullptr) return;
 
   backend_->PushTranslation({content.x, content.y});
-  layout::PaintBackdrop(backend_, &engine_, *document_, route_, size, theme_, nullptr);
-  const layout::LayoutNode& tree = engine_.LayoutRoute(*document_, route_, size, nullptr);
-  last_tree_ = &tree;
-  PaintNode(tree);
+  switch (plan_.kind) {
+    case config::Route::BackdropKind::Color: {
+      config::Rgba rgba{};
+      if (document_->Token(theme_, plan_.value, &rgba)) {
+        backend_->FillRect({0.0f, 0.0f, content.width, content.height},
+                           render::Color{rgba.r, rgba.g, rgba.b, rgba.a});
+      }
+      break;
+    }
+    case config::Route::BackdropKind::Image: {
+      const render::ImageHandle image = backend_->LoadImageFile(plan_.value);
+      if (image != render::ImageHandle::Invalid) {
+        backend_->DrawImage(image, {0.0f, 0.0f, content.width, content.height}, 1.0f);
+        backend_->ReleaseImage(image);
+      }
+      break;
+    }
+    case config::Route::BackdropKind::Screen:
+      if (backdrop_tree_ != nullptr) {
+        layout::PaintBackdropTree(backend_, *backdrop_tree_);
+      }
+      break;
+    case config::Route::BackdropKind::None:
+      break;
+  }
+  PaintNode(*last_tree_);
   backend_->PopTranslation();
 }
 

--- a/src/ui/presenter/screen_presenter.h
+++ b/src/ui/presenter/screen_presenter.h
@@ -13,6 +13,7 @@
 #include "render/render_backend.h"
 #include "ui/config/resolved_ui_document.h"
 #include "ui/focus/focus_coordinator.h"
+#include "ui/layout/backdrop.h"
 #include "ui/layout/layout_engine.h"
 
 namespace ui::presenter {
@@ -28,7 +29,10 @@ class ScreenPresenter final {
   const std::wstring& current_route() const { return route_; }
   void SwitchRoute(std::wstring_view route);
 
-  // Frame-scope paint of backdrop + layout tree + focus ring.
+  // Measurement pass: layout the route (and a screen backdrop) OUTSIDE the
+  // paint scope. The shell calls this before BeginFrame.
+  void Prepare(const render::Rect& content);
+  // Draw pass: paints the cached trees inside the frame scope.
   void Paint(const render::Rect& content);
 
   // VK_TAB / Shift+VK_TAB advance focus; returns true when handled.
@@ -48,6 +52,8 @@ class ScreenPresenter final {
   focus::FocusCoordinator focus_;
   const config::ResolvedUiDocument* document_ = nullptr;
   const layout::LayoutNode* last_tree_ = nullptr;
+  const layout::LayoutNode* backdrop_tree_ = nullptr;
+  layout::PaintPlan plan_;
   std::wstring route_;
   std::wstring theme_;
 };

--- a/src/ui/shell/app_window.cpp
+++ b/src/ui/shell/app_window.cpp
@@ -137,6 +137,10 @@ void AppWindow::set_content_painter(
   content_painter_ = std::move(painter);
 }
 
+void AppWindow::set_content_layout(std::function<void(const render::Rect&)> layout) {
+  content_layout_ = std::move(layout);
+}
+
 void AppWindow::set_content_key_handler(std::function<bool(int)> handler) {
   content_key_handler_ = std::move(handler);
 }
@@ -302,6 +306,12 @@ void AppWindow::RenderFullFrame() {
   if (!backend_.TakeInvalidation(dirty)) {
     backend_.InvalidateAll();
     backend_.TakeInvalidation(dirty);
+  }
+  if (content_layout_) {
+    const float width = backend_.surface_size().width;
+    const float height = backend_.surface_size().height;
+    const float margin = maximized_ ? 0.0f : kShadowMargin;
+    content_layout_({margin, margin, width - margin * 2, height - margin * 2});
   }
   backend_.BeginFrame(dirty);
   PaintContent();

--- a/src/ui/shell/app_window.h
+++ b/src/ui/shell/app_window.h
@@ -103,6 +103,10 @@ class AppWindow final {
   // the content area and for WM_KEYDOWN; returning true means "handled,
   // repaint". Unset hooks cost nothing.
   void set_content_painter(std::function<void(render::GdiBackend&, const render::Rect&)> painter);
+  // Runs before BeginFrame with the content rect: measurement (layout) must
+  // happen outside the paint scope — the backend refuses font creation
+  // inside a frame. Unset costs nothing.
+  void set_content_layout(std::function<void(const render::Rect&)> layout);
   void set_content_key_handler(std::function<bool(int virtual_key)> handler);
   void set_content_click_handler(std::function<bool(float x_logical, float y_logical)> handler);
 
@@ -134,6 +138,7 @@ class AppWindow final {
   std::function<void()> settle_handler_;
   std::function<void()> settings_handler_;
   std::function<void(render::GdiBackend&, const render::Rect&)> content_painter_;
+  std::function<void(const render::Rect&)> content_layout_;
   std::function<bool(int)> content_key_handler_;
   std::function<bool(float, float)> content_click_handler_;
   std::uint32_t last_os_signals_ = 0;

--- a/tests/ui/presenter/input_to_paint_test.cpp
+++ b/tests/ui/presenter/input_to_paint_test.cpp
@@ -89,6 +89,8 @@ DHEPZ_TEST(GatePhase2, InputToPaintWithinBudget) {
   window.set_content_painter([](render::GdiBackend&, const render::Rect& content) {
     presenter.Paint(content);
   });
+  window.set_content_layout(
+      [](const render::Rect& content) { presenter.Prepare(content); });
   window.set_content_key_handler([](int vk) { return presenter.HandleKey(vk); });
   window.Show();
   PumpFor(50);

--- a/tests/ui/presenter/screen_presenter_test.cpp
+++ b/tests/ui/presenter/screen_presenter_test.cpp
@@ -114,6 +114,7 @@ DHEPZ_TEST(ScreenPresenter, PaintsBackdropFirstThenContent) {
   const auto document = Resolve();
   presenter.SetDocument(document.get());
 
+  presenter.Prepare({24.0f, 24.0f, 400.0f, 300.0f});
   presenter.Paint({24.0f, 24.0f, 400.0f, 300.0f});
 
   DHEPZ_CHECK(!backend.calls.empty());
@@ -133,12 +134,14 @@ DHEPZ_TEST(ScreenPresenter, TabAdvancesFocusAndDrawsTheRing) {
   ui::presenter::ScreenPresenter presenter(&backend);
   const auto document = Resolve();
   presenter.SetDocument(document.get());
+  presenter.Prepare({0.0f, 0.0f, 400.0f, 300.0f});
   presenter.Paint({0.0f, 0.0f, 400.0f, 300.0f});
 
   DHEPZ_CHECK(presenter.HandleKey(0x09));  // VK_TAB
   DHEPZ_CHECK_EQ(presenter.focused(), std::wstring(L"go"));
 
   backend.calls.clear();
+  presenter.Prepare({0.0f, 0.0f, 400.0f, 300.0f});
   presenter.Paint({0.0f, 0.0f, 400.0f, 300.0f});
   bool saw_ring = false;
   for (const auto& call : backend.calls) {
@@ -152,6 +155,7 @@ DHEPZ_TEST(ScreenPresenter, ClickFocusesTheHitButton) {
   ui::presenter::ScreenPresenter presenter(&backend);
   const auto document = Resolve();
   presenter.SetDocument(document.get());
+  presenter.Prepare({0.0f, 0.0f, 400.0f, 300.0f});
   presenter.Paint({0.0f, 0.0f, 400.0f, 300.0f});
 
   // Button sits below the text row: container column, gap 8, text 20 high.
@@ -167,6 +171,7 @@ DHEPZ_TEST(ScreenPresenter, RouteSwitchChangesTheDrawSet) {
 
   presenter.SwitchRoute(L"other");
   DHEPZ_CHECK_EQ(presenter.current_route(), std::wstring(L"other"));
+  presenter.Prepare({0.0f, 0.0f, 400.0f, 300.0f});
   presenter.Paint({0.0f, 0.0f, 400.0f, 300.0f});
   bool saw_second = false;
   for (const auto& call : backend.calls) {


### PR DESCRIPTION
The #71 integration measured text inside the frame scope; the backend's paint-scope guard (#17) refuses font creation there, so the demo rendered zero-size components. Shell gains a content layout hook invoked before BeginFrame; ScreenPresenter splits into Prepare (measurement, cached trees) and Paint (draw-only). Backdrop adds PaintBackdropTree. Suite green both configs; demo now renders home.json correctly.