### PR TITLE
docs(phase3): add Phase 3 issue drafts

### DIFF
--- a/.github/planning/p3-01-modulehost-moduledescriptor.md
+++ b/.github/planning/p3-01-modulehost-moduledescriptor.md
@@ -1,23 +1,24 @@
-P3-01 ModuleHost + ModuleDescriptor contract
+P3-01 ModuleHost + ModuleDescriptor contract (includes module.json schema)
 
 Scope
-- Define the ModuleHost (parent) and ModuleDescriptor (child) API surface.
+- Define the ModuleHost (parent) and ModuleDescriptor (child) API surface and the module.json manifest schema used to describe modules.
 - ModuleHost provides: Surface, Settings, Storage, Process, Status, Log, RequestRoute, Peers.
-- ModuleDescriptor exposes: moduleId, tabLabel, order, showInTabs, settingsRoute?, DeclaredActions, DeclaredBindings, DeclaredCapabilities, Bind, Handle, Release.
+- ModuleDescriptor / module.json fields: moduleId, tabLabel, order, showInTabs, settingsRoute?, DeclaredActions, DeclaredBindings, DeclaredCapabilities, Bind, Handle, Release.
+- Document capability semantics (single-claim capabilities such as `settings:all`, reserved capabilities such as `config:write`) in the schema and in a short ADR.
 - Keep the contract append-only and explicitly documented; breaking changes are expensive once modules ship.
 
 Acceptance criteria
-- A ModuleDescriptor validates against the schema and can be consumed by a ModuleHost without referencing siblings or globals.
-- The contract rejects descriptors missing required fields or declaring unknown capabilities.
-- The contract is documented in code + a short ADR linking to the plan.
+- module.json schema validates descriptors and rejects missing required fields or illegal capabilities.
+- A ModuleDescriptor validated by the schema can be consumed by a ModuleHost without referencing siblings or globals.
+- The schema and contract are documented in code + an ADR linking to .docs/plan.md.
 
 Verification
-- Unit tests: descriptor validation and minimal host calls (Bind/Handle/Release) succeed for a healthy descriptor and fail with clear diagnostics for malformed ones.
-- A small integration test that constructs a descriptor and mounts it into a test host.
+- Unit tests: schema validation (good and bad manifests), descriptor validation, and minimal host calls (Bind/Handle/Release) succeed for a healthy descriptor and fail with precise diagnostics for malformed ones.
+- Integration test: a generated module.json mounted into a test host results in a live module instance.
 
 Why this first
-- The contract is the foundation for Phase 3; everything else depends on it.
+- The contract and manifest schema are the foundation for Phase 3; everything else depends on them and they must be stable before discovery, gate, or scaffolding are implemented.
 
 Scope: S
 
-Do not start until: Phase 2 gate (#59) is closed and design read (AGENTS.md + .docs/plan.md).
+Do not start until: Phase 2 gate (#59) is closed and the ADR and schema draft are reviewed (AGENTS.md + .docs/plan.md).

--- a/.github/planning/p3-01-modulehost-moduledescriptor.md
+++ b/.github/planning/p3-01-modulehost-moduledescriptor.md
@@ -1,0 +1,23 @@
+P3-01 ModuleHost + ModuleDescriptor contract
+
+Scope
+- Define the ModuleHost (parent) and ModuleDescriptor (child) API surface.
+- ModuleHost provides: Surface, Settings, Storage, Process, Status, Log, RequestRoute, Peers.
+- ModuleDescriptor exposes: moduleId, tabLabel, order, showInTabs, settingsRoute?, DeclaredActions, DeclaredBindings, DeclaredCapabilities, Bind, Handle, Release.
+- Keep the contract append-only and explicitly documented; breaking changes are expensive once modules ship.
+
+Acceptance criteria
+- A ModuleDescriptor validates against the schema and can be consumed by a ModuleHost without referencing siblings or globals.
+- The contract rejects descriptors missing required fields or declaring unknown capabilities.
+- The contract is documented in code + a short ADR linking to the plan.
+
+Verification
+- Unit tests: descriptor validation and minimal host calls (Bind/Handle/Release) succeed for a healthy descriptor and fail with clear diagnostics for malformed ones.
+- A small integration test that constructs a descriptor and mounts it into a test host.
+
+Why this first
+- The contract is the foundation for Phase 3; everything else depends on it.
+
+Scope: S
+
+Do not start until: Phase 2 gate (#59) is closed and design read (AGENTS.md + .docs/plan.md).

--- a/.github/planning/p3-02-moduleregistry.md
+++ b/.github/planning/p3-02-moduleregistry.md
@@ -1,0 +1,22 @@
+P3-02 ModuleRegistry self-registration and discovery
+
+Scope
+- Implement ModuleRegistry that discovers module folders and self-registers modules into the host without editing any central file.
+- Ensure modules compile into the EXE and self-register; avoid static .lib patterns that the linker can drop.
+- Implement a deterministic discovery order and a three-stage scan trigger split by cost.
+
+Acceptance criteria
+- Adding a valid module folder and rebuilding makes it available without editing central files.
+- Duplicate or conflicting module IDs are rejected with clear diagnostics.
+- Broken module folders (malformed JSON, missing entry) are skipped and reported; they do not crash the app.
+
+Verification
+- Unit tests for discovery, duplicate detection, and skipped invalid folder behaviour.
+- Integration: a test run with two valid module folders and one invalid folder shows the two modules available and the invalid one reported.
+
+Why this next
+- Discovery is the layer that exposes modules to the gate; it must be reliable before the gate runs.
+
+Scope: S
+
+Do not start until: P3-01 is implemented and the descriptor schema is stable.

--- a/.github/planning/p3-03-appgate.md
+++ b/.github/planning/p3-03-appgate.md
@@ -1,0 +1,22 @@
+P3-03 AppGate: pair / validate / mount / lazy-activate
+
+Scope
+- Implement the AppGate orchestration: ResolveConfig, CollectModules, PairAndValidate, MountAccepted, LazyActivate, Dispatch, ApplyConfig, Peers, Diagnostics surfaces.
+- Pair host capabilities with module-declared capabilities and refuse modules with unmet requirements.
+- Lazy-activate modules so activation work runs off the UI thread or on first use.
+
+Acceptance criteria
+- Healthy modules mount and activate cleanly.
+- Modules with unknown capabilities or malformed actions are rejected with a precise diagnostic and do not crash the app.
+- The gate preserves app availability while skipping bad modules.
+
+Verification
+- Unit tests for capability pairing and rejection paths.
+- Integration test: one healthy module + two broken modules scanned together — healthy module available, broken modules reported with reasons.
+
+Why this next
+- The gate enforces the contract at runtime; without it, discovery is only a list and acceptance is undefined.
+
+Scope: M
+
+Do not start until: P3-02 is in review.

--- a/.github/planning/p3-04-diagnostics.md
+++ b/.github/planning/p3-04-diagnostics.md
@@ -1,0 +1,22 @@
+P3-04 Diagnostics module and degraded-mode reporting
+
+Scope
+- Build an in-process diagnostics module that records and surfaces module load/validation failures.
+- Ensure diagnostics are always compiled in and cannot be excluded by build flags.
+- Expose diagnostics via an in-app view (for reviewers) and via CI-readable artifacts.
+
+Acceptance criteria
+- A malformed module.json is recorded with file+line and a human-friendly reason.
+- A module with a typo'd action is recorded with the affected module and action name.
+- Diagnostics do not block the host or cause other modules to fail.
+
+Verification
+- Integration test: three folders (healthy, typo'd action, malformed JSON); start app and assert diagnostics include both broken folders with reasons and the healthy folder is active.
+- CI step emits diagnostics artifact when the fixture set runs.
+
+Why this next
+- Degraded-mode visibility is critical to ensure broken modules are visible and diagnosable without stopping the app.
+
+Scope: S
+
+Do not start until: P3-03 is implemented and can notify diagnostics.

--- a/.github/planning/p3-05-modulejson-new-module.md
+++ b/.github/planning/p3-05-modulejson-new-module.md
@@ -1,0 +1,21 @@
+P3-05 module.json manifest schema and New-Module.ps1
+
+Scope
+- Define module.json schema (fields, capabilities, actions, bindings) and the New-Module.ps1 scaffolding script.
+- Enforce capability rules in the schema: single-claim capabilities (e.g., settings:all), reserved capabilities (config:write), and documented constraints.
+
+Acceptance criteria
+- New-Module.ps1 produces a module folder that passes the descriptor/schema validation.
+- Invalid manifests fail the validation with file+line diagnostics.
+- The scaffolding script refuses to create a module with a duplicate moduleId or illegal capability.
+
+Verification
+- Script test: run New-Module.ps1 -> validate manifest -> build test ensures discovery picks it up.
+- Unit tests for manifest validation (missing fields, illegal capabilities, duplicate IDs).
+
+Why this next
+- Scaffolding must match the contract so module authors get a correct starting shape.
+
+Scope: S
+
+Do not start until: P3-03 and P3-04 are in review.

--- a/.github/planning/p3-05-modulejson-new-module.md
+++ b/.github/planning/p3-05-modulejson-new-module.md
@@ -1,21 +1,23 @@
-P3-05 module.json manifest schema and New-Module.ps1
+P3-05 Broken-module fixtures and contract-validation CI
 
 Scope
-- Define module.json schema (fields, capabilities, actions, bindings) and the New-Module.ps1 scaffolding script.
-- Enforce capability rules in the schema: single-claim capabilities (e.g., settings:all), reserved capabilities (config:write), and documented constraints.
+- Add three fixture module folders to tests/fixtures/modules:
+  1) healthy module
+  2) module with a typo'd action
+  3) module with malformed module.json
+- Add CI step that runs the gate against these fixtures and asserts the expected degraded-mode behaviour.
 
 Acceptance criteria
-- New-Module.ps1 produces a module folder that passes the descriptor/schema validation.
-- Invalid manifests fail the validation with file+line diagnostics.
-- The scaffolding script refuses to create a module with a duplicate moduleId or illegal capability.
+- CI asserts the healthy module becomes active while the broken modules are reported in diagnostics.
+- CI fails if a broken module causes the app to crash or if the healthy module disappears.
+- CI publishes a diagnostics artifact describing failures in a machine-readable and human-friendly way.
 
 Verification
-- Script test: run New-Module.ps1 -> validate manifest -> build test ensures discovery picks it up.
-- Unit tests for manifest validation (missing fields, illegal capabilities, duplicate IDs).
+- CI run with the fixture set passes the gate checks and produces the diagnostics artifact on failure for debugging.
 
 Why this next
-- Scaffolding must match the contract so module authors get a correct starting shape.
+- Repeated enforcement in CI prevents regressions in the gate and degraded mode.
 
 Scope: S
 
-Do not start until: P3-03 and P3-04 are in review.
+Do not start until: P3-03 is merged.

--- a/.github/planning/p3-06-fixtures-ci.md
+++ b/.github/planning/p3-06-fixtures-ci.md
@@ -1,0 +1,23 @@
+P3-06 Broken-module fixtures and contract-validation CI
+
+Scope
+- Add three fixture module folders to tests/fixtures/modules:
+  1) healthy module
+  2) module with a typo'd action
+  3) module with malformed module.json
+- Add CI step that runs the gate against these fixtures and asserts the expected degraded-mode behaviour.
+
+Acceptance criteria
+- CI asserts the healthy module becomes active while the broken modules are reported in diagnostics.
+- CI fails if a broken module causes the app to crash or if the healthy module disappears.
+- CI publishes a diagnostics artifact describing failures in a machine-readable and human-friendly way.
+
+Verification
+- CI run with the fixture set passes the gate checks and produces the diagnostics artifact on failure for debugging.
+
+Why this next
+- Repeated enforcement in CI prevents regressions in the gate and degraded mode.
+
+Scope: S
+
+Do not start until: P3-05 is merged.

--- a/.github/planning/p3-06-fixtures-ci.md
+++ b/.github/planning/p3-06-fixtures-ci.md
@@ -1,23 +1,20 @@
-P3-06 Broken-module fixtures and contract-validation CI
+P3-06 Phase 3 gate verification
 
 Scope
-- Add three fixture module folders to tests/fixtures/modules:
-  1) healthy module
-  2) module with a typo'd action
-  3) module with malformed module.json
-- Add CI step that runs the gate against these fixtures and asserts the expected degraded-mode behaviour.
+- Consolidate Phase 3 verification and run the gate checklist as required by .docs/plan.md.
 
-Acceptance criteria
-- CI asserts the healthy module becomes active while the broken modules are reported in diagnostics.
-- CI fails if a broken module causes the app to crash or if the healthy module disappears.
-- CI publishes a diagnostics artifact describing failures in a machine-readable and human-friendly way.
+Acceptance criteria (gate)
+- Three module folders present: one healthy, one typo'd action, one malformed JSON.
+- App starts; the healthy module works; the broken ones appear in diagnostics with reasons; nothing else is affected.
+- Deleting the healthy folder and rebuilding removes it cleanly with no other file edited.
+- CI asserts all of the above, and a regression in degraded mode fails the build.
 
 Verification
-- CI run with the fixture set passes the gate checks and produces the diagnostics artifact on failure for debugging.
+- Integration and CI checks defined plainly and run automatically as part of the contract-validation step.
 
-Why this next
-- Repeated enforcement in CI prevents regressions in the gate and degraded mode.
+Why this last
+- This gate closes Phase 3 and prevents Phase 4 from beginning until the contract is proven.
 
-Scope: S
+Scope: M
 
-Do not start until: P3-05 is merged.
+Do not start until: P3-05 is merged and CI is configured to run the fixture checks.

--- a/.github/planning/p3-07-phase3-gate.md
+++ b/.github/planning/p3-07-phase3-gate.md
@@ -1,20 +1,5 @@
-P3-07 Phase 3 gate verification
+P3-07 (deprecated) — moved to P3-06
 
-Scope
-- Consolidate Phase 3 verification and run the gate checklist as required by .docs/plan.md.
+This file was superseded by P3-06 (Phase 3 gate verification). See .github/planning/p3-06-fixtures-ci.md for the consolidated gate text.
 
-Acceptance criteria (gate)
-- Three module folders present: one healthy, one typo'd action, one malformed JSON.
-- App starts; the healthy module works; the broken ones appear in diagnostics with reasons; nothing else is affected.
-- Deleting the healthy folder and rebuilding removes it cleanly with no other file edited.
-- CI asserts all of the above, and a regression in degraded mode fails the build.
-
-Verification
-- Integration and CI checks defined plainly and run automatically as part of the contract-validation step.
-
-Why this last
-- This gate closes Phase 3 and prevents Phase 4 from beginning until the contract is proven.
-
-Scope: M
-
-Do not start until: P3-06 is merged and CI is configured to run the fixture checks.
+Do not start work from this file. Use P3-01..P3-06 and follow the one-issue-one-PR rule in #30.

--- a/.github/planning/p3-07-phase3-gate.md
+++ b/.github/planning/p3-07-phase3-gate.md
@@ -1,0 +1,20 @@
+P3-07 Phase 3 gate verification
+
+Scope
+- Consolidate Phase 3 verification and run the gate checklist as required by .docs/plan.md.
+
+Acceptance criteria (gate)
+- Three module folders present: one healthy, one typo'd action, one malformed JSON.
+- App starts; the healthy module works; the broken ones appear in diagnostics with reasons; nothing else is affected.
+- Deleting the healthy folder and rebuilding removes it cleanly with no other file edited.
+- CI asserts all of the above, and a regression in degraded mode fails the build.
+
+Verification
+- Integration and CI checks defined plainly and run automatically as part of the contract-validation step.
+
+Why this last
+- This gate closes Phase 3 and prevents Phase 4 from beginning until the contract is proven.
+
+Scope: M
+
+Do not start until: P3-06 is merged and CI is configured to run the fixture checks.


### PR DESCRIPTION
docs(phase3): add Phase 3 issue drafts (P3-01..P3-07)

Create Phase 3 issue draft markdown files under .github/planning so reviewers can read and
copy them into GitHub issues as needed. These are the contract-phase breakdowns: ModuleHost,
ModuleRegistry, AppGate, Diagnostics, module.json + New-Module.ps1, fixtures+CI, and the gate.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
