### PR TITLE
feat(modules): built-in diagnostics module + action cross-check (#84)

### DIFF
--- a/src/modules/diagnostics/diagnostics_module.cpp
+++ b/src/modules/diagnostics/diagnostics_module.cpp
@@ -1,0 +1,66 @@
+// Built-in diagnostics module: always compiled in, cannot be excluded
+// (plan Part 3, degraded mode). Records module load/validation failures
+// from the gate and surfaces them via Log/ReportStatus; the rendered
+// in-app list lands with viewState bindings, the CI artifact with #85.
+#include "modules/contract/module_contract.h"
+#include "modules/gate/app_gate.h"
+#include "modules/registry/module_registry.h"
+
+#include <memory>
+#include <string>
+
+namespace {
+
+class DiagnosticsModule final : public modules::ModuleDescriptor {
+ public:
+  std::wstring_view ModuleId() const override { return L"diagnostics"; }
+  std::wstring_view TabLabel() const override { return L"Diagnostics"; }
+  int Order() const override { return 900; }
+  bool ShowInTabs() const override { return false; }
+  std::wstring_view SettingsRoute() const override { return {}; }
+  std::vector<std::wstring> DeclaredActions() const override {
+    return {L"diagnostics:refresh"};
+  }
+  std::vector<std::wstring> DeclaredBindings() const override { return {}; }
+  std::vector<std::wstring> DeclaredCapabilities() const override { return {}; }
+
+  core::Status Bind(modules::ModuleHost& host) override {
+    host_ = &host;
+    return core::Ok();
+  }
+
+  core::Status Handle(std::wstring_view action, const json::Value&, json::Value*) override {
+    if (action != L"diagnostics:refresh" || host_ == nullptr) {
+      return core::Err(core::ErrorCode::NotFound, L"unknown action");
+    }
+    last_summary_.clear();
+    for (const modules::RejectEntry& reject : modules::CurrentRejects()) {
+      const std::wstring line = reject.module_id + L": " + reject.reason;
+      host_->Log(L"warn", line);
+      if (!last_summary_.empty()) last_summary_ += L"\n";
+      last_summary_ += line;
+    }
+    return core::Ok();
+  }
+
+  void Release() override { host_ = nullptr; }
+
+  static const std::wstring& LastSummary() { return last_summary_; }
+
+ private:
+  modules::ModuleHost* host_ = nullptr;
+  inline static std::wstring last_summary_;
+};
+
+std::unique_ptr<modules::ModuleDescriptor> Make() {
+  return std::make_unique<DiagnosticsModule>();
+}
+
+const modules::ModuleRegistrar registrar{L"diagnostics", &Make};
+
+}  // namespace
+
+namespace modules {
+const std::wstring& DiagnosticsLastSummary() { return DiagnosticsModule::LastSummary(); }
+std::unique_ptr<ModuleDescriptor> MakeDiagnosticsForTests() { return Make(); }
+}  // namespace modules

--- a/src/modules/diagnostics/diagnostics_module.h
+++ b/src/modules/diagnostics/diagnostics_module.h
@@ -1,0 +1,18 @@
+// Built-in diagnostics module (P3-04). Always compiled in; the gate's
+// reject list is its input, Log/ReportStatus its output until the rendered
+// list lands with viewState bindings.
+#pragma once
+
+#include <memory>
+#include <string>
+
+#include "modules/contract/module_contract.h"
+
+namespace modules {
+
+// Summary text produced by the last diagnostics:refresh dispatch.
+const std::wstring& DiagnosticsLastSummary();
+// Test hook: a fresh diagnostics descriptor without relying on statics.
+std::unique_ptr<ModuleDescriptor> MakeDiagnosticsForTests();
+
+}  // namespace modules

--- a/src/modules/diagnostics/module.json
+++ b/src/modules/diagnostics/module.json
@@ -1,0 +1,9 @@
+{
+  "moduleId": "diagnostics",
+  "tabLabel": "Diagnostics",
+  "order": 900,
+  "showInTabs": false,
+  "actions": ["diagnostics:refresh"],
+  "bindings": [],
+  "capabilities": []
+}

--- a/src/modules/diagnostics/screen.json
+++ b/src/modules/diagnostics/screen.json
@@ -1,0 +1,15 @@
+{
+  "components": [
+    {
+      "type": "screen",
+      "route_id": "diagnostics",
+      "module_id": "diagnostics",
+      "tab_label": "Diagnostics",
+      "show_in_tabs": false,
+      "children": [
+        { "type": "text", "text": "Diagnostics", "variant": "title" },
+        { "type": "text", "text": "Rejected modules appear here with file and line. The rendered list lands with viewState bindings; until then rejections are logged and exported to CI." }
+      ]
+    }
+  ]
+}

--- a/src/modules/gate/app_gate.cpp
+++ b/src/modules/gate/app_gate.cpp
@@ -1,5 +1,6 @@
 #include "modules/gate/app_gate.h"
 
+#include <algorithm>
 #include <map>
 #include <mutex>
 
@@ -12,7 +13,14 @@ namespace {
 
 std::vector<RegisteredModule> RegistrySnapshot() { return CollectModules(); }
 
+const std::vector<RejectEntry>* g_rejects = nullptr;
+
 }  // namespace
+
+const std::vector<RejectEntry>& CurrentRejects() {
+  static const std::vector<RejectEntry> empty;
+  return g_rejects != nullptr ? *g_rejects : empty;
+}
 
 // Per-module host view. Settings reach is narrowed here by construction:
 // writes land only in the module's own section; global is read-only.
@@ -132,7 +140,10 @@ core::Status AppGate::PairAndMount(std::wstring_view embedded_text,
       ModuleManifest manifest;
       std::vector<ManifestDiagnostic> manifest_diags;
       if (!ParseManifest(json::Serialize(manifest_value), &manifest, &manifest_diags).ok()) {
-        rejects_.push_back({manifest.module_id.empty() ? L"?" : manifest.module_id,
+        const json::Value* raw_id = manifest_value.Find(L"moduleId");
+        const std::wstring id =
+            (raw_id != nullptr && raw_id->is_string()) ? raw_id->AsString() : L"?";
+        rejects_.push_back({id,
                             L"manifest invalid: " +
                                 (manifest_diags.empty() ? L"?" : manifest_diags[0].message)});
         continue;
@@ -169,6 +180,22 @@ core::Status AppGate::PairAndMount(std::wstring_view embedded_text,
         rejects_.push_back({manifest.module_id,
                             L"DeclaredCapabilities() does not match module.json"});
         continue;
+      }
+      {
+        const std::vector<std::wstring> code_actions = descriptor->DeclaredActions();
+        std::vector<std::wstring> missing_in_code;
+        for (const std::wstring& action : manifest.actions) {
+          if (std::find(code_actions.begin(), code_actions.end(), action) ==
+              code_actions.end()) {
+            missing_in_code.push_back(action);
+          }
+        }
+        if (!missing_in_code.empty()) {
+          rejects_.push_back({manifest.module_id,
+                              L"action '" + missing_in_code[0] +
+                                  L"' declared in module.json has no handler in C++"});
+          continue;
+        }
       }
       bool capability_ok = true;
       for (const std::wstring& cap : declared) {
@@ -229,6 +256,7 @@ core::Status AppGate::PairAndMount(std::wstring_view embedded_text,
   }
 
   current_route_ = document_->initial_route();
+  g_rejects = &rejects_;
   return core::Ok();
 }
 

--- a/src/modules/gate/app_gate.h
+++ b/src/modules/gate/app_gate.h
@@ -25,6 +25,10 @@ struct RejectEntry {
   std::wstring reason;
 };
 
+// Reject list of the most recent gate Start — the diagnostics module reads
+// this; there is exactly one gate (single choke point).
+const std::vector<RejectEntry>& CurrentRejects();
+
 class GateHost;
 
 class AppGate final {

--- a/tests/dhepz_tests.vcxproj
+++ b/tests/dhepz_tests.vcxproj
@@ -131,6 +131,7 @@
     <ClCompile Include="..\src\modules\contract\**\*.cpp" />
     <ClCompile Include="..\src\modules\registry\**\*.cpp" />
     <ClCompile Include="..\src\modules\gate\**\*.cpp" />
+    <ClCompile Include="..\src\modules\diagnostics\**\*.cpp" />
     <ClInclude Include="**\*.h" />
     <ResourceCompile Include="app_icon.rc" />
   </ItemGroup>

--- a/tests/modules/diagnostics/diagnostics_test.cpp
+++ b/tests/modules/diagnostics/diagnostics_test.cpp
@@ -1,0 +1,140 @@
+#include "modules/diagnostics/diagnostics_module.h"
+
+#include "framework/test_case.h"
+#include "modules/gate/app_gate.h"
+#include "modules/registry/module_registry.h"
+
+#include <cstdio>
+#include <memory>
+#include <string>
+
+namespace {
+
+std::wstring W(const char* utf8) {
+  std::wstring wide;
+  for (const char* p = utf8; *p != '\0'; ++p) {
+    wide.push_back(static_cast<wchar_t>(static_cast<unsigned char>(*p)));
+  }
+  return wide;
+}
+
+const char* kCore = R"({
+  "schema": "dhepz.ui.core",
+  "version": 1,
+  "tokens": {
+    "dark": { "text": "#E9EDF4", "window": "#14161B" },
+    "light": { "text": "#181C24", "window": "#F5F6F9" }
+  },
+  "allows_children": ["screen"],
+  "components": {
+    "screen": { "properties": {
+      "route_id": { "kind": "string", "required": true },
+      "module_id": { "kind": "string" },
+      "tab_label": { "kind": "string" },
+      "show_in_tabs": { "kind": "bool" } } },
+    "text": { "properties": { "text": { "kind": "text", "required": true } } }
+  }
+})";
+
+struct Healthy {
+  static std::wstring_view Id() { return L"alpha"; }
+  static std::vector<std::wstring> Actions() { return {L"launch"}; }
+  static std::vector<std::wstring> Caps() { return {}; }
+};
+struct Typo {
+  static std::wstring_view Id() { return L"typo"; }
+  // The handler registered under the misspelled name; module.json declares
+  // the correct one, so the gate must reject the module naming the action.
+  static std::vector<std::wstring> Actions() { return {L"lauch"}; }
+  static std::vector<std::wstring> Caps() { return {}; }
+};
+
+template <typename Base>
+class SimpleModule final : public modules::ModuleDescriptor {
+ public:
+  std::wstring_view ModuleId() const override { return Base::Id(); }
+  std::wstring_view TabLabel() const override { return Base::Id(); }
+  int Order() const override { return 100; }
+  bool ShowInTabs() const override { return true; }
+  std::wstring_view SettingsRoute() const override { return {}; }
+  std::vector<std::wstring> DeclaredActions() const override { return Base::Actions(); }
+  std::vector<std::wstring> DeclaredBindings() const override { return {}; }
+  std::vector<std::wstring> DeclaredCapabilities() const override { return Base::Caps(); }
+  core::Status Bind(modules::ModuleHost&) override { return core::Ok(); }
+  core::Status Handle(std::wstring_view, const json::Value&, json::Value*) override {
+    return core::Ok();
+  }
+  void Release() override {}
+};
+
+std::unique_ptr<modules::ModuleDescriptor> MakeHealthy() {
+  return std::make_unique<SimpleModule<Healthy>>();
+}
+std::unique_ptr<modules::ModuleDescriptor> MakeTypo() {
+  return std::make_unique<SimpleModule<Typo>>();
+}
+
+std::wstring ScreenFor(const wchar_t* id) {
+  return std::wstring(L"{ \"type\": \"screen\", \"route_id\": \"") + id +
+         L"-home\", \"module_id\": \"" + id +
+         L"\", \"tab_label\": \"" + id +
+         L"\", \"children\": [ { \"type\": \"text\", \"text\": \"x\" } ] }";
+}
+
+}  // namespace
+
+DHEPZ_TEST(Diagnostics, ThreeFoldersHealthyActiveBrokenReported) {
+  modules::ResetRegistryForTests();
+  modules::RegisterModule(L"alpha", &MakeHealthy);
+  modules::RegisterModule(L"typo", &MakeTypo);
+  modules::RegisterModule(L"diagnostics", &modules::MakeDiagnosticsForTests);
+
+  const std::wstring screens = ScreenFor(L"alpha") + L", " + ScreenFor(L"typo") + L", " +
+                               ScreenFor(L"diagnostics");
+  // alpha healthy; typo declares the correct action name in module.json but
+  // the code registered the misspelling; malformed manifest does not parse.
+  // "broken" fails schema validation (missing tabLabel) — the runtime form
+  // of a corrupt manifest; byte-level malformed JSON fails the build (#85).
+  const std::wstring manifests =
+      L"{ \"moduleId\": \"alpha\", \"tabLabel\": \"alpha\", \"actions\": [\"launch\"] }, "
+      L"{ \"moduleId\": \"typo\", \"tabLabel\": \"typo\", \"actions\": [\"launch\"] }, "
+      L"{ \"moduleId\": \"broken\" }";
+  const std::wstring diagnostics_manifest =
+      L"{ \"moduleId\": \"diagnostics\", \"tabLabel\": \"Diagnostics\", "
+        L"\"showInTabs\": false, \"actions\": [\"diagnostics:refresh\"] }";
+  const std::wstring embedded = L"{ \"core\": " + W(kCore) + L", \"components\": [ " +
+                                screens + L" ], \"modules\": [ " + manifests + L", " +
+                                diagnostics_manifest + L" ] }";
+
+  modules::AppGate gate;
+  DHEPZ_CHECK(gate.StartWithEmbedded(embedded).ok());
+
+  DHEPZ_CHECK(gate.Mounted(L"alpha"));
+  DHEPZ_CHECK(gate.Mounted(L"diagnostics"));
+  DHEPZ_CHECK(!gate.Mounted(L"typo"));
+
+  // Both broken entries reported: the typo'd action and the malformed manifest.
+  DHEPZ_CHECK_EQ(gate.Rejects().size(), static_cast<std::size_t>(2));
+  bool saw_typo = false;
+  bool saw_malformed = false;
+  for (const modules::RejectEntry& reject : gate.Rejects()) {
+    if (reject.module_id == L"typo" &&
+        reject.reason.find(L"launch") != std::wstring::npos) {
+      saw_typo = true;
+    }
+    if (reject.module_id == L"broken" &&
+        reject.reason.find(L"manifest invalid") != std::wstring::npos) {
+      saw_malformed = true;
+    }
+  }
+  DHEPZ_CHECK(saw_typo);
+  DHEPZ_CHECK(saw_malformed);
+
+  // The diagnostics module summarizes the reject list on refresh.
+  DHEPZ_CHECK(gate.Activate(L"diagnostics").ok());
+  json::Value payload;
+  json::Value patch;
+  DHEPZ_CHECK(gate.Dispatch(L"diagnostics:refresh", payload, &patch).ok());
+  DHEPZ_CHECK(modules::DiagnosticsLastSummary().find(L"typo") != std::wstring::npos);
+  modules::ResetRegistryForTests();
+}


### PR DESCRIPTION
Diagnostics module (always compiled in) reads the gate reject list and logs a summary on refresh; gate cross-checks manifest actions vs DeclaredActions naming the typo; corrupt manifest rejects keep the module id. Integration test: healthy + typo'd + corrupt — healthy active, both broken reported, app starts.