### PR TITLE
docs(phase4): add Phase 4 issue drafts

### DIFF
--- a/.github/planning/p4-01-terminal-scaffold.md
+++ b/.github/planning/p4-01-terminal-scaffold.md
@@ -1,0 +1,19 @@
+P4-01 Terminal module scaffold and manifest
+
+Scope
+- Create the terminal module folder shape used as the Phase 4 reference module.
+- Include module.json manifest, module entrypoints, minimal UI screen JSON (screen id + route), and New-Module-derived scaffold for the terminal.
+- Ensure the module builds into the EXE and self-registers with ModuleRegistry.
+
+Acceptance criteria
+- The scaffolded module compiles and is discovered by the ModuleRegistry without editing central files.
+- module.json is valid and declares the capabilities it needs (process:launch, settings:own) and no global reach.
+- The module folder is self-contained: all code, assets, and manifest live inside it.
+
+Verification
+- Unit test: scaffold -> build -> discovery shows the module in the ModuleRegistry.
+- Manual check: module folder contains only its own files; no central file edits were required.
+
+Scope: S
+
+Do not start until: Phase 3 gate is closed and P3-01..P3-06 are merged.

--- a/.github/planning/p4-02-process-launch-and-runcapture.md
+++ b/.github/planning/p4-02-process-launch-and-runcapture.md
@@ -1,0 +1,19 @@
+P4-02 Process launch and RunCapture for shells
+
+Scope
+- Implement robust process launch helpers and RunCapture used by the terminal module for launching PowerShell, Admin elevation, and other shells.
+- Ensure process output capture is deadlock-free, bounded, deadline-aware, and offloaded to a worker when blocking.
+- Add strict command-line building using str::QuoteArg and safe argument passing.
+
+Acceptance criteria
+- The RunCapture helper returns exit code, stdout/stderr, and a timed-out status; it never blocks the UI thread.
+- Process launch paths use QuoteArg for all child arguments; no ad-hoc concatenation.
+- Elevation and Admin launch paths are present and fail with an explanatory Status when unavailable.
+
+Verification
+- Tests that RunCapture captures stdout/stderr and times out at the given deadline.
+- Smoke test: launching PowerShell and retrieving its version string via RunCapture on a worker.
+
+Scope: M
+
+Do not start until: P4-01 scaffold is merged.

--- a/.github/planning/p4-03-wsl-enumeration-and-caching.md
+++ b/.github/planning/p4-03-wsl-enumeration-and-caching.md
@@ -1,0 +1,19 @@
+P4-03 WSL enumeration and caching
+
+Scope
+- Implement WSL distro enumeration (`wsl -l -q`) via RunCapture on a worker and cache per session.
+- Provide an explicit refresh operation and an invalidation path when the cache is stale.
+- Ensure UTF-16/UTF-8 sniffing and correct decoding of captured output.
+
+Acceptance criteria
+- WSL enumeration runs on a worker and returns a stable list of distro names.
+- Adding a new distro (on the machine) becomes visible after calling the explicit refresh; no rebuild required.
+- Enumeration is cached per process session and refreshable via UI.
+
+Verification
+- Integration test: mock RunCapture output to return a list and verify the cache + refresh behavior.
+- Manual check on a machine with WSL installed shows distro list returned and refresh picks up new ones.
+
+Scope: S
+
+Do not start until: P4-02 has basic RunCapture tests passing.

--- a/.github/planning/p4-04-recent-folders-and-venv-toggle.md
+++ b/.github/planning/p4-04-recent-folders-and-venv-toggle.md
@@ -1,0 +1,19 @@
+P4-04 Recent folders, venv toggle, and folder validation
+
+Scope
+- Implement recent-folder history in the terminal module, user-visible in the terminal UI.
+- Add venv toggle support (virtualenv/venv detection and activation toggle) in the module UI.
+- Validate folder paths on a worker and surface human-friendly diagnostics when invalid.
+
+Acceptance criteria
+- Recent folders persist per-session and across runs in the module's own storage section.
+- Venv toggle detects standard virtualenv layouts and toggles activation in the launched shell.
+- Folder validation is performed on a worker; invalid folders show a Status diagnostic without blocking the UI.
+
+Verification
+- Unit tests for recent-folder add/remove and persistence.
+- Integration test for venv detection logic with sample folder layouts.
+
+Scope: S
+
+Do not start until: P4-03 WSL enumeration is in review.

--- a/.github/planning/p4-05-worker-offload-and-validation.md
+++ b/.github/planning/p4-05-worker-offload-and-validation.md
@@ -1,0 +1,19 @@
+P4-05 Worker offload: validation, enumeration, and blocking work
+
+Scope
+- Ensure all blocking work (RunCapture, folder validation, distro enumeration, heavy IO) runs on the worker pool.
+- Add completion callbacks posted to the UI thread with safe marshaling and Status results.
+- Instrument the worker tasks so CI can detect if work is accidentally performed on the UI thread.
+
+Acceptance criteria
+- No worker-bound function performs blocking IO on the UI thread.
+- Callbacks arrive on the UI thread with a Status; failures are handled gracefully.
+- Tests or instrumentation assert the worker pool handles the expected load.
+
+Verification
+- Unit tests that artificially delay worker tasks and assert the UI thread remains responsive.
+- Instrumentation added to the test run to assert no blocking operations on the UI thread.
+
+Scope: M
+
+Do not start until: P4-02 and P4-03 are merged and tested.

--- a/.github/planning/p4-06-phase4-gate.md
+++ b/.github/planning/p4-06-phase4-gate.md
@@ -1,0 +1,19 @@
+P4-06 Phase 4 gate verification
+
+Scope
+- Consolidate Phase 4 verification steps and run the gate checklist.
+
+Acceptance criteria (gate)
+- Terminal module launches PowerShell (and other enumerated shells) and returns a usable prompt.
+- UI thread never blocks when launching a shell; measured traces confirm the work is offloaded.
+- WSL distro enumeration is cached and refreshable; adding a distro is visible after refresh.
+- The terminal module touches only its own folder; adding or deleting the folder appears/disappears without editing other files.
+- CI asserts the gate (integration tests + instrumentation).
+
+Verification
+- Integration tests and CI-run instrumentation demonstrate warm-start budgets and worker-offload behavior.
+- The gate checklist is recorded in the PR and must pass before Phase 5 is broken down.
+
+Scope: M
+
+Do not start until: P4-01..P4-05 are merged and their core tests pass.


### PR DESCRIPTION
docs(phase4): add Phase 4 issue drafts (P4-01..P4-06)

Adds Phase 4 planning drafts under .github/planning so reviewers can read and
convert them into GitHub issues when ready. Phase 4 is the terminal reference
module: process launch, WSL enumeration, worker offload, recent folders/venv.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
