### PR TITLE
feat(terminal): WSL enumeration with session cache and explicit refresh (#96)

### DIFF
--- a/src/modules/terminal/wsl.cpp
+++ b/src/modules/terminal/wsl.cpp
@@ -1,0 +1,62 @@
+#include "modules/terminal/wsl.h"
+
+namespace terminal {
+namespace {
+
+core::Status DefaultRunner(std::wstring_view command_line, process::RunResult* out) {
+  return process::RunCapture(command_line, L"", 10000, out);
+}
+
+}  // namespace
+
+WslEnumerator::WslEnumerator() : WslEnumerator(&DefaultRunner) {}
+
+WslEnumerator::WslEnumerator(Runner runner) : runner_(std::move(runner)) {}
+
+std::vector<std::wstring> WslEnumerator::ParseListOutput(const std::wstring& output) {
+  std::vector<std::wstring> distros;
+  std::wstring line;
+  bool first_content = true;
+  const auto flush = [&] {
+    std::wstring name = line;
+    // strip \r and surrounding whitespace
+    while (!name.empty() && (name.back() == L'\r' || name.back() == L' ')) name.pop_back();
+    while (!name.empty() && (name.front() == L' ')) name.erase(name.begin());
+    // remove a trailing " (Default)" marker wherever it sits
+    const std::wstring marker = L"(Default)";
+    const auto pos = name.find(marker);
+    if (pos != std::wstring::npos) {
+      name.erase(pos);
+      while (!name.empty() && (name.back() == L' ')) name.pop_back();
+    }
+    if (first_content) {
+      first_content = false;  // the header line ("Windows Subsystem ...")
+      return;
+    }
+    if (!name.empty()) distros.push_back(name);
+  };
+  for (const wchar_t c : output) {
+    if (c == L'\n') {
+      flush();
+      line.clear();
+    } else {
+      line.push_back(c);
+    }
+  }
+  if (!line.empty()) flush();
+  return distros;
+}
+
+core::Status WslEnumerator::Refresh() {
+  process::RunResult result;
+  const core::Status status = runner_(L"wsl.exe -l -q", &result);
+  if (!status.ok()) return status;
+  if (result.timed_out) {
+    return core::Err(core::ErrorCode::Cancelled, L"wsl enumeration timed out");
+  }
+  distros_ = ParseListOutput(result.output);
+  cached_ = true;
+  return core::Ok();
+}
+
+}  // namespace terminal

--- a/src/modules/terminal/wsl.h
+++ b/src/modules/terminal/wsl.h
@@ -1,0 +1,45 @@
+// WSL distro enumeration (P4-03): `wsl -l -q` through an injected runner
+// (process::RunCapture by default, a mock in tests), cached per session,
+// refreshable explicitly. Adding a distro on the machine shows up after
+// Refresh — no rebuild, no code change.
+#pragma once
+
+#include <functional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "core/status.h"
+#include "platform/process.h"
+
+namespace terminal {
+
+class WslEnumerator final {
+ public:
+  using Runner =
+      std::function<core::Status(std::wstring_view command_line, process::RunResult* out)>;
+
+  // Default runner: process::RunCapture with a 10 s deadline. Callers run
+  // this off the UI thread (worker offload, P4-05).
+  WslEnumerator();
+  explicit WslEnumerator(Runner runner);
+
+  // Runs `wsl -l -q`, parses, replaces the cache. A failed run keeps the
+  // previous cache and returns the Status.
+  core::Status Refresh();
+
+  // Session cache; empty until the first successful Refresh.
+  const std::vector<std::wstring>& Distros() const { return distros_; }
+  bool cached() const { return cached_; }
+
+  // Pure parse, exposed for tests: tolerates UTF-16-decoded input, skips
+  // the header line, blank lines, and "(Default)" markers.
+  static std::vector<std::wstring> ParseListOutput(const std::wstring& output);
+
+ private:
+  Runner runner_;
+  std::vector<std::wstring> distros_;
+  bool cached_ = false;
+};
+
+}  // namespace terminal

--- a/tests/modules/terminal/wsl_test.cpp
+++ b/tests/modules/terminal/wsl_test.cpp
@@ -1,0 +1,60 @@
+#include "modules/terminal/wsl.h"
+
+#include <string>
+
+#include "framework/test_case.h"
+
+namespace {
+
+const std::wstring kTwoDistros =
+    L"Windows Subsystem for Linux Distributions:\nUbuntu (Default)\r\nDebian\r\n";
+const std::wstring kThreeDistros =
+    L"Windows Subsystem for Linux Distributions:\nUbuntu (Default)\r\nDebian\r\nAlpine\r\n";
+
+}  // namespace
+
+DHEPZ_TEST(Wsl, ParseSkipsHeaderBlankLinesAndDefaultMarker) {
+  const std::vector<std::wstring> distros =
+      terminal::WslEnumerator::ParseListOutput(kTwoDistros);
+  DHEPZ_CHECK_EQ(distros.size(), static_cast<std::size_t>(2));
+  DHEPZ_CHECK_EQ(distros[0], std::wstring(L"Ubuntu"));
+  DHEPZ_CHECK_EQ(distros[1], std::wstring(L"Debian"));
+}
+
+DHEPZ_TEST(Wsl, RefreshCachesPerSession) {
+  terminal::WslEnumerator enumerator(
+      [](std::wstring_view, process::RunResult* out) {
+        out->output = kTwoDistros;
+        return core::Ok();
+      });
+  DHEPZ_CHECK(!enumerator.cached());
+  DHEPZ_CHECK(enumerator.Refresh().ok());
+  DHEPZ_CHECK(enumerator.cached());
+  DHEPZ_CHECK_EQ(enumerator.Distros().size(), static_cast<std::size_t>(2));
+}
+
+DHEPZ_TEST(Wsl, FailedRefreshKeepsThePreviousCache) {
+  int calls = 0;
+  terminal::WslEnumerator enumerator([&calls](std::wstring_view, process::RunResult* out) {
+    if (++calls == 1) {
+      out->output = kTwoDistros;
+      return core::Ok();
+    }
+    return core::Err(core::ErrorCode::IoError, L"wsl missing");
+  });
+  DHEPZ_CHECK(enumerator.Refresh().ok());
+  DHEPZ_CHECK(!enumerator.Refresh().ok());
+  DHEPZ_CHECK_EQ(enumerator.Distros().size(), static_cast<std::size_t>(2));
+}
+
+DHEPZ_TEST(Wsl, ExplicitRefreshPicksUpNewDistros) {
+  int calls = 0;
+  terminal::WslEnumerator enumerator([&calls](std::wstring_view, process::RunResult* out) {
+    out->output = (++calls == 1) ? kTwoDistros : kThreeDistros;
+    return core::Ok();
+  });
+  DHEPZ_CHECK(enumerator.Refresh().ok());
+  DHEPZ_CHECK_EQ(enumerator.Distros().size(), static_cast<std::size_t>(2));
+  DHEPZ_CHECK(enumerator.Refresh().ok());
+  DHEPZ_CHECK_EQ(enumerator.Distros().size(), static_cast<std::size_t>(3));
+}


### PR DESCRIPTION
P4-03: WslEnumerator with injected runner, tolerant parse, session cache, explicit refresh, failure keeps cache. Tests with mocked RunCapture output.