### PR TITLE
feat(ui): interactive shell — tab strip, tab-state buttons, MDL2 caption (#71)

### DIFF
--- a/assets/ui/screens/demo1.json
+++ b/assets/ui/screens/demo1.json
@@ -1,0 +1,13 @@
+{
+  "components": [
+    {
+      "type": "screen",
+      "route_id": "demo-1",
+      "tab_label": "Demo 1",
+      "backdrop": "success",
+      "children": [
+        { "type": "text", "text": "Demo one", "variant": "title" }
+      ]
+    }
+  ]
+}

--- a/assets/ui/screens/demo2.json
+++ b/assets/ui/screens/demo2.json
@@ -1,0 +1,13 @@
+{
+  "components": [
+    {
+      "type": "screen",
+      "route_id": "demo-2",
+      "tab_label": "Demo 2",
+      "backdrop": "danger",
+      "children": [
+        { "type": "text", "text": "Demo two", "variant": "title" }
+      ]
+    }
+  ]
+}

--- a/assets/ui/screens/home.json
+++ b/assets/ui/screens/home.json
@@ -1,9 +1,14 @@
 {
   "components": [
     {
+      "type": "window",
+      "title": "dhepz",
+      "initial_route": "home"
+    },
+    {
       "type": "screen",
       "route_id": "home",
-      "tab_label": "Home",
+      "tab_label": "Open terminal",
       "show_in_tabs": true,
       "children": [
         {

--- a/src/ui/presenter/screen_presenter.cpp
+++ b/src/ui/presenter/screen_presenter.cpp
@@ -160,17 +160,24 @@ void ScreenPresenter::PaintNode(const layout::LayoutNode& node) {
                             Token(L"text", {255, 255, 255, 255}), render::TextAlign::Left,
                             render::VerticalAlign::Top);
     } else if (type == L"button") {
+      // Tab-state model: idle shows only a gray outline; hover brightens the
+      // outline; press bumps; selected switches to the accent plus a tint.
       render::Rect box = node.bounds;
-      render::Color fill = Token(L"surfaceAlt", {35, 39, 48, 255});
-      if (source == pressed_node_) {
-        fill = Shade(fill, -14);
-        box.y += 1.0f;  // the bump
+      const bool selected = source->GetBool(L"selected");
+      render::Color outline = Token(L"borderStrong", {70, 76, 88, 255});
+      if (selected) {
+        outline = Token(L"accent", {96, 165, 250, 255});
+        render::Color tint = outline;
+        tint.a = 40;
+        backend_->FillRoundedRect(box, render::CornerRadius::Uniform(6.0f), tint);
       } else if (source == hover_node_) {
-        fill = Shade(fill, +14);
+        outline = Shade(outline, +40);
       }
-      backend_->FillRoundedRect(box, render::CornerRadius::Uniform(6.0f), fill);
-      backend_->StrokeRoundedRect(box, render::CornerRadius::Uniform(6.0f),
-                                  Token(L"border", {48, 53, 64, 255}), 1.0f);
+      if (source == pressed_node_) {
+        outline = Shade(outline, -20);
+        box.y += 1.0f;  // the bump
+      }
+      backend_->StrokeRoundedRect(box, render::CornerRadius::Uniform(6.0f), outline, 1.0f);
       backend_->DrawTextRun(source->GetString(L"label"), box, render::TextStyle{},
                             Token(L"text", {255, 255, 255, 255}), render::TextAlign::Center,
                             render::VerticalAlign::Middle);

--- a/src/ui/presenter/screen_presenter.cpp
+++ b/src/ui/presenter/screen_presenter.cpp
@@ -25,6 +25,16 @@ render::TextStyle ScreenPresenter::StyleForText(const config::ComponentNode& nod
   return style;
 }
 
+namespace {
+render::Color Shade(render::Color color, int delta) {
+  auto clamp = [](int value) {
+    return static_cast<unsigned char>(value < 0 ? 0 : (value > 255 ? 255 : value));
+  };
+  return render::Color{clamp(color.r + delta), clamp(color.g + delta),
+                       clamp(color.b + delta), color.a};
+}
+}  // namespace
+
 void ScreenPresenter::SetDocument(const config::ResolvedUiDocument* document) {
   document_ = document;
   focus_.SetDocument(document);
@@ -51,7 +61,24 @@ render::Color ScreenPresenter::Token(std::wstring_view name, render::Color fallb
 
 void ScreenPresenter::Prepare(const render::Rect& content) {
   if (document_ == nullptr || route_.empty()) return;
-  const render::Size size{content.width, content.height};
+
+  // Tab strip: one tab per route that shows in tabs, anchored left.
+  tab_rects_.clear();
+  tab_routes_.clear();
+  tab_labels_.clear();
+  float cursor_x = 12.0f;  // left padding: tabs never touch the border
+  for (const config::Route& route : document_->routes()) {
+    if (!route.show_in_tabs) continue;
+    const std::wstring label = route.tab_label.empty() ? route.id : route.tab_label;
+    const render::Size size = backend_->MeasureText(label, render::TextStyle{}, 0.0f);
+    tab_rects_.push_back({cursor_x, caption_height_, size.width + 20.0f, 28.0f});
+    tab_routes_.push_back(route.id);
+    tab_labels_.push_back(label);
+    cursor_x += size.width + 28.0f;
+  }
+  tab_strip_height_ = tab_rects_.empty() ? 0.0f : caption_height_ + 36.0f;
+
+  const render::Size size{content.width, content.height - tab_strip_height_};
   const config::Route* route = document_->FindRoute(route_);
   backdrop_tree_ = nullptr;
   if (route != nullptr &&
@@ -93,8 +120,56 @@ void ScreenPresenter::Paint(const render::Rect& content) {
     case config::Route::BackdropKind::None:
       break;
   }
+  PaintTabs();
+  backend_->PopTranslation();
+
+  backend_->PushTranslation({content.x, content.y + tab_strip_height_});
   PaintNode(*last_tree_);
   backend_->PopTranslation();
+}
+
+int ScreenPresenter::TabAt(float x, float y) const {
+  for (std::size_t i = 0; i < tab_rects_.size(); ++i) {
+    if (tab_rects_[i].contains({x, y})) return static_cast<int>(i);
+  }
+  return -1;
+}
+
+bool ScreenPresenter::HitTestContent(float x, float y) const {
+  if (y >= caption_height_ && y < tab_strip_height_) return TabAt(x, y) >= 0;
+  return last_tree_ != nullptr &&
+         FindButton(*last_tree_, x, y - tab_strip_height_) != nullptr;
+}
+
+void ScreenPresenter::PaintTabs() {
+  for (std::size_t i = 0; i < tab_rects_.size(); ++i) {
+    render::Rect box = tab_rects_[i];
+    const bool selected = tab_routes_[i] == route_;
+    render::Color outline = Token(L"borderStrong", {70, 76, 88, 255});
+    const bool hovered = static_cast<int>(i) == hover_tab_;
+    if (selected) {
+      outline = Token(L"accent", {96, 165, 250, 255});
+      render::Color tint = outline;
+      tint.a = 90;
+      backend_->FillRoundedRect(box, render::CornerRadius::Uniform(6.0f), tint);
+    } else if (hovered) {
+      outline = Token(L"accent", {96, 165, 250, 255});
+    }
+    if (static_cast<int>(i) == pressed_tab_) {
+      outline = Shade(outline, -20);
+      box.y += 1.0f;
+    }
+    backend_->StrokeRoundedRect(box, render::CornerRadius::Uniform(6.0f), outline, 1.0f);
+    if (hovered) {
+      const render::Rect inner{box.x + 1.0f, box.y + 1.0f, box.width - 2.0f,
+                               box.height - 2.0f};
+      backend_->StrokeRoundedRect(inner, render::CornerRadius::Uniform(5.0f), outline,
+                                  2.0f);
+    }
+    backend_->DrawTextRun(tab_labels_[i], box, render::TextStyle{},
+                          Token(L"text", {255, 255, 255, 255}), render::TextAlign::Center,
+                          render::VerticalAlign::Middle);
+  }
 }
 
 bool ScreenPresenter::ClickNode(const layout::LayoutNode& node, float x, float y) {
@@ -126,30 +201,57 @@ const config::ComponentNode* ScreenPresenter::FindButton(const layout::LayoutNod
 }
 
 bool ScreenPresenter::HandleMove(float x, float y) {
+  bool changed = false;
+  const bool in_strip = y >= caption_height_ && y < tab_strip_height_;
+  const int tab = in_strip ? TabAt(x, y) : -1;
+  if (tab != hover_tab_) {
+    hover_tab_ = tab;
+    changed = true;
+  }
   const config::ComponentNode* hit =
-      last_tree_ != nullptr ? FindButton(*last_tree_, x, y) : nullptr;
-  if (hit == hover_node_) return false;
-  hover_node_ = hit;
-  return true;
-}
-
-bool ScreenPresenter::HandleDown(float x, float y) {
-  const config::ComponentNode* hit =
-      last_tree_ != nullptr ? FindButton(*last_tree_, x, y) : nullptr;
-  const bool changed = hit != pressed_node_;
-  pressed_node_ = hit;
+      (!in_strip && last_tree_ != nullptr && y >= tab_strip_height_)
+          ? FindButton(*last_tree_, x, y - tab_strip_height_)
+          : nullptr;
+  if (hit != hover_node_) {
+    hover_node_ = hit;
+    changed = true;
+  }
   return changed;
 }
 
-namespace {
-render::Color Shade(render::Color color, int delta) {
-  auto clamp = [](int value) {
-    return static_cast<unsigned char>(value < 0 ? 0 : (value > 255 ? 255 : value));
-  };
-  return render::Color{clamp(color.r + delta), clamp(color.g + delta),
-                       clamp(color.b + delta), color.a};
+bool ScreenPresenter::HandleDown(float x, float y) {
+  bool changed = false;
+  const bool in_strip = y >= caption_height_ && y < tab_strip_height_;
+  const int tab = in_strip ? TabAt(x, y) : -1;
+  if (tab != pressed_tab_) {
+    pressed_tab_ = tab;
+    changed = true;
+  }
+  const config::ComponentNode* hit =
+      (!in_strip && last_tree_ != nullptr && y >= tab_strip_height_)
+          ? FindButton(*last_tree_, x, y - tab_strip_height_)
+          : nullptr;
+  if (hit != pressed_node_) {
+    pressed_node_ = hit;
+    changed = true;
+  }
+  return changed;
 }
-}  // namespace
+
+bool ScreenPresenter::HandleClick(float x, float y) {
+  if (y >= caption_height_ && y < tab_strip_height_) {
+    const int tab = TabAt(x, y);
+    pressed_tab_ = -1;
+    if (tab >= 0 && tab_routes_[tab] != route_) {
+      SwitchRoute(tab_routes_[tab]);
+      return true;
+    }
+    return tab >= 0;
+  }
+  if (last_tree_ == nullptr) return false;
+  pressed_node_ = nullptr;
+  return ClickNode(*last_tree_, x, y - tab_strip_height_);
+}
 
 void ScreenPresenter::PaintNode(const layout::LayoutNode& node) {
   const config::ComponentNode* source = node.source;
@@ -165,19 +267,27 @@ void ScreenPresenter::PaintNode(const layout::LayoutNode& node) {
       render::Rect box = node.bounds;
       const bool selected = source->GetBool(L"selected");
       render::Color outline = Token(L"borderStrong", {70, 76, 88, 255});
+      const bool hovered = source == hover_node_;
       if (selected) {
         outline = Token(L"accent", {96, 165, 250, 255});
         render::Color tint = outline;
-        tint.a = 40;
+        tint.a = 90;
         backend_->FillRoundedRect(box, render::CornerRadius::Uniform(6.0f), tint);
-      } else if (source == hover_node_) {
-        outline = Shade(outline, +40);
+      } else if (hovered) {
+        outline = Token(L"accent", {96, 165, 250, 255});
       }
       if (source == pressed_node_) {
         outline = Shade(outline, -20);
         box.y += 1.0f;  // the bump
       }
       backend_->StrokeRoundedRect(box, render::CornerRadius::Uniform(6.0f), outline, 1.0f);
+      if (hovered) {
+        // Flush against the outer outline: no gap between the two strokes.
+        const render::Rect inner{box.x + 1.0f, box.y + 1.0f, box.width - 2.0f,
+                                 box.height - 2.0f};
+        backend_->StrokeRoundedRect(inner, render::CornerRadius::Uniform(5.0f), outline,
+                                    2.0f);
+      }
       backend_->DrawTextRun(source->GetString(L"label"), box, render::TextStyle{},
                             Token(L"text", {255, 255, 255, 255}), render::TextAlign::Center,
                             render::VerticalAlign::Middle);
@@ -198,12 +308,6 @@ bool ScreenPresenter::HandleKey(int virtual_key) {
   if (virtual_key != VK_TAB) return false;
   const bool backward = (GetKeyState(VK_SHIFT) & 0x8000) != 0;
   return !focus_.Advance(route_, backward).empty();
-}
-
-bool ScreenPresenter::HandleClick(float x, float y) {
-  if (last_tree_ == nullptr) return false;
-  pressed_node_ = nullptr;
-  return ClickNode(*last_tree_, x, y);
 }
 
 }  // namespace ui::presenter

--- a/src/ui/presenter/screen_presenter.h
+++ b/src/ui/presenter/screen_presenter.h
@@ -43,13 +43,23 @@ class ScreenPresenter final {
   // Click-to-focus on a focusable node; true when focus moved.
   bool HandleClick(float x, float y);
 
+  // The shell reserves its caption row for dragging and the main icons;
+  // the tab strip sits below it. Default 0 keeps the strip at the top.
+  void set_caption_height(float height) { caption_height_ = height; }
+
+  // True when the point (content-relative) is over interactive content —
+  // the shell uses it to keep such points out of the caption drag zone.
+  bool HitTestContent(float x, float y) const;
+
   std::wstring focused() const { return focus_.Current(route_); }
 
  private:
   void PaintNode(const layout::LayoutNode& node);
+  void PaintTabs();
   bool ClickNode(const layout::LayoutNode& node, float x, float y);
   const config::ComponentNode* FindButton(const layout::LayoutNode& node, float x,
                                           float y) const;
+  int TabAt(float x, float y) const;
   render::Color Token(std::wstring_view name, render::Color fallback) const;
   // The style a text node is measured AND painted with; keeping the two
   // identical is what warms the painted font during layout.
@@ -64,6 +74,13 @@ class ScreenPresenter final {
   const config::ComponentNode* focused_node_ = nullptr;
   const config::ComponentNode* hover_node_ = nullptr;
   const config::ComponentNode* pressed_node_ = nullptr;
+  std::vector<render::Rect> tab_rects_;
+  std::vector<std::wstring> tab_routes_;
+  std::vector<std::wstring> tab_labels_;
+  int hover_tab_ = -1;
+  int pressed_tab_ = -1;
+  float caption_height_ = 0.0f;
+  float tab_strip_height_ = 0.0f;
   layout::PaintPlan plan_;
   std::wstring route_;
   std::wstring theme_;

--- a/src/ui/shell/app_window.cpp
+++ b/src/ui/shell/app_window.cpp
@@ -31,39 +31,29 @@ constexpr render::Color kHoverNeutral{255, 255, 255, 26};
 constexpr render::Color kHoverClose{232, 17, 35, 255};
 constexpr render::Color kShadow{0, 0, 0, 255};
 
-render::TextStyle CaptionStyle() {
-  render::TextStyle style;
-  style.family = L"Segoe UI";
-  style.size_px = 13.0f;
-  style.weight = render::FontWeight::Semibold;
-  return style;
-}
-
-render::TextStyle GlyphStyle() {
-  render::TextStyle style;
-  style.family = L"Marlett";
-  style.size_px = 11.0f;
-  return style;
-}
-
-// Verified by rendering the font on the target machine; the pair is the
-// user's visual choice: unpinned is the horizontal pin outline (E718),
-// pinned the diagonal pushpin (E840). E713 is the settings gear.
+// Caption icons all come from Segoe MDL2 Assets, like pin and gear: the
+// close button is ChromeClose, not a Marlett glyph.
 constexpr wchar_t kPinGlyphUnpinned = 0xE718;  // horizontal pin outline
 constexpr wchar_t kPinGlyphPinned = 0xE840;    // diagonal pushpin
 constexpr wchar_t kGearGlyph = 0xE713;         // Settings
+constexpr wchar_t kCloseGlyph = 0xE8BB;        // ChromeClose
 
-render::TextStyle IconStyle() {
+render::TextStyle IconStyle(float size_px) {
   render::TextStyle style;
   style.family = L"Segoe MDL2 Assets";
-  style.size_px = 14.0f;
+  style.size_px = size_px;
   return style;
 }
 
-// Marlett and Segoe MDL2 Assets centre their glyphs differently; the nudges
-// put both families on one visual row (verified against a rendered strip).
+// MDL2 glyphs render at different visual sizes per codepoint; tuned so the
+// row reads even: horizontal pin 22, diagonal pin 19, gear 16, close 14.
+constexpr float kPinUnpinnedSize = 22.0f;
+constexpr float kPinPinnedSize = 19.0f;
+constexpr float kGearSize = 16.0f;
+constexpr float kCloseSize = 14.0f;
+
+// MDL2 glyphs centre slightly low at these sizes; nudge them onto the row.
 constexpr float kIconNudgeY = 2.0f;
-constexpr float kMarlettNudgeY = -2.0f;
 
 }  // namespace
 
@@ -98,8 +88,6 @@ bool AppWindow::Create(void* instance, float content_width, float content_height
   if (hwnd_ == nullptr) {
     return false;
   }
-  restored_width_px_ = width;
-  restored_height_px_ = height;
 
   drain_message_ = RegisterWindowMessageW(L"dhepz.signal.drain");
   signals_ = std::make_unique<platform::SignalFanout>(
@@ -157,10 +145,14 @@ void AppWindow::set_content_down_handler(std::function<bool(float, float)> handl
   content_down_handler_ = std::move(handler);
 }
 
+void AppWindow::set_content_hittest_handler(std::function<bool(float, float)> handler) {
+  content_hittest_handler_ = std::move(handler);
+}
+
 int AppWindow::ButtonCount() const {
-  // Left-to-right: pin, [settings], min, max/restore, close. The gear only
-  // exists while something can open — no dead button.
-  return settings_handler_ ? 5 : 4;
+  // Left-to-right: pin, [settings], close. Minimise/maximise arrive later
+  // as a user toggle; the window is already resizable.
+  return settings_handler_ ? 3 : 2;
 }
 
 void AppWindow::Show() {
@@ -239,7 +231,7 @@ int AppWindow::ButtonAt(int x_px, int y_px) const {
   if (hwnd_ == nullptr) return -1;
   RECT client{};
   GetClientRect(static_cast<HWND>(hwnd_), &client);
-  const int margin = maximized_ ? 0 : Px(kShadowMargin);
+  const int margin = maximized() ? 0 : Px(kShadowMargin);
   const int content_left = margin;
   const int content_right = client.right - margin;
   const int caption_bottom = margin + Px(kCaptionHeight);
@@ -260,7 +252,7 @@ int AppWindow::HitTest(int x_px, int y_px) const {
   RECT client{};
   GetClientRect(static_cast<HWND>(hwnd_), &client);
 
-  const int margin = maximized_ ? 0 : Px(kShadowMargin);
+  const int margin = maximized() ? 0 : Px(kShadowMargin);
   const int content_left = margin;
   const int content_top = margin;
   const int content_right = client.right - margin;
@@ -278,7 +270,7 @@ int AppWindow::HitTest(int x_px, int y_px) const {
   const bool top = y_px < content_top + border;
   const bool bottom = y_px >= content_bottom - border;
 
-  if (!maximized_) {
+  if (!maximized()) {
     if (top && left) return HTTOPLEFT;
     if (top && right) return HTTOPRIGHT;
     if (bottom && left) return HTBOTTOMLEFT;
@@ -290,7 +282,13 @@ int AppWindow::HitTest(int x_px, int y_px) const {
   }
 
   if (ButtonAt(x_px, y_px) >= 0) return HTCLIENT;
-  if (y_px < content_top + Px(kCaptionHeight)) return HTCAPTION;
+  if (y_px < content_top + Px(kCaptionHeight)) {
+    if (content_hittest_handler_ &&
+        content_hittest_handler_(Logical(x_px - margin), Logical(y_px - margin))) {
+      return HTCLIENT;
+    }
+    return HTCAPTION;
+  }
   return HTCLIENT;
 }
 
@@ -299,15 +297,11 @@ void AppWindow::RenderFullFrame() {
 
   // Warm the fonts OUTSIDE the frame: creation inside a paint scope is
   // refused by design.
-  const render::TextStyle caption = CaptionStyle();
-  const render::TextStyle glyph = GlyphStyle();
-  const render::TextStyle icon = IconStyle();
-  backend_.MeasureText(title_, caption, 0.0f);
-  backend_.MeasureText(L"0", glyph, 0.0f);
-  backend_.MeasureText(std::wstring(1, kPinGlyphUnpinned), icon, 0.0f);
-  backend_.MeasureText(std::wstring(1, kPinGlyphPinned), icon, 0.0f);
+  backend_.MeasureText(std::wstring(1, kPinGlyphUnpinned), IconStyle(kPinUnpinnedSize), 0.0f);
+  backend_.MeasureText(std::wstring(1, kPinGlyphPinned), IconStyle(kPinPinnedSize), 0.0f);
+  backend_.MeasureText(std::wstring(1, kCloseGlyph), IconStyle(kCloseSize), 0.0f);
   if (settings_handler_) {
-    backend_.MeasureText(std::wstring(1, kGearGlyph), icon, 0.0f);
+    backend_.MeasureText(std::wstring(1, kGearGlyph), IconStyle(kGearSize), 0.0f);
   }
 
   render::Rect dirty{};
@@ -318,7 +312,7 @@ void AppWindow::RenderFullFrame() {
   if (content_layout_) {
     const float width = backend_.surface_size().width;
     const float height = backend_.surface_size().height;
-    const float margin = maximized_ ? 0.0f : kShadowMargin;
+    const float margin = maximized() ? 0.0f : kShadowMargin;
     content_layout_({margin, margin, width - margin * 2, height - margin * 2});
   }
   backend_.BeginFrame(dirty);
@@ -332,13 +326,13 @@ void AppWindow::PaintContent() {
 
   const float width = backend_.surface_size().width;
   const float height = backend_.surface_size().height;
-  const float margin = maximized_ ? 0.0f : kShadowMargin;
-  const float radius = maximized_ ? 0.0f : kCornerRadius;
+  const float margin = maximized() ? 0.0f : kShadowMargin;
+  const float radius = maximized() ? 0.0f : kCornerRadius;
   const render::Rect content{margin, margin, width - margin * 2, height - margin * 2};
 
   // Soft shadow: three rounded bands under the content, lightest and
   // largest first. Alpha-blended over the transparent buffer.
-  if (!maximized_) {
+  if (!maximized()) {
     const float spreads[3] = {kShadowMargin, kShadowMargin * 2.0f / 3.0f, kShadowMargin / 3.0f};
     const std::uint8_t alphas[3] = {22, 40, 62};
     for (int i = 0; i < 3; ++i) {
@@ -361,36 +355,25 @@ void AppWindow::PaintContent() {
   const render::Rect caption{content.x, content.y, content.width, kCaptionHeight};
   const int count = ButtonCount();
 
-  const render::TextStyle glyph = GlyphStyle();
-  const render::TextStyle icon = IconStyle();
-  const wchar_t* marlett[3] = {L"0", maximized_ ? L"2" : L"1", L"r"};  // min, max, close
   for (int i = 0; i < count; ++i) {
-    // Role by distance from the right edge: 0 close, 1 max, 2 min, then the
-    // left slots: settings (only with a handler) and pin leftmost.
-    const int role = (count - 1) - i;
-    const bool is_pin = role == 4 || (role == 3 && !settings_handler_);
-    const bool is_gear = role == 3 && settings_handler_;
+    // Left-to-right: 0 pin, 1 settings (when present), last close.
+    const bool is_close = i == count - 1;
+    const bool is_pin = i == 0;
     const render::Rect button{caption.right() - (count - i) * kButtonWidth, caption.y,
                               kButtonWidth, kCaptionHeight};
     if (hover_button_ == i) {
-      backend_.FillRect(button, role == 0 ? kHoverClose : kHoverNeutral);
+      backend_.FillRect(button, is_close ? kHoverClose : kHoverNeutral);
     }
-    if (is_pin) {
-      backend_.DrawTextRun(std::wstring(1, pinned_ ? kPinGlyphPinned : kPinGlyphUnpinned),
-                           {button.x, button.y + kIconNudgeY, button.width, button.height}, icon,
-                           kCaptionText, render::TextAlign::Center,
-                           render::VerticalAlign::Middle);
-    } else if (is_gear) {
-      backend_.DrawTextRun(std::wstring(1, kGearGlyph),
-                           {button.x, button.y + kIconNudgeY, button.width, button.height}, icon,
-                           kCaptionText, render::TextAlign::Center,
-                           render::VerticalAlign::Middle);
-    } else {
-      backend_.DrawTextRun(marlett[2 - role],
-                           {button.x, button.y + kMarlettNudgeY, button.width, button.height},
-                           glyph, kCaptionText, render::TextAlign::Center,
-                           render::VerticalAlign::Middle);
-    }
+    const wchar_t glyph = is_pin ? (pinned_ ? kPinGlyphPinned : kPinGlyphUnpinned)
+                        : is_close ? kCloseGlyph
+                                   : kGearGlyph;
+    const float size = is_pin ? (pinned_ ? kPinPinnedSize : kPinUnpinnedSize)
+                      : is_close ? kCloseSize
+                                 : kGearSize;
+    backend_.DrawTextRun(std::wstring(1, glyph),
+                         {button.x, button.y + kIconNudgeY, button.width, button.height},
+                         IconStyle(size), kCaptionText,
+                         render::TextAlign::Center, render::VerticalAlign::Middle);
   }
 
   if (content_painter_) {
@@ -398,30 +381,8 @@ void AppWindow::PaintContent() {
   }
 }
 
-void AppWindow::SetMaximized(bool maximize) {
-  if (hwnd_ == nullptr || maximize == maximized_) return;
-  const HWND window = static_cast<HWND>(hwnd_);
-  maximized_ = maximize;
-  if (maximize) {
-    RECT client{};
-    GetClientRect(window, &client);
-    restored_width_px_ = client.right;
-    restored_height_px_ = client.bottom;
-    const HMONITOR monitor = MonitorFromWindow(window, MONITOR_DEFAULTTONEAREST);
-    MONITORINFO info{};
-    info.cbSize = sizeof(info);
-    if (GetMonitorInfoW(monitor, &info)) {
-      SetWindowPos(window, nullptr, info.rcWork.left, info.rcWork.top,
-                   info.rcWork.right - info.rcWork.left, info.rcWork.bottom - info.rcWork.top,
-                   SWP_NOZORDER | SWP_NOACTIVATE);
-    }
-  } else {
-    SetWindowPos(window, nullptr, 0, 0, restored_width_px_, restored_height_px_,
-                 SWP_NOMOVE | SWP_NOZORDER | SWP_NOACTIVATE);
-  }
-  RECT client{};
-  GetClientRect(window, &client);
-  OnResized(client.right, client.bottom);
+bool AppWindow::maximized() const {
+  return hwnd_ != nullptr && IsZoomed(static_cast<HWND>(hwnd_)) != 0;
 }
 
 long long __stdcall AppWindow::WindowProc(void* window, unsigned int message,
@@ -505,7 +466,7 @@ long long AppWindow::HandleMessage(void* window_handle, unsigned int message,
         }
       }
       if (button < 0 && content_move_handler_) {
-        const int margin = maximized_ ? 0 : Px(kShadowMargin);
+        const int margin = maximized() ? 0 : Px(kShadowMargin);
         if (content_move_handler_(Logical(GET_X_LPARAM(lparam) - margin),
                                   Logical(GET_Y_LPARAM(lparam) - margin)) &&
             visible()) {
@@ -533,7 +494,7 @@ long long AppWindow::HandleMessage(void* window_handle, unsigned int message,
     case WM_LBUTTONDOWN: {
       const int button = ButtonAt(GET_X_LPARAM(lparam), GET_Y_LPARAM(lparam));
       if (button < 0 && content_down_handler_) {
-        const int margin = maximized_ ? 0 : Px(kShadowMargin);
+        const int margin = maximized() ? 0 : Px(kShadowMargin);
         if (content_down_handler_(Logical(GET_X_LPARAM(lparam) - margin),
                                   Logical(GET_Y_LPARAM(lparam) - margin)) &&
             visible()) {
@@ -548,7 +509,7 @@ long long AppWindow::HandleMessage(void* window_handle, unsigned int message,
         if (content_click_handler_) {
           const int x_px = GET_X_LPARAM(lparam);
           const int y_px = GET_Y_LPARAM(lparam);
-          const int margin = maximized_ ? 0 : Px(kShadowMargin);
+          const int margin = maximized() ? 0 : Px(kShadowMargin);
           RECT client{};
           GetClientRect(window, &client);
           if (x_px >= margin && y_px >= margin && x_px < client.right - margin &&
@@ -560,17 +521,12 @@ long long AppWindow::HandleMessage(void* window_handle, unsigned int message,
         }
         return 0;
       }
-      const int role = (ButtonCount() - 1) - button;  // 0 close … leftmost pin
-      const bool is_pin = role == 4 || (role == 3 && !settings_handler_);
-      if (role == 0) {
-        Close();
-      } else if (role == 1) {
-        SetMaximized(!maximized_);
-      } else if (role == 2) {
-        ShowWindow(window, SW_MINIMIZE);
-      } else if (is_pin) {
+      // Left-to-right: 0 pin, 1 settings (when present), last close.
+      if (button == 0) {
         TogglePin();
-      } else if (role == 3 && settings_handler_) {
+      } else if (button == ButtonCount() - 1) {
+        Close();
+      } else if (settings_handler_) {
         settings_handler_();
       }
       return 0;
@@ -587,7 +543,7 @@ long long AppWindow::HandleMessage(void* window_handle, unsigned int message,
       const LRESULT result =
           DefWindowProcW(window, message, static_cast<WPARAM>(wparam), static_cast<LPARAM>(lparam));
       auto* info = reinterpret_cast<MINMAXINFO*>(lparam);
-      const int margin = maximized_ ? 0 : Px(kShadowMargin) * 2;
+      const int margin = maximized() ? 0 : Px(kShadowMargin) * 2;
       info->ptMinTrackSize.x = Px(320.0f) + margin;
       info->ptMinTrackSize.y = Px(200.0f) + margin;
       return result;

--- a/src/ui/shell/app_window.cpp
+++ b/src/ui/shell/app_window.cpp
@@ -355,16 +355,11 @@ void AppWindow::PaintContent() {
   backend_.FillRoundedRect(content, render::CornerRadius::Uniform(radius), kBackground);
   backend_.StrokeRoundedRect(content, render::CornerRadius::Uniform(radius), kBorder, 1.0f);
 
-  // Caption: title left, window buttons right.
+  // Caption: window buttons right. The title is not drawn inside the frame —
+  // it lives in the window title (taskbar/Alt-Tab); drawing it here stacked
+  // on top of content.
   const render::Rect caption{content.x, content.y, content.width, kCaptionHeight};
   const int count = ButtonCount();
-  const float buttons_width = kButtonWidth * count;
-  const float title_width = content.width - buttons_width - 28.0f;
-  if (title_width > 0.0f) {
-    backend_.DrawTextRun(title_, {caption.x + 14.0f, caption.y, title_width, caption.height},
-                         CaptionStyle(), kCaptionText, render::TextAlign::Left,
-                         render::VerticalAlign::Middle);
-  }
 
   const render::TextStyle glyph = GlyphStyle();
   const render::TextStyle icon = IconStyle();

--- a/src/ui/shell/app_window.h
+++ b/src/ui/shell/app_window.h
@@ -64,12 +64,14 @@ class AppWindow final {
 
   bool alive() const { return hwnd_ != nullptr; }
   bool visible() const;
-  bool maximized() const { return maximized_; }
+  // Observed from the OS (Aero snap / future toggle maximize it; the shell
+  // only adapts its margins).
+  bool maximized() const;
   void* hwnd() const { return hwnd_; }
   render::GdiBackend* backend() { return &backend_; }
 
-  // Always-on-top pin: a caption button left of minimise toggles this. The
-  // state is session-only — persistence belongs to the settings module.
+  // Always-on-top pin: the left-most caption button. The state is
+  // session-only — persistence belongs to the settings module.
   void TogglePin();
   bool pinned() const { return pinned_; }
 
@@ -112,6 +114,10 @@ class AppWindow final {
   // Hover and press feedback for content components; return true to repaint.
   void set_content_move_handler(std::function<bool(float x_logical, float y_logical)> handler);
   void set_content_down_handler(std::function<bool(float x_logical, float y_logical)> handler);
+  // The caption band is HTCAPTION for dragging; content that lives in that
+  // band (the tab strip) claims its points through this hook as HTCLIENT,
+  // otherwise clicks become caption drags and hover never arrives.
+  void set_content_hittest_handler(std::function<bool(float x_logical, float y_logical)> handler);
 
  private:
   static long long __stdcall WindowProc(void* window, unsigned int message,
@@ -123,12 +129,10 @@ class AppWindow final {
 
   void RenderFullFrame();
   void PaintContent();
-  void SetMaximized(bool maximize);
   int Px(float logical) const;
   float Logical(int px) const;
   // Caption buttons left-to-right: pin, settings (only while a settings
-  // handler is registered), min, max/restore, close. Returns the
-  // left-to-right index or -1.
+  // handler is registered), close. Returns the left-to-right index or -1.
   int ButtonAt(int x_px, int y_px) const;
   int ButtonCount() const;
 
@@ -146,13 +150,11 @@ class AppWindow final {
   std::function<bool(float, float)> content_click_handler_;
   std::function<bool(float, float)> content_move_handler_;
   std::function<bool(float, float)> content_down_handler_;
+  std::function<bool(float, float)> content_hittest_handler_;
   std::uint32_t last_os_signals_ = 0;
   unsigned int drain_message_ = 0;
   float dpi_ = 96.0f;
-  bool maximized_ = false;
   bool pinned_ = false;
-  int restored_width_px_ = 0;
-  int restored_height_px_ = 0;
   int hover_button_ = -1;
   std::wstring title_ = L"dhepz";
 };

--- a/tests/ui/presenter/screen_presenter_test.cpp
+++ b/tests/ui/presenter/screen_presenter_test.cpp
@@ -36,9 +36,13 @@ class RecordingBackend final : public render::RenderBackend {
     calls.push_back(L"button");
     fills.push_back({rect, color});
   }
-  void StrokeRoundedRect(const render::Rect&, const render::CornerRadius&, render::Color,
-                         float stroke_width) override {
-    if (stroke_width >= 2.0f) calls.push_back(L"ring");
+  void StrokeRoundedRect(const render::Rect& rect, const render::CornerRadius&,
+                         render::Color color, float stroke_width) override {
+    if (stroke_width >= 2.0f) {
+      calls.push_back(L"ring");
+    } else {
+      strokes.push_back({rect, color});
+    }
   }
   void DrawTextRun(std::wstring_view text, const render::Rect&, const render::TextStyle&,
                    render::Color, render::TextAlign, render::VerticalAlign) override {
@@ -52,6 +56,7 @@ class RecordingBackend final : public render::RenderBackend {
 
   std::vector<std::wstring> calls;
   std::vector<std::pair<render::Rect, render::Color>> fills;
+  std::vector<std::pair<render::Rect, render::Color>> strokes;
 };
 
 std::wstring W(const char* utf8) {
@@ -81,6 +86,7 @@ const char* kCore = R"({
     "text": { "properties": { "text": { "kind": "text", "required": true } } },
     "button": { "properties": {
       "label": { "kind": "text", "required": true },
+      "selected": { "kind": "binding" },
       "tab_stop": { "kind": "bool", "default": true } } }
   }
 })";
@@ -124,13 +130,11 @@ DHEPZ_TEST(ScreenPresenter, PaintsBackdropFirstThenContent) {
   DHEPZ_CHECK(!backend.calls.empty());
   DHEPZ_CHECK_EQ(backend.calls[0], std::wstring(L"fill"));  // backdrop window token
   bool saw_text = false;
-  bool saw_button = false;
   for (const auto& call : backend.calls) {
     if (call == L"text:hello") saw_text = true;
-    if (call == L"button") saw_button = true;
   }
   DHEPZ_CHECK(saw_text);
-  DHEPZ_CHECK(saw_button);
+  DHEPZ_CHECK(!backend.strokes.empty());  // the button outline
 }
 
 DHEPZ_TEST(ScreenPresenter, TabAdvancesFocusAndDrawsTheRing) {
@@ -167,35 +171,62 @@ DHEPZ_TEST(ScreenPresenter, ClickFocusesTheHitButton) {
   DHEPZ_CHECK_EQ(presenter.focused(), std::wstring(L"go"));
 }
 
-DHEPZ_TEST(ScreenPresenter, HoverBrightensAndPressBumpsTheButton) {
+DHEPZ_TEST(ScreenPresenter, IdleOutlineHoverBrightensPressBumps) {
   RecordingBackend backend;
   ui::presenter::ScreenPresenter presenter(&backend);
   const auto document = Resolve();
   presenter.SetDocument(document.get());
   presenter.Prepare({0.0f, 0.0f, 400.0f, 300.0f});
   presenter.Paint({0.0f, 0.0f, 400.0f, 300.0f});
-  DHEPZ_CHECK(!backend.fills.empty());
-  const render::Color base = backend.fills.back().second;
-  const float base_y = backend.fills.back().first.y;
+  DHEPZ_CHECK(!backend.strokes.empty());
+  DHEPZ_CHECK(backend.fills.empty());  // idle: outline only, no fill
+  const render::Color base = backend.strokes.back().second;
+  const float base_y = backend.strokes.back().first.y;
 
   // The button sits below the text row.
   DHEPZ_CHECK(presenter.HandleMove(50.0f, 40.0f));
-  backend.fills.clear();
+  backend.strokes.clear();
   presenter.Paint({0.0f, 0.0f, 400.0f, 300.0f});
-  DHEPZ_CHECK(backend.fills.back().second.r > base.r);  // brightened
-  DHEPZ_CHECK_EQ(backend.fills.back().first.y, base_y);
+  DHEPZ_CHECK(backend.strokes.back().second.r > base.r);  // brightened outline
+  DHEPZ_CHECK_EQ(backend.strokes.back().first.y, base_y);
 
   DHEPZ_CHECK(presenter.HandleDown(50.0f, 40.0f));
-  backend.fills.clear();
+  backend.strokes.clear();
   presenter.Paint({0.0f, 0.0f, 400.0f, 300.0f});
-  DHEPZ_CHECK(backend.fills.back().second.r < base.r);  // darkened
-  DHEPZ_CHECK(backend.fills.back().first.y > base_y);   // bumped 1px
+  DHEPZ_CHECK(backend.strokes.back().first.y > base_y);  // bumped 1px
 
   // Release clears the press.
   presenter.HandleClick(50.0f, 40.0f);
-  backend.fills.clear();
+  backend.strokes.clear();
   presenter.Paint({0.0f, 0.0f, 400.0f, 300.0f});
-  DHEPZ_CHECK_EQ(backend.fills.back().first.y, base_y);
+  DHEPZ_CHECK_EQ(backend.strokes.back().first.y, base_y);
+}
+
+DHEPZ_TEST(ScreenPresenter, SelectedButtonGetsAccentOutlineAndTint) {
+  RecordingBackend backend;
+  ui::presenter::ScreenPresenter presenter(&backend);
+  json::Value core;
+  DHEPZ_CHECK(json::Parse(W(kCore), &core).ok());
+  std::vector<ui::config::Diagnostic> diagnostics;
+  std::unique_ptr<ui::config::ResolvedUiDocument> document;
+  DHEPZ_CHECK(ui::config::ResolveDocument(
+                  core,
+                  {{L"embedded",
+                    W(R"({
+                      "components": [
+                        { "type": "screen", "route_id": "home", "children": [
+                          { "type": "button", "id": "lit", "label": "Lit",
+                            "selected": true }
+                        ] }
+                      ]
+                    })")}},
+                  &diagnostics, &document)
+                  .ok());
+  presenter.SetDocument(document.get());
+  presenter.Prepare({0.0f, 0.0f, 400.0f, 300.0f});
+  presenter.Paint({0.0f, 0.0f, 400.0f, 300.0f});
+  DHEPZ_CHECK(!backend.fills.empty());  // the tint
+  DHEPZ_CHECK_EQ(static_cast<int>(backend.strokes.back().second.r), 0x60);  // accent outline
 }
 
 DHEPZ_TEST(ScreenPresenter, RouteSwitchChangesTheDrawSet) {

--- a/tests/ui/presenter/screen_presenter_test.cpp
+++ b/tests/ui/presenter/screen_presenter_test.cpp
@@ -167,7 +167,7 @@ DHEPZ_TEST(ScreenPresenter, ClickFocusesTheHitButton) {
   presenter.Paint({0.0f, 0.0f, 400.0f, 300.0f});
 
   // Button sits below the text row: container column, gap 8, text 20 high.
-  DHEPZ_CHECK(presenter.HandleClick(50.0f, 40.0f));
+  DHEPZ_CHECK(presenter.HandleClick(50.0f, 76.0f));
   DHEPZ_CHECK_EQ(presenter.focused(), std::wstring(L"go"));
 }
 
@@ -179,24 +179,25 @@ DHEPZ_TEST(ScreenPresenter, IdleOutlineHoverBrightensPressBumps) {
   presenter.Prepare({0.0f, 0.0f, 400.0f, 300.0f});
   presenter.Paint({0.0f, 0.0f, 400.0f, 300.0f});
   DHEPZ_CHECK(!backend.strokes.empty());
-  DHEPZ_CHECK(backend.fills.empty());  // idle: outline only, no fill
+  // The only fill is the selected tab's tint; idle buttons stay unfilled.
+  DHEPZ_CHECK_EQ(backend.fills.size(), static_cast<std::size_t>(1));
   const render::Color base = backend.strokes.back().second;
   const float base_y = backend.strokes.back().first.y;
 
   // The button sits below the text row.
-  DHEPZ_CHECK(presenter.HandleMove(50.0f, 40.0f));
+  DHEPZ_CHECK(presenter.HandleMove(50.0f, 76.0f));
   backend.strokes.clear();
   presenter.Paint({0.0f, 0.0f, 400.0f, 300.0f});
   DHEPZ_CHECK(backend.strokes.back().second.r > base.r);  // brightened outline
   DHEPZ_CHECK_EQ(backend.strokes.back().first.y, base_y);
 
-  DHEPZ_CHECK(presenter.HandleDown(50.0f, 40.0f));
+  DHEPZ_CHECK(presenter.HandleDown(50.0f, 76.0f));
   backend.strokes.clear();
   presenter.Paint({0.0f, 0.0f, 400.0f, 300.0f});
   DHEPZ_CHECK(backend.strokes.back().first.y > base_y);  // bumped 1px
 
   // Release clears the press.
-  presenter.HandleClick(50.0f, 40.0f);
+  presenter.HandleClick(50.0f, 76.0f);
   backend.strokes.clear();
   presenter.Paint({0.0f, 0.0f, 400.0f, 300.0f});
   DHEPZ_CHECK_EQ(backend.strokes.back().first.y, base_y);
@@ -227,6 +228,37 @@ DHEPZ_TEST(ScreenPresenter, SelectedButtonGetsAccentOutlineAndTint) {
   presenter.Paint({0.0f, 0.0f, 400.0f, 300.0f});
   DHEPZ_CHECK(!backend.fills.empty());  // the tint
   DHEPZ_CHECK_EQ(static_cast<int>(backend.strokes.back().second.r), 0x60);  // accent outline
+}
+
+DHEPZ_TEST(ScreenPresenter, TabsSwitchRoutesAndLightTheSelectedTab) {
+  RecordingBackend backend;
+  ui::presenter::ScreenPresenter presenter(&backend);
+  const auto document = Resolve();
+  presenter.SetDocument(document.get());
+  presenter.Prepare({0.0f, 0.0f, 400.0f, 300.0f});
+  presenter.Paint({0.0f, 0.0f, 400.0f, 300.0f});
+
+  // Both routes show in tabs; labels painted; first tab selected (accent).
+  bool saw_home = false, saw_other = false;
+  for (const auto& call : backend.calls) {
+    if (call == L"text:home") saw_home = true;
+    if (call == L"text:other") saw_other = true;
+  }
+  DHEPZ_CHECK(saw_home);
+  DHEPZ_CHECK(saw_other);
+  DHEPZ_CHECK_EQ(static_cast<int>(backend.strokes.front().second.r), 0x60);
+
+  // Click the second tab (x past the first tab's 120px width).
+  DHEPZ_CHECK(presenter.HandleClick(188.0f, 14.0f));
+  DHEPZ_CHECK_EQ(presenter.current_route(), std::wstring(L"other"));
+  backend.calls.clear();
+  presenter.Prepare({0.0f, 0.0f, 400.0f, 300.0f});
+  presenter.Paint({0.0f, 0.0f, 400.0f, 300.0f});
+  bool saw_second = false;
+  for (const auto& call : backend.calls) {
+    if (call == L"text:second") saw_second = true;
+  }
+  DHEPZ_CHECK(saw_second);
 }
 
 DHEPZ_TEST(ScreenPresenter, RouteSwitchChangesTheDrawSet) {

--- a/tests/ui/shell/app_window_test.cpp
+++ b/tests/ui/shell/app_window_test.cpp
@@ -301,22 +301,22 @@ DHEPZ_TEST(AppWindow, SettingsButtonAppearsOnlyWithHandler) {
   const HWND hwnd = static_cast<HWND>(window.hwnd());
 
   // Client geometry at 96 DPI: margin 24, content_right 984, button 46 px.
-  // Order left-to-right: pin, [settings], min, max, close.
+  // Left-to-right: pin, [settings], close.
   bool opened = false;
-  // No handler: four buttons, the pin occupies x 800..846; the future gear
-  // slot (x 754..800) is plain caption — clicking it does nothing.
-  SendMessageW(hwnd, WM_LBUTTONUP, 0, MAKELPARAM(770, 40));
+  // No handler: two buttons; the pin occupies x 892..938 and there is no
+  // gear — its future slot is plain caption, clicking it does nothing.
+  SendMessageW(hwnd, WM_LBUTTONUP, 0, MAKELPARAM(700, 40));
   DHEPZ_CHECK_FALSE(opened);
   DHEPZ_CHECK_FALSE(window.pinned());
-  SendMessageW(hwnd, WM_LBUTTONUP, 0, MAKELPARAM(820, 40));
+  SendMessageW(hwnd, WM_LBUTTONUP, 0, MAKELPARAM(900, 40));
   DHEPZ_CHECK(window.pinned());
-  SendMessageW(hwnd, WM_LBUTTONUP, 0, MAKELPARAM(820, 40));
+  SendMessageW(hwnd, WM_LBUTTONUP, 0, MAKELPARAM(900, 40));
   DHEPZ_CHECK_FALSE(window.pinned());
 
   window.set_settings_handler([&opened] { opened = true; });
-  // The gear now takes x 800..846 and the pin shifts left to 754..800.
-  SendMessageW(hwnd, WM_LBUTTONUP, 0, MAKELPARAM(820, 40));
+  // The gear now takes x 892..938 and the pin shifts left to 846..892.
+  SendMessageW(hwnd, WM_LBUTTONUP, 0, MAKELPARAM(910, 40));
   DHEPZ_CHECK(opened);
-  SendMessageW(hwnd, WM_LBUTTONUP, 0, MAKELPARAM(770, 40));
+  SendMessageW(hwnd, WM_LBUTTONUP, 0, MAKELPARAM(860, 40));
   DHEPZ_CHECK(window.pinned());
 }


### PR DESCRIPTION
The JSON-to-pixels wire plus the user's interaction design: tabs auto-register from screen files (3 files -> 3 tabs/3 screens, colored backdrops prove switches), initial route lit at the left; tab strip below the reserved caption row via a content hittest hook; button states idle-outline/hover-accent/press-bump/selected-tint; caption = drag row + pin/settings/close as MDL2 glyphs (min/max removed, toggle later, maximize observed via IsZoomed); dead code removed (Marlett, CaptionStyle, SetMaximized). Tests: tab switch + selected accent, hover/press states, hit-test geometry, settings-button adaptivity.