### PR TITLE
fix(ui): rounded focus ring; distinct home heading (#59)

### DIFF
--- a/assets/ui/screens/home.json
+++ b/assets/ui/screens/home.json
@@ -12,7 +12,7 @@
           "gap": 12,
           "padding": { "left": 24, "top": 24, "right": 24, "bottom": 24 },
           "children": [
-            { "type": "text", "text": "dhepz", "variant": "title" },
+            { "type": "text", "text": "Welcome", "variant": "title" },
             { "type": "button", "label": "Open terminal" }
           ]
         }

--- a/src/ui/presenter/screen_presenter.cpp
+++ b/src/ui/presenter/screen_presenter.cpp
@@ -178,7 +178,8 @@ void ScreenPresenter::PaintNode(const layout::LayoutNode& node) {
     if (source == focused_node_) {
       const render::Rect ring{node.bounds.x - 2.0f, node.bounds.y - 2.0f,
                               node.bounds.width + 4.0f, node.bounds.height + 4.0f};
-      backend_->StrokeRect(ring, Token(L"accent", {96, 165, 250, 255}), 2.0f);
+      backend_->StrokeRoundedRect(ring, render::CornerRadius::Uniform(8.0f),
+                                  Token(L"accent", {96, 165, 250, 255}), 2.0f);
     }
   }
   for (const layout::LayoutNode& child : node.children) {

--- a/tests/ui/presenter/screen_presenter_test.cpp
+++ b/tests/ui/presenter/screen_presenter_test.cpp
@@ -37,7 +37,9 @@ class RecordingBackend final : public render::RenderBackend {
     fills.push_back({rect, color});
   }
   void StrokeRoundedRect(const render::Rect&, const render::CornerRadius&, render::Color,
-                         float) override {}
+                         float stroke_width) override {
+    if (stroke_width >= 2.0f) calls.push_back(L"ring");
+  }
   void DrawTextRun(std::wstring_view text, const render::Rect&, const render::TextStyle&,
                    render::Color, render::TextAlign, render::VerticalAlign) override {
     calls.push_back(L"text:" + std::wstring(text));


### PR DESCRIPTION
Focus ring now StrokeRoundedRect matching the button radius; home.json heading changed to 'Welcome' so the content no longer duplicates the window caption.