### PR TITLE
feat(platform): process launch, ShellLaunch, deadline-aware RunCapture (#95)

### DIFF
--- a/src/modules/gate/app_gate.cpp
+++ b/src/modules/gate/app_gate.cpp
@@ -6,6 +6,7 @@
 
 #include "core/json.h"
 #include "modules/registry/module_registry.h"
+#include "platform/process.h"
 #include "ui/config/config_store.h"
 
 namespace modules {
@@ -68,9 +69,15 @@ class GateHost final : public ModuleHost {
     return core::Ok();
   }
 
-  core::Status ProcessRun(std::wstring_view, std::wstring*) override {
-    // Worker offload lands with the terminal module (Phase 4).
-    return core::Err(core::ErrorCode::Unsupported, L"process launch not wired yet");
+  core::Status ProcessRun(std::wstring_view command_line, std::wstring* captured) override {
+    process::RunResult result;
+    const core::Status status = process::RunCapture(command_line, L"", 10000, &result);
+    if (!status.ok()) return status;
+    if (result.timed_out) {
+      return core::Err(core::ErrorCode::Cancelled, L"process timed out");
+    }
+    if (captured != nullptr) *captured = result.output;
+    return core::Ok();
   }
 
   void ReportStatus(const core::Status& status) override { last_status_ = status; }

--- a/src/modules/terminal/terminal_module.cpp
+++ b/src/modules/terminal/terminal_module.cpp
@@ -1,9 +1,10 @@
-// Self-registering logic half of the terminal module (P4-01). The real
-// launch path lands in P4-02; until then terminal:launch reports
-// Unsupported so a missing implementation can never masquerade as success.
+// Self-registering logic half of the terminal module. terminal:launch opens
+// an external console (P4-02); RunCapture-based flows (WSL enumeration etc.)
+// land with worker offload (P4-05).
 #include "modules/contract/module_contract.h"
 #include "modules/registry/module_registry.h"
 #include "modules/terminal/terminal_logic.h"
+#include "platform/process.h"
 
 #include <memory>
 
@@ -30,9 +31,9 @@ class TerminalModule final : public modules::ModuleDescriptor {
     if (action != L"terminal:launch") {
       return core::Err(core::ErrorCode::NotFound, L"terminal: unknown action");
     }
-    // P4-02 wires ProcessRun; until then refuse loudly-but-gracefully.
-    return core::Err(core::ErrorCode::Unsupported,
-                     L"terminal:launch lands with P4-02 process launch");
+    LaunchSpec spec;
+    const std::wstring command = BuildCommandLine(spec);
+    return process::Launch(L"", command, spec.working_dir, process::WindowMode::NewConsole);
   }
 
   void Release() override { host_ = nullptr; }

--- a/src/platform/process.cpp
+++ b/src/platform/process.cpp
@@ -1,0 +1,232 @@
+#include "platform/process.h"
+
+#include <windows.h>
+#include <objbase.h>
+#include <shellapi.h>
+
+#include <cstring>
+#include <vector>
+
+#include "platform/strings.h"
+
+namespace process {
+namespace {
+
+// wsl.exe writes its own messages (--list, --status) as UTF-16LE while
+// piping an inner command's stdout through unchanged as UTF-8. Sniff
+// instead of assuming: a BOM, or NULs in the odd byte positions, means
+// UTF-16LE.
+std::wstring DecodeOutput(const std::string& raw) {
+  if (raw.size() >= 2 && static_cast<unsigned char>(raw[0]) == 0xFF &&
+      static_cast<unsigned char>(raw[1]) == 0xFE) {
+    const size_t units = (raw.size() - 2) / sizeof(wchar_t);
+    std::wstring out(units, L'\0');
+    memcpy(out.data(), raw.data() + 2, units * sizeof(wchar_t));
+    return out;
+  }
+  if (raw.size() >= 4 && (raw.size() % 2) == 0) {
+    size_t odd_nulls = 0;
+    size_t odd_total = 0;
+    for (size_t i = 1; i < raw.size(); i += 2) {
+      ++odd_total;
+      if (raw[i] == '\0') ++odd_nulls;
+    }
+    if (odd_total > 0 && odd_nulls * 4 >= odd_total * 3) {
+      const size_t units = raw.size() / sizeof(wchar_t);
+      std::wstring out(units, L'\0');
+      memcpy(out.data(), raw.data(), units * sizeof(wchar_t));
+      return out;
+    }
+  }
+  std::wstring out;
+  if (!str::FromUtf8(raw, &out).ok()) return std::wstring();
+  return out;
+}
+
+void EnsureCom() {
+  static const bool initialized = [] {
+    CoInitializeEx(nullptr, COINIT_MULTITHREADED);
+    return true;
+  }();
+  (void)initialized;
+}
+
+}  // namespace
+
+std::wstring ErrorMessage(unsigned long code) {
+  LPWSTR buffer = nullptr;
+  const DWORD length =
+      FormatMessageW(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM |
+                         FORMAT_MESSAGE_IGNORE_INSERTS,
+                     nullptr, code, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+                     reinterpret_cast<LPWSTR>(&buffer), 0, nullptr);
+  std::wstring message;
+  if (length != 0 && buffer != nullptr) {
+    message.assign(buffer, length);
+    message = str::Trim(message);
+  }
+  if (buffer != nullptr) LocalFree(buffer);
+  if (message.empty()) message = L"error " + std::to_wstring(code);
+  return message;
+}
+
+core::Status Launch(std::wstring_view exe, std::wstring_view command_line,
+                    std::wstring_view working_dir, WindowMode window) {
+  std::wstring mutable_cmd(command_line);
+  std::wstring exe_storage(exe);
+  std::wstring dir_storage(working_dir);
+
+  STARTUPINFOW si{};
+  si.cb = sizeof(si);
+  if (window == WindowMode::Hidden) {
+    si.dwFlags = STARTF_USESHOWWINDOW;
+    si.wShowWindow = SW_HIDE;
+  }
+  PROCESS_INFORMATION pi{};
+  const DWORD flags = CREATE_UNICODE_ENVIRONMENT |
+                      (window == WindowMode::Hidden ? CREATE_NO_WINDOW : CREATE_NEW_CONSOLE);
+  const BOOL ok = CreateProcessW(exe_storage.empty() ? nullptr : exe_storage.c_str(),
+                                 mutable_cmd.empty() ? nullptr : mutable_cmd.data(), nullptr,
+                                 nullptr, FALSE, flags, nullptr,
+                                 dir_storage.empty() ? nullptr : dir_storage.c_str(), &si, &pi);
+  if (!ok) {
+    return core::Err(core::ErrorCode::IoError,
+                     L"launch failed: " + ErrorMessage(GetLastError()));
+  }
+  CloseHandle(pi.hThread);
+  CloseHandle(pi.hProcess);
+  return core::Ok();
+}
+
+core::Status ShellLaunch(std::wstring_view verb, std::wstring_view file,
+                         std::wstring_view parameters, std::wstring_view working_dir) {
+  // Shell verbs go through COM handlers, so the apartment must exist; it is
+  // created on demand, never on the startup path.
+  EnsureCom();
+
+  const std::wstring verb_storage(verb);
+  const std::wstring file_storage(file);
+  const std::wstring params_storage(parameters);
+  const std::wstring dir_storage(working_dir);
+
+  SHELLEXECUTEINFOW info{};
+  info.cbSize = sizeof(info);
+  info.fMask = SEE_MASK_NOASYNC | SEE_MASK_FLAG_NO_UI;
+  info.lpVerb = verb_storage.empty() ? nullptr : verb_storage.c_str();
+  info.lpFile = file_storage.c_str();
+  info.lpParameters = params_storage.empty() ? nullptr : params_storage.c_str();
+  info.lpDirectory = dir_storage.empty() ? nullptr : dir_storage.c_str();
+  info.nShow = SW_SHOWNORMAL;
+
+  if (!ShellExecuteExW(&info)) {
+    const DWORD code = GetLastError();
+    if (code == ERROR_CANCELLED) {
+      return core::Err(core::ErrorCode::Cancelled, L"Cancelled by the user.");
+    }
+    return core::Err(core::ErrorCode::IoError, L"shell launch failed: " + ErrorMessage(code));
+  }
+  if (info.hProcess != nullptr) CloseHandle(info.hProcess);
+  return core::Ok();
+}
+
+core::Status RunCapture(std::wstring_view command_line, std::wstring_view working_dir,
+                        unsigned long timeout_ms, RunResult* out) {
+  if (out != nullptr) *out = RunResult{};
+
+  SECURITY_ATTRIBUTES sa{};
+  sa.nLength = sizeof(sa);
+  sa.bInheritHandle = TRUE;
+
+  HANDLE read_end = nullptr;
+  HANDLE write_end = nullptr;
+  if (!CreatePipe(&read_end, &write_end, &sa, 0)) {
+    return core::Err(core::ErrorCode::IoError,
+                     L"pipe creation failed: " + ErrorMessage(GetLastError()));
+  }
+  SetHandleInformation(read_end, HANDLE_FLAG_INHERIT, 0);
+
+  std::wstring mutable_cmd(command_line);
+  std::wstring dir_storage(working_dir);
+
+  STARTUPINFOW si{};
+  si.cb = sizeof(si);
+  si.dwFlags = STARTF_USESTDHANDLES | STARTF_USESHOWWINDOW;
+  si.wShowWindow = SW_HIDE;
+  si.hStdOutput = write_end;
+  si.hStdError = write_end;
+  si.hStdInput = nullptr;
+
+  PROCESS_INFORMATION pi{};
+  const BOOL ok = CreateProcessW(nullptr, mutable_cmd.data(), nullptr, nullptr, TRUE,
+                                 CREATE_UNICODE_ENVIRONMENT | CREATE_NO_WINDOW, nullptr,
+                                 dir_storage.empty() ? nullptr : dir_storage.c_str(), &si, &pi);
+  CloseHandle(write_end);
+  if (!ok) {
+    CloseHandle(read_end);
+    return core::Err(core::ErrorCode::IoError,
+                     L"capture spawn failed: " + ErrorMessage(GetLastError()));
+  }
+  CloseHandle(pi.hThread);
+
+  // Deadline-bounded drain: a child that keeps the write end open must not
+  // hang us past timeout_ms. PeekNamedPipe polls without blocking in
+  // ReadFile, and the deadline is checked between polls.
+  const ULONGLONG deadline = GetTickCount64() + timeout_ms;
+  std::string raw;
+  char buffer[4096];
+  bool timed_out = false;
+  for (;;) {
+    DWORD available = 0;
+    if (!PeekNamedPipe(read_end, nullptr, 0, nullptr, &available, nullptr)) break;
+    if (available > 0) {
+      DWORD read = 0;
+      if (!ReadFile(read_end, buffer, sizeof(buffer), &read, nullptr) || read == 0) break;
+      raw.append(buffer, read);
+      if (raw.size() > 4u * 1024 * 1024) break;  // bounded capture
+      continue;
+    }
+    if (WaitForSingleObject(pi.hProcess, 0) == WAIT_OBJECT_0) {
+      DWORD remaining = 0;
+      if (PeekNamedPipe(read_end, nullptr, 0, nullptr, &remaining, nullptr) && remaining > 0) {
+        continue;
+      }
+      break;
+    }
+    if (GetTickCount64() >= deadline) {
+      timed_out = true;
+      break;
+    }
+    Sleep(15);
+  }
+  CloseHandle(read_end);
+
+  if (timed_out) {
+    TerminateProcess(pi.hProcess, 1);
+    WaitForSingleObject(pi.hProcess, 2000);
+    CloseHandle(pi.hProcess);
+    if (out != nullptr) {
+      out->timed_out = true;
+      out->output = DecodeOutput(raw);
+    }
+    return core::Ok();
+  }
+
+  const DWORD wait = WaitForSingleObject(pi.hProcess, timeout_ms);
+  if (wait == WAIT_TIMEOUT) {
+    TerminateProcess(pi.hProcess, 1);
+    CloseHandle(pi.hProcess);
+    if (out != nullptr) out->timed_out = true;
+    return core::Ok();
+  }
+  DWORD code = 0;
+  GetExitCodeProcess(pi.hProcess, &code);
+  CloseHandle(pi.hProcess);
+
+  if (out != nullptr) {
+    out->exit_code = static_cast<int>(code);
+    out->output = DecodeOutput(raw);
+  }
+  return core::Ok();
+}
+
+}  // namespace process

--- a/src/platform/process.h
+++ b/src/platform/process.h
@@ -1,0 +1,44 @@
+// Process launch + capture (P4-02), ported from the old build's
+// logic/platform/process.* and converted to core::Status.
+//
+// Launches open EXTERNAL console windows (the old model; no in-app conpty).
+// RunCapture is bounded and deadline-aware: a child that keeps the pipe open
+// cannot hang the caller past timeout_ms, and all arguments the callers
+// build must go through str::QuoteArg (the module side does; the tests
+// prove the round trip).
+#pragma once
+
+#include <string>
+#include <string_view>
+
+#include "core/status.h"
+
+namespace process {
+
+enum class WindowMode { NewConsole, Hidden };
+
+struct RunResult {
+  int exit_code = 0;
+  std::wstring output;  // decoded: UTF-16LE sniffed, else UTF-8
+  bool timed_out = false;
+};
+
+// Detached launch; the child owns its console.
+core::Status Launch(std::wstring_view exe, std::wstring_view command_line,
+                    std::wstring_view working_dir, WindowMode window);
+
+// ShellExecuteExW so verbs like "runas" (UAC elevation) work. A cancelled
+// elevation prompt is ErrorCode::Cancelled, not a crash.
+core::Status ShellLaunch(std::wstring_view verb, std::wstring_view file,
+                         std::wstring_view parameters, std::wstring_view working_dir);
+
+// Runs hidden, captures stdout+stderr (merged), bounded by timeout_ms.
+// Timeout is reported in the result (timed_out) with the child terminated;
+// spawn failures are a Status error. Never blocks past the deadline.
+core::Status RunCapture(std::wstring_view command_line, std::wstring_view working_dir,
+                        unsigned long timeout_ms, RunResult* out);
+
+// FormatMessageW for humans.
+std::wstring ErrorMessage(unsigned long code);
+
+}  // namespace process

--- a/tests/platform/process_test.cpp
+++ b/tests/platform/process_test.cpp
@@ -1,0 +1,40 @@
+#include "platform/process.h"
+
+#include <string>
+
+#include "framework/test_case.h"
+
+DHEPZ_TEST(Process, RunCaptureCapturesOutputAndExitCode) {
+  process::RunResult result;
+  DHEPZ_CHECK(
+      process::RunCapture(L"cmd.exe /c echo dhepz-proc-test", L"", 10000, &result).ok());
+  DHEPZ_CHECK(!result.timed_out);
+  DHEPZ_CHECK_EQ(result.exit_code, 0);
+  DHEPZ_CHECK(result.output.find(L"dhepz-proc-test") != std::wstring::npos);
+}
+
+DHEPZ_TEST(Process, RunCaptureReportsExitCode) {
+  process::RunResult result;
+  DHEPZ_CHECK(process::RunCapture(L"cmd.exe /c exit 7", L"", 10000, &result).ok());
+  DHEPZ_CHECK(!result.timed_out);
+  DHEPZ_CHECK_EQ(result.exit_code, 7);
+}
+
+DHEPZ_TEST(Process, RunCaptureHonoursTheDeadline) {
+  process::RunResult result;
+  DHEPZ_CHECK(process::RunCapture(L"powershell.exe -NoProfile -Command Start-Sleep 5",
+                                  L"", 400, &result)
+                  .ok());
+  DHEPZ_CHECK(result.timed_out);
+}
+
+DHEPZ_TEST(Process, LaunchSmoke) {
+  DHEPZ_CHECK(process::Launch(L"", L"cmd.exe /c exit 0", L"", process::WindowMode::Hidden)
+                  .ok());
+}
+
+DHEPZ_TEST(Process, ShellLaunchMissingFileFailsWithStatus) {
+  const core::Status status =
+      process::ShellLaunch(L"open", L"C:\\dhepz-does-not-exist-9x7q.exe", L"", L"");
+  DHEPZ_CHECK(!status.ok());
+}


### PR DESCRIPTION
P4-02: Launch (external console), ShellLaunch (runas, Cancelled as Status), RunCapture (exit code + merged output + timed_out, bounded, UTF-16LE sniff). GateHost::ProcessRun wired; terminal:launch launches. Tests: capture, exit code, deadline, launch smoke, shell-launch failure.