### PR TITLE
feat(modules): terminal module scaffold (#94)

### DIFF
--- a/src/modules/terminal/module.json
+++ b/src/modules/terminal/module.json
@@ -1,0 +1,9 @@
+{
+  "moduleId": "terminal",
+  "tabLabel": "Terminal",
+  "order": 10,
+  "showInTabs": true,
+  "actions": ["terminal:launch"],
+  "bindings": [],
+  "capabilities": []
+}

--- a/src/modules/terminal/screen.json
+++ b/src/modules/terminal/screen.json
@@ -1,0 +1,15 @@
+{
+  "components": [
+    {
+      "type": "screen",
+      "route_id": "terminal",
+      "module_id": "terminal",
+      "tab_label": "Terminal",
+      "show_in_tabs": true,
+      "children": [
+        { "type": "text", "text": "Terminal", "variant": "title" },
+        { "type": "button", "label": "Open PowerShell" }
+      ]
+    }
+  ]
+}

--- a/src/modules/terminal/terminal_logic.cpp
+++ b/src/modules/terminal/terminal_logic.cpp
@@ -1,0 +1,27 @@
+#include "modules/terminal/terminal_logic.h"
+
+#include "platform/strings.h"
+
+namespace terminal {
+
+std::wstring BuildCommandLine(const LaunchSpec& spec) {
+  std::wstring command;
+  switch (spec.shell) {
+    case Shell::PowerShell:
+      command = L"powershell.exe -NoExit";
+      break;
+    case Shell::Cmd:
+      command = L"cmd.exe";
+      break;
+    case Shell::Wsl:
+      command = L"wsl.exe -d " + str::QuoteArg(spec.wsl_distro);
+      break;
+  }
+  if (spec.venv_enabled && !spec.venv_activate_path.empty()) {
+    command += L" -NoExit -Command " + str::QuoteArg(spec.venv_activate_path);
+  }
+  (void)spec.working_dir;  // applied as the child's working directory at launch
+  return command;
+}
+
+}  // namespace terminal

--- a/src/modules/terminal/terminal_logic.h
+++ b/src/modules/terminal/terminal_logic.h
@@ -1,0 +1,23 @@
+// Terminal feature logic — no UI types (plan: terminal_logic.* is the
+// feature itself). Command lines are built strictly through QuoteArg.
+#pragma once
+
+#include <string>
+
+namespace terminal {
+
+enum class Shell { PowerShell, Cmd, Wsl };
+
+struct LaunchSpec {
+  Shell shell = Shell::PowerShell;
+  std::wstring working_dir;
+  std::wstring wsl_distro;   // used when shell == Wsl
+  bool admin = false;       // elevation handled by ShellLaunch (P4-02)
+  bool venv_enabled = false;
+  std::wstring venv_activate_path;
+};
+
+// Builds the child command line; every argument quoted via str::QuoteArg.
+std::wstring BuildCommandLine(const LaunchSpec& spec);
+
+}  // namespace terminal

--- a/src/modules/terminal/terminal_module.cpp
+++ b/src/modules/terminal/terminal_module.cpp
@@ -1,0 +1,54 @@
+// Self-registering logic half of the terminal module (P4-01). The real
+// launch path lands in P4-02; until then terminal:launch reports
+// Unsupported so a missing implementation can never masquerade as success.
+#include "modules/contract/module_contract.h"
+#include "modules/registry/module_registry.h"
+#include "modules/terminal/terminal_logic.h"
+
+#include <memory>
+
+namespace terminal {
+namespace {
+
+class TerminalModule final : public modules::ModuleDescriptor {
+ public:
+  std::wstring_view ModuleId() const override { return L"terminal"; }
+  std::wstring_view TabLabel() const override { return L"Terminal"; }
+  int Order() const override { return 10; }
+  bool ShowInTabs() const override { return true; }
+  std::wstring_view SettingsRoute() const override { return {}; }
+  std::vector<std::wstring> DeclaredActions() const override { return {L"terminal:launch"}; }
+  std::vector<std::wstring> DeclaredBindings() const override { return {}; }
+  std::vector<std::wstring> DeclaredCapabilities() const override { return {}; }
+
+  core::Status Bind(modules::ModuleHost& host) override {
+    host_ = &host;
+    return core::Ok();
+  }
+
+  core::Status Handle(std::wstring_view action, const json::Value&, json::Value*) override {
+    if (action != L"terminal:launch") {
+      return core::Err(core::ErrorCode::NotFound, L"terminal: unknown action");
+    }
+    // P4-02 wires ProcessRun; until then refuse loudly-but-gracefully.
+    return core::Err(core::ErrorCode::Unsupported,
+                     L"terminal:launch lands with P4-02 process launch");
+  }
+
+  void Release() override { host_ = nullptr; }
+
+ private:
+  modules::ModuleHost* host_ = nullptr;
+};
+
+std::unique_ptr<modules::ModuleDescriptor> Make() {
+  return std::make_unique<TerminalModule>();
+}
+
+const modules::ModuleRegistrar registrar{L"terminal", &Make};
+
+}  // namespace
+
+std::unique_ptr<modules::ModuleDescriptor> MakeTerminalForTests() { return Make(); }
+
+}  // namespace terminal

--- a/src/modules/terminal/terminal_module.h
+++ b/src/modules/terminal/terminal_module.h
@@ -1,0 +1,13 @@
+// Terminal module scaffold (P4-01): self-contained folder, discovered
+// without central edits, manifest valid with no capabilities.
+#pragma once
+
+#include <memory>
+
+#include "modules/contract/module_contract.h"
+
+namespace terminal {
+
+std::unique_ptr<modules::ModuleDescriptor> MakeTerminalForTests();
+
+}  // namespace terminal

--- a/tests/dhepz_tests.vcxproj
+++ b/tests/dhepz_tests.vcxproj
@@ -132,6 +132,7 @@
     <ClCompile Include="..\src\modules\registry\**\*.cpp" />
     <ClCompile Include="..\src\modules\gate\**\*.cpp" />
     <ClCompile Include="..\src\modules\diagnostics\**\*.cpp" />
+    <ClCompile Include="..\src\modules\terminal\**\*.cpp" />
     <ClInclude Include="**\*.h" />
     <ResourceCompile Include="app_icon.rc" />
   </ItemGroup>

--- a/tests/modules/terminal/terminal_scaffold_test.cpp
+++ b/tests/modules/terminal/terminal_scaffold_test.cpp
@@ -1,0 +1,74 @@
+#include "modules/terminal/terminal_module.h"
+
+#include <windows.h>
+
+#include <fstream>
+#include <sstream>
+#include <string>
+
+#include "framework/test_case.h"
+#include "modules/contract/module_manifest.h"
+#include "modules/registry/module_registry.h"
+#include "modules/terminal/terminal_logic.h"
+
+namespace {
+
+std::wstring Ws(const std::string& narrow) {
+  std::wstring wide;
+  for (const char c : narrow) wide.push_back(static_cast<wchar_t>(static_cast<unsigned char>(c)));
+  return wide;
+}
+
+std::string ReadFile(const std::wstring& path) {
+  std::ifstream stream(path, std::ios::binary);
+  std::ostringstream text;
+  text << stream.rdbuf();
+  return text.str();
+}
+
+std::wstring RepoRoot() {
+  wchar_t buffer[MAX_PATH]{};
+  GetModuleFileNameW(nullptr, buffer, MAX_PATH);
+  std::wstring path(buffer);
+  for (int i = 0; i < 4; ++i) {
+    const auto slash = path.find_last_of(L"\\/");
+    if (slash == std::wstring::npos) return {};
+    path.resize(slash);
+  }
+  return path;
+}
+
+}  // namespace
+
+DHEPZ_TEST(TerminalScaffold, ManifestValidWithNoCapabilities) {
+  const std::wstring root = RepoRoot();
+  const std::string manifest_text =
+      ReadFile(root + L"\\src\\modules\\terminal\\module.json");
+  DHEPZ_CHECK(!manifest_text.empty());
+  modules::ModuleManifest manifest;
+  std::vector<modules::ManifestDiagnostic> diagnostics;
+  DHEPZ_CHECK(
+      modules::ParseManifest(Ws(manifest_text), &manifest, &diagnostics).ok());
+  DHEPZ_CHECK_EQ(manifest.module_id, std::wstring(L"terminal"));
+  DHEPZ_CHECK(manifest.capabilities.empty());
+  DHEPZ_CHECK(manifest.show_in_tabs);
+}
+
+DHEPZ_TEST(TerminalScaffold, SelfRegistersAndIsDiscoverable) {
+  modules::ResetRegistryForTests();
+  modules::RegisterModule(L"terminal", &terminal::MakeTerminalForTests);
+  bool found = false;
+  for (const modules::RegisteredModule& module : modules::CollectModules()) {
+    if (module.module_id == L"terminal") found = true;
+  }
+  DHEPZ_CHECK(found);
+  modules::ResetRegistryForTests();
+}
+
+DHEPZ_TEST(TerminalLogic, WslCommandLineQuotesTheDistro) {
+  terminal::LaunchSpec spec;
+  spec.shell = terminal::Shell::Wsl;
+  spec.wsl_distro = L"My Distro";
+  const std::wstring command = terminal::BuildCommandLine(spec);
+  DHEPZ_CHECK(command.find(L"\"My Distro\"") != std::wstring::npos);
+}


### PR DESCRIPTION
P4-01: self-contained terminal folder (manifest without capabilities, screen.json, self-registering descriptor, QuoteArg-strict terminal_logic). Tests: manifest valid, registry discovery, WSL distro quoting. The embedded merge picks the screen up with no central edits.