### PR TITLE
feat(modules): AppGate pair/validate/mount/lazy-activate (#83)

### DIFF
--- a/src/modules/gate/app_gate.cpp
+++ b/src/modules/gate/app_gate.cpp
@@ -1,0 +1,315 @@
+#include "modules/gate/app_gate.h"
+
+#include <map>
+#include <mutex>
+
+#include "core/json.h"
+#include "modules/registry/module_registry.h"
+#include "ui/config/config_store.h"
+
+namespace modules {
+namespace {
+
+std::vector<RegisteredModule> RegistrySnapshot() { return CollectModules(); }
+
+}  // namespace
+
+// Per-module host view. Settings reach is narrowed here by construction:
+// writes land only in the module's own section; global is read-only.
+class GateHost final : public ModuleHost {
+ public:
+  GateHost(AppGate* gate, std::wstring module_id)
+      : gate_(gate), module_id_(std::move(module_id)) {}
+
+  ModuleSurface Surface() override { return surface_; }
+
+  core::Status SettingsRead(std::wstring_view key, std::wstring* out) override {
+    std::lock_guard lock(mutex_);
+    const auto& section = settings_[std::wstring(module_id_)];
+    const auto it = section.find(std::wstring(key));
+    if (it == section.end()) return core::Err(core::ErrorCode::NotFound, L"no such key");
+    *out = it->second;
+    return core::Ok();
+  }
+
+  core::Status SettingsReadGlobal(std::wstring_view key, std::wstring* out) override {
+    std::lock_guard lock(mutex_);
+    const auto it = global_.find(std::wstring(key));
+    if (it == global_.end()) return core::Err(core::ErrorCode::NotFound, L"no such key");
+    *out = it->second;
+    return core::Ok();
+  }
+
+  core::Status SettingsWrite(std::wstring_view key, std::wstring_view value) override {
+    std::lock_guard lock(mutex_);
+    settings_[std::wstring(module_id_)][std::wstring(key)] = std::wstring(value);
+    return core::Ok();
+  }
+
+  core::Status StorageWrite(std::wstring_view name, std::wstring_view data) override {
+    std::lock_guard lock(mutex_);
+    storage_[std::wstring(name)] = std::wstring(data);
+    return core::Ok();
+  }
+
+  core::Status StorageRead(std::wstring_view name, std::wstring* out) override {
+    std::lock_guard lock(mutex_);
+    const auto it = storage_.find(std::wstring(name));
+    if (it == storage_.end()) return core::Err(core::ErrorCode::NotFound, L"no such blob");
+    *out = it->second;
+    return core::Ok();
+  }
+
+  core::Status ProcessRun(std::wstring_view, std::wstring*) override {
+    // Worker offload lands with the terminal module (Phase 4).
+    return core::Err(core::ErrorCode::Unsupported, L"process launch not wired yet");
+  }
+
+  void ReportStatus(const core::Status& status) override { last_status_ = status; }
+  void Log(std::wstring_view level, std::wstring_view text) override {
+    std::lock_guard lock(mutex_);
+    log_.push_back(std::wstring(level) + L": " + std::wstring(text));
+  }
+
+  core::Status RequestRoute(std::wstring_view route_id) override;
+  std::vector<PeerInfo> Peers() override;
+
+ private:
+  AppGate* gate_;
+  std::wstring module_id_;
+  ModuleSurface surface_;
+  std::mutex mutex_;
+  std::map<std::wstring, std::map<std::wstring, std::wstring>> settings_;
+  std::map<std::wstring, std::wstring> global_;
+  std::map<std::wstring, std::wstring> storage_;
+  std::vector<std::wstring> log_;
+  core::Status last_status_;
+};
+
+AppGate::AppGate() = default;
+AppGate::~AppGate() = default;
+
+core::Status AppGate::Start(std::wstring_view override_path) {
+  // Embedded RCDATA read lands here once the resource is wired; tests and
+  // the gate fixtures use StartWithEmbedded.
+  (void)override_path;
+  return core::Err(core::ErrorCode::Unsupported, L"embedded resource read lands with #84");
+}
+
+core::Status AppGate::StartWithEmbedded(std::wstring_view embedded_text,
+                                        std::wstring_view override_text) {
+  return PairAndMount(embedded_text, override_text);
+}
+
+core::Status AppGate::PairAndMount(std::wstring_view embedded_text,
+                                   std::wstring_view override_text) {
+  json::Value embedded;
+  DHEPZ_RETURN_IF_ERROR(json::Parse(embedded_text, &embedded));
+  const json::Value* core = embedded.Find(L"core");
+  if (core == nullptr || !core->is_object()) {
+    return core::Err(core::ErrorCode::InvalidArgument,
+                     L"embedded document carries no core catalog");
+  }
+
+  json::Value embedded_screens = json::Value::Object();
+  if (const json::Value* components = embedded.Find(L"components")) {
+    embedded_screens.Set(L"components", *components);
+  }
+  std::vector<ui::config::ScreenSource> sources;
+  sources.push_back({L"embedded", json::Serialize(embedded_screens)});
+  if (!override_text.empty()) {
+    sources.push_back({L"override", std::wstring(override_text)});
+  }
+  std::vector<ui::config::Diagnostic> ui_diags;
+  DHEPZ_RETURN_IF_ERROR(ui::config::ResolveDocument(*core, sources, &ui_diags, &document_));
+
+  const std::vector<RegisteredModule> registered = RegistrySnapshot();
+  const json::Value* manifests = embedded.Find(L"modules");
+  int settings_all_claimants = 0;
+
+  if (manifests != nullptr && manifests->is_array()) {
+    for (const json::Value& manifest_value : manifests->items()) {
+      ModuleManifest manifest;
+      std::vector<ManifestDiagnostic> manifest_diags;
+      if (!ParseManifest(json::Serialize(manifest_value), &manifest, &manifest_diags).ok()) {
+        rejects_.push_back({manifest.module_id.empty() ? L"?" : manifest.module_id,
+                            L"manifest invalid: " +
+                                (manifest_diags.empty() ? L"?" : manifest_diags[0].message)});
+        continue;
+      }
+
+      const ModuleFactory* factory = nullptr;
+      for (const RegisteredModule& reg : registered) {
+        if (reg.module_id == manifest.module_id) {
+          factory = &reg.factory;
+          break;
+        }
+      }
+      if (factory == nullptr) {
+        rejects_.push_back({manifest.module_id, L"logic half not self-registered"});
+        continue;
+      }
+
+      // Pairing: a screen half with matching module_id must exist.
+      const ui::config::Route* screen = nullptr;
+      for (const ui::config::Route& route : document_->routes()) {
+        if (route.root.GetString(L"module_id") == manifest.module_id) {
+          screen = &route;
+          break;
+        }
+      }
+      if (screen == nullptr) {
+        rejects_.push_back({manifest.module_id, L"no screen half with matching module_id"});
+        continue;
+      }
+
+      std::unique_ptr<ModuleDescriptor> descriptor = (*factory)();
+      const std::vector<std::wstring> declared = descriptor->DeclaredCapabilities();
+      if (declared != manifest.capabilities) {
+        rejects_.push_back({manifest.module_id,
+                            L"DeclaredCapabilities() does not match module.json"});
+        continue;
+      }
+      bool capability_ok = true;
+      for (const std::wstring& cap : declared) {
+        if (cap == std::wstring(kCapabilitySettingsAll)) {
+          if (++settings_all_claimants > 1) {
+            rejects_.push_back({manifest.module_id,
+                                L"settings:all already claimed by another module"});
+            capability_ok = false;
+            break;
+          }
+        } else if (cap != std::wstring(kCapabilityConfigWrite)) {
+          rejects_.push_back({manifest.module_id, L"unknown capability '" + cap + L"'"});
+          capability_ok = false;
+          break;
+        }
+      }
+      if (!capability_ok) continue;
+
+      if (!manifest.settings_route.empty()) {
+        bool ships = false;
+        for (const ui::config::Route& route : document_->routes()) {
+          if (route.id == manifest.settings_route &&
+              route.root.GetString(L"module_id") == manifest.module_id) {
+            ships = true;
+            break;
+          }
+        }
+        if (!ships) {
+          rejects_.push_back({manifest.module_id,
+                              L"settingsRoute not shipped by this module"});
+          continue;
+        }
+      }
+
+      MountedModule module;
+      module.manifest = std::move(manifest);
+      bool actions_ok = true;
+      for (const std::wstring& action : descriptor->DeclaredActions()) {
+        for (const auto& [existing_action, existing_id] : action_map_) {
+          if (existing_action == action) {
+            rejects_.push_back({module.manifest.module_id,
+                                L"action '" + action + L"' already registered by " +
+                                    existing_id});
+            actions_ok = false;
+            break;
+          }
+        }
+        if (!actions_ok) break;
+      }
+      if (!actions_ok) continue;
+      for (const std::wstring& action : descriptor->DeclaredActions()) {
+        action_map_.emplace_back(action, module.manifest.module_id);
+      }
+      module.descriptor = std::move(descriptor);
+      module.host = std::make_unique<GateHost>(this, module.manifest.module_id);
+      mounted_.push_back(std::move(module));
+    }
+  }
+
+  current_route_ = document_->initial_route();
+  return core::Ok();
+}
+
+AppGate::MountedModule* AppGate::FindByRoute(std::wstring_view route_id) {
+  for (MountedModule& module : mounted_) {
+    if (document_ != nullptr) {
+      const ui::config::Route* route = document_->FindRoute(route_id);
+      if (route != nullptr && route->root.GetString(L"module_id") == module.manifest.module_id) {
+        return &module;
+      }
+    }
+  }
+  return nullptr;
+}
+
+AppGate::MountedModule* AppGate::FindByModule(std::wstring_view module_id) {
+  for (MountedModule& module : mounted_) {
+    if (module.manifest.module_id == module_id) return &module;
+  }
+  return nullptr;
+}
+
+bool AppGate::Mounted(std::wstring_view module_id) const {
+  for (const MountedModule& module : mounted_) {
+    if (module.manifest.module_id == module_id) return true;
+  }
+  return false;
+}
+
+core::Status AppGate::Activate(std::wstring_view route_id) {
+  MountedModule* module = FindByRoute(route_id);
+  if (module == nullptr) return core::Ok();  // built-in screen: nothing to activate
+  if (module->activated) return core::Ok();
+  const core::Status bound = module->descriptor->Bind(*module->host);
+  if (!bound.ok()) {
+    rejects_.push_back({module->manifest.module_id, L"Bind failed: " + bound.Message()});
+    return bound;
+  }
+  module->activated = true;
+  return core::Ok();
+}
+
+core::Status AppGate::Dispatch(std::wstring_view action, const json::Value& payload,
+                               json::Value* state_patch) {
+  for (const auto& [registered_action, module_id] : action_map_) {
+    if (registered_action != action) continue;
+    MountedModule* module = FindByModule(module_id);
+    if (module == nullptr) {
+      return core::Err(core::ErrorCode::NotFound, L"module not mounted");
+    }
+    if (!module->activated) {
+      const core::Status bound = module->descriptor->Bind(*module->host);
+      if (!bound.ok()) return bound;
+      module->activated = true;
+    }
+    return module->descriptor->Handle(action, payload, state_patch);
+  }
+  return core::Err(core::ErrorCode::NotFound, L"no module declares this action");
+}
+
+core::Status AppGate::RequestRoute(std::wstring_view route_id) {
+  if (document_ == nullptr || document_->FindRoute(route_id) == nullptr) {
+    return core::Err(core::ErrorCode::NotFound, L"unknown route");
+  }
+  current_route_ = std::wstring(route_id);
+  return Activate(route_id);
+}
+
+std::vector<PeerInfo> AppGate::Peers() const {
+  std::vector<PeerInfo> peers;
+  for (const MountedModule& module : mounted_) {
+    peers.push_back({module.manifest.module_id, module.manifest.tab_label,
+                     module.manifest.settings_route});
+  }
+  return peers;
+}
+
+core::Status GateHost::RequestRoute(std::wstring_view route_id) {
+  return gate_->RequestRoute(route_id);
+}
+
+std::vector<PeerInfo> GateHost::Peers() { return gate_->Peers(); }
+
+}  // namespace modules

--- a/src/modules/gate/app_gate.h
+++ b/src/modules/gate/app_gate.h
@@ -1,0 +1,76 @@
+// AppGate — the single orchestrator (P3-03, plan Part 3). One choke point:
+// nothing else mounts modules, registers actions, or swaps the config.
+//
+//   Start()          ResolveConfig + CollectModules + PairAndValidate + Mount
+//   Activate(route)  lazy Bind() on first visit, never at startup (G1/G2)
+//   Dispatch(action) route to the owning module
+//
+// Degraded mode: a broken module is never mounted, recorded with a reason,
+// and everything else keeps working. The window frame, tabs, and routing
+// never depend on any module loading.
+#pragma once
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "modules/contract/module_contract.h"
+#include "modules/contract/module_manifest.h"
+#include "ui/config/resolved_ui_document.h"
+
+namespace modules {
+
+struct RejectEntry {
+  std::wstring module_id;
+  std::wstring reason;
+};
+
+class GateHost;
+
+class AppGate final {
+ public:
+  AppGate();
+  ~AppGate();
+  AppGate(const AppGate&) = delete;
+  AppGate& operator=(const AppGate&) = delete;
+
+  // Runtime path: embedded RCDATA resource (+ optional override file).
+  core::Status Start(std::wstring_view override_path = {});
+  // Test path: explicit texts.
+  core::Status StartWithEmbedded(std::wstring_view embedded_text,
+                                 std::wstring_view override_text = {});
+
+  const ui::config::ResolvedUiDocument* document() const { return document_.get(); }
+  std::vector<PeerInfo> Peers() const;
+  const std::vector<RejectEntry>& Rejects() const { return rejects_; }
+  bool Mounted(std::wstring_view module_id) const;
+
+  // Lazy activation: builds the descriptor and Bind()s it on first visit.
+  core::Status Activate(std::wstring_view route_id);
+  // Route an action to its owning module (auto-activates it).
+  core::Status Dispatch(std::wstring_view action, const json::Value& payload,
+                        json::Value* state_patch);
+  // From ModuleHost::RequestRoute; the gate may refuse unknown routes.
+  core::Status RequestRoute(std::wstring_view route_id);
+  const std::wstring& current_route() const { return current_route_; }
+
+ private:
+  struct MountedModule {
+    ModuleManifest manifest;
+    std::unique_ptr<ModuleDescriptor> descriptor;
+    std::unique_ptr<GateHost> host;
+    bool activated = false;
+  };
+
+  core::Status PairAndMount(std::wstring_view embedded_text, std::wstring_view override_text);
+  MountedModule* FindByRoute(std::wstring_view route_id);
+  MountedModule* FindByModule(std::wstring_view module_id);
+
+  std::unique_ptr<ui::config::ResolvedUiDocument> document_;
+  std::vector<MountedModule> mounted_;
+  std::vector<RejectEntry> rejects_;
+  std::vector<std::pair<std::wstring, std::wstring>> action_map_;  // action -> moduleId
+  std::wstring current_route_;
+};
+
+}  // namespace modules

--- a/tests/dhepz_tests.vcxproj
+++ b/tests/dhepz_tests.vcxproj
@@ -130,6 +130,7 @@
     <ClCompile Include="..\src\ui\theme\**\*.cpp" />
     <ClCompile Include="..\src\modules\contract\**\*.cpp" />
     <ClCompile Include="..\src\modules\registry\**\*.cpp" />
+    <ClCompile Include="..\src\modules\gate\**\*.cpp" />
     <ClInclude Include="**\*.h" />
     <ResourceCompile Include="app_icon.rc" />
   </ItemGroup>

--- a/tests/modules/gate/app_gate_test.cpp
+++ b/tests/modules/gate/app_gate_test.cpp
@@ -1,0 +1,205 @@
+#include "modules/gate/app_gate.h"
+
+#include <memory>
+#include <string>
+
+#include "framework/test_case.h"
+#include "modules/registry/module_registry.h"
+
+namespace {
+
+std::wstring W(const char* utf8) {
+  std::wstring wide;
+  for (const char* p = utf8; *p != '\0'; ++p) {
+    wide.push_back(static_cast<wchar_t>(static_cast<unsigned char>(*p)));
+  }
+  return wide;
+}
+
+template <typename Base>
+class SimpleModule final : public modules::ModuleDescriptor {
+ public:
+  std::wstring_view ModuleId() const override { return Base::Id(); }
+  std::wstring_view TabLabel() const override { return Base::Id(); }
+  int Order() const override { return 100; }
+  bool ShowInTabs() const override { return true; }
+  std::wstring_view SettingsRoute() const override { return {}; }
+  std::vector<std::wstring> DeclaredActions() const override { return Base::Actions(); }
+  std::vector<std::wstring> DeclaredBindings() const override { return {}; }
+  std::vector<std::wstring> DeclaredCapabilities() const override { return Base::Caps(); }
+  core::Status Bind(modules::ModuleHost& host) override {
+    bound_ = true;
+    return host.SettingsWrite(L"k", L"v");
+  }
+  core::Status Handle(std::wstring_view action, const json::Value&, json::Value*) override {
+    handled_ = std::wstring(action);
+    return core::Ok();
+  }
+  void Release() override {}
+  bool bound_ = false;
+  std::wstring handled_;
+};
+
+struct Alpha {
+  static std::wstring_view Id() { return L"alpha"; }
+  static std::vector<std::wstring> Actions() { return {L"alpha-launch"}; }
+  static std::vector<std::wstring> Caps() { return {}; }
+};
+struct BadCap {
+  static std::wstring_view Id() { return L"badcap"; }
+  static std::vector<std::wstring> Actions() { return {}; }
+  static std::vector<std::wstring> Caps() { return {L"kernel:admin"}; }
+};
+struct Mismatch {
+  static std::wstring_view Id() { return L"mismatch"; }
+  static std::vector<std::wstring> Actions() { return {}; }
+  static std::vector<std::wstring> Caps() { return {L"config:write"}; }
+};
+struct ClaimA {
+  static std::wstring_view Id() { return L"claim-a"; }
+  static std::vector<std::wstring> Actions() { return {}; }
+  static std::vector<std::wstring> Caps() { return {L"settings:all"}; }
+};
+struct ClaimB {
+  static std::wstring_view Id() { return L"claim-b"; }
+  static std::vector<std::wstring> Actions() { return {}; }
+  static std::vector<std::wstring> Caps() { return {L"settings:all"}; }
+};
+
+std::unique_ptr<modules::ModuleDescriptor> MakeAlpha() {
+  return std::make_unique<SimpleModule<Alpha>>();
+}
+std::unique_ptr<modules::ModuleDescriptor> MakeBadCap() {
+  return std::make_unique<SimpleModule<BadCap>>();
+}
+std::unique_ptr<modules::ModuleDescriptor> MakeMismatch() {
+  return std::make_unique<SimpleModule<Mismatch>>();
+}
+std::unique_ptr<modules::ModuleDescriptor> MakeClaimA() {
+  return std::make_unique<SimpleModule<ClaimA>>();
+}
+std::unique_ptr<modules::ModuleDescriptor> MakeClaimB() {
+  return std::make_unique<SimpleModule<ClaimB>>();
+}
+
+const char* kCore = R"({
+  "schema": "dhepz.ui.core",
+  "version": 1,
+  "tokens": {
+    "dark": { "text": "#E9EDF4", "window": "#14161B" },
+    "light": { "text": "#181C24", "window": "#F5F6F9" }
+  },
+  "allows_children": ["screen"],
+  "components": {
+    "screen": { "properties": {
+      "route_id": { "kind": "string", "required": true },
+      "module_id": { "kind": "string" },
+      "tab_label": { "kind": "string" } } },
+    "text": { "properties": { "text": { "kind": "text", "required": true } } }
+  }
+})";
+
+const char* kScreenAlpha =
+    R"({ "type": "screen", "route_id": "alpha-home", "module_id": "alpha",
+         "tab_label": "Alpha", "children": [ { "type": "text", "text": "a" } ] })";
+
+std::wstring EmbeddedWith(const std::wstring& screens, const std::wstring& manifests) {
+  return L"{ \"core\": " + W(kCore) + L", \"components\": [ " + screens +
+         L" ], \"modules\": [ " + manifests + L" ] }";
+}
+
+std::wstring ManifestFor(const wchar_t* id, const wchar_t* caps = L"") {
+  return std::wstring(L"{ \"moduleId\": \"") + id + L"\", \"tabLabel\": \"" + id +
+         L"\", \"capabilities\": [" + caps + L"] }";
+}
+
+}  // namespace
+
+DHEPZ_TEST(AppGate, HealthyModuleMountsActivatesAndDispatches) {
+  modules::ResetRegistryForTests();
+  modules::RegisterModule(L"alpha", &MakeAlpha);
+  modules::AppGate gate;
+  DHEPZ_CHECK(
+      gate.StartWithEmbedded(EmbeddedWith(W(kScreenAlpha), ManifestFor(L"alpha"))).ok());
+  DHEPZ_CHECK(gate.Rejects().empty());
+  DHEPZ_CHECK(gate.Mounted(L"alpha"));
+  DHEPZ_CHECK_EQ(gate.Peers().size(), static_cast<std::size_t>(1));
+
+  DHEPZ_CHECK(gate.Activate(L"alpha-home").ok());
+  json::Value payload;
+  json::Value patch;
+  DHEPZ_CHECK(gate.Dispatch(L"alpha-launch", payload, &patch).ok());
+  DHEPZ_CHECK(!gate.Dispatch(L"unknown-action", payload, &patch).ok());
+
+  // RequestRoute navigates and activates lazily.
+  DHEPZ_CHECK(gate.RequestRoute(L"alpha-home").ok());
+  DHEPZ_CHECK_EQ(gate.current_route(), std::wstring(L"alpha-home"));
+  DHEPZ_CHECK(!gate.RequestRoute(L"nope").ok());
+  modules::ResetRegistryForTests();
+}
+
+DHEPZ_TEST(AppGate, BrokenModulesRejectedAppContinues) {
+  modules::ResetRegistryForTests();
+  modules::RegisterModule(L"alpha", &MakeAlpha);
+  modules::RegisterModule(L"badcap", &MakeBadCap);
+  modules::RegisterModule(L"ghost", &MakeAlpha);  // registered but no screen half
+  modules::AppGate gate;
+  const std::wstring screens =
+      W(kScreenAlpha) +
+      L", { \"type\": \"screen\", \"route_id\": \"badcap-home\", \"module_id\": \"badcap\","
+        L" \"children\": [ { \"type\": \"text\", \"text\": \"b\" } ] }";
+  const std::wstring manifests =
+      ManifestFor(L"alpha") + L", " + ManifestFor(L"badcap", L"\"kernel:admin\"") + L", " +
+      ManifestFor(L"ghost");
+  DHEPZ_CHECK(gate.StartWithEmbedded(EmbeddedWith(screens, manifests)).ok());
+
+  DHEPZ_CHECK(gate.Mounted(L"alpha"));
+  DHEPZ_CHECK(!gate.Mounted(L"badcap"));
+  DHEPZ_CHECK(!gate.Mounted(L"ghost"));
+  DHEPZ_CHECK_EQ(gate.Rejects().size(), static_cast<std::size_t>(2));
+  bool saw_unknown_cap = false;
+  bool saw_no_screen = false;
+  for (const modules::RejectEntry& reject : gate.Rejects()) {
+    if (reject.reason.find(L"kernel:admin") != std::wstring::npos) saw_unknown_cap = true;
+    if (reject.reason.find(L"screen half") != std::wstring::npos) saw_no_screen = true;
+  }
+  DHEPZ_CHECK(saw_unknown_cap);
+  DHEPZ_CHECK(saw_no_screen);
+  modules::ResetRegistryForTests();
+}
+
+DHEPZ_TEST(AppGate, CapabilityMismatchBetweenCodeAndManifestRejected) {
+  modules::ResetRegistryForTests();
+  modules::RegisterModule(L"mismatch", &MakeMismatch);
+  modules::AppGate gate;
+  const std::wstring screens =
+      L"{ \"type\": \"screen\", \"route_id\": \"mismatch-home\", \"module_id\": \"mismatch\","
+        L" \"children\": [ { \"type\": \"text\", \"text\": \"m\" } ] }";
+  // Manifest declares no capabilities; the code declares config:write.
+  DHEPZ_CHECK(gate.StartWithEmbedded(EmbeddedWith(screens, ManifestFor(L"mismatch"))).ok());
+  DHEPZ_CHECK(!gate.Mounted(L"mismatch"));
+  DHEPZ_CHECK_EQ(gate.Rejects().size(), static_cast<std::size_t>(1));
+  DHEPZ_CHECK(gate.Rejects()[0].reason.find(L"does not match") != std::wstring::npos);
+  modules::ResetRegistryForTests();
+}
+
+DHEPZ_TEST(AppGate, SettingsAllIsSingleClaimant) {
+  modules::ResetRegistryForTests();
+  modules::RegisterModule(L"claim-a", &MakeClaimA);
+  modules::RegisterModule(L"claim-b", &MakeClaimB);
+  modules::AppGate gate;
+  const std::wstring screens =
+      L"{ \"type\": \"screen\", \"route_id\": \"a-home\", \"module_id\": \"claim-a\","
+        L" \"children\": [ { \"type\": \"text\", \"text\": \"a\" } ] },"
+        L"{ \"type\": \"screen\", \"route_id\": \"b-home\", \"module_id\": \"claim-b\","
+        L" \"children\": [ { \"type\": \"text\", \"text\": \"b\" } ] }";
+  const std::wstring manifests =
+      ManifestFor(L"claim-a", L"\"settings:all\"") + L", " +
+      ManifestFor(L"claim-b", L"\"settings:all\"");
+  DHEPZ_CHECK(gate.StartWithEmbedded(EmbeddedWith(screens, manifests)).ok());
+  DHEPZ_CHECK(gate.Mounted(L"claim-a"));
+  DHEPZ_CHECK(!gate.Mounted(L"claim-b"));
+  DHEPZ_CHECK_EQ(gate.Rejects().size(), static_cast<std::size_t>(1));
+  DHEPZ_CHECK(gate.Rejects()[0].reason.find(L"already claimed") != std::wstring::npos);
+  modules::ResetRegistryForTests();
+}

--- a/tools/Merge-UiConfig.ps1
+++ b/tools/Merge-UiConfig.ps1
@@ -35,6 +35,7 @@ if ($GenerateEmbedded) {
     # it before the exe exists; full schema validation runs at test time and
     # at the gate.
     $components = New-Object System.Collections.ArrayList
+    $manifests = New-Object System.Collections.ArrayList
     $screensRoot = Join-Path $RepositoryRoot 'assets\ui\screens'
     if (Test-Path -LiteralPath $screensRoot -PathType Container) {
         foreach ($file in @(Get-ChildItem -LiteralPath $screensRoot -Filter *.json | Sort-Object Name)) {
@@ -59,9 +60,12 @@ if ($GenerateEmbedded) {
             }
             $doc = Get-Content -LiteralPath $screenPath -Raw | ConvertFrom-Json
             foreach ($component in $doc.components) { $null = $components.Add($component) }
+            $manifest = Get-Content -LiteralPath $manifestPath -Raw | ConvertFrom-Json
+            $null = $manifests.Add($manifest)
         }
     }
-    $merged = [ordered]@{ components = $components }
+    $core = Get-Content -LiteralPath (Join-Path $RepositoryRoot 'assets\ui\core.json') -Raw | ConvertFrom-Json
+    $merged = [ordered]@{ core = $core; components = $components; modules = $manifests }
     $outDir = Join-Path $RepositoryRoot 'build\generated'
     $null = New-Item -ItemType Directory -Force -Path $outDir
     $json = ($merged | ConvertTo-Json -Depth 32) + "`n"


### PR DESCRIPTION
The single gate per plan Part 3: embedded core+screens+manifests resolved, pairing rules enforced with precise reject reasons, lazy activation, action dispatch, peers metadata, per-module narrowed host. Tests: healthy mount/activate/dispatch, unknown capability, code/manifest mismatch, missing screen half, settings:all single claimant — app always starts.