### PR TITLE
ui: drop the welcome heading; home keeps only the action

### DIFF
--- a/assets/ui/screens/home.json
+++ b/assets/ui/screens/home.json
@@ -12,7 +12,6 @@
           "gap": 12,
           "padding": { "left": 24, "top": 24, "right": 24, "bottom": 24 },
           "children": [
-            { "type": "text", "text": "Welcome", "variant": "title" },
             { "type": "button", "label": "Open terminal" }
           ]
         }


### PR DESCRIPTION
User space optimization: the sample screen keeps only its action button. Tab feature work tracked in #77.