### PR TITLE
feat(terminal): worker offload for blocking terminal work (#98)

### DIFF
--- a/src/modules/terminal/terminal_offload.h
+++ b/src/modules/terminal/terminal_offload.h
@@ -1,0 +1,45 @@
+// Worker offload for the terminal module (P4-05): blocking work (RunCapture,
+// validation, enumeration) runs on worker::Worker threads; results travel
+// back as messages to the UI window and never touch UI state directly.
+#pragma once
+
+#include <cstdint>
+#include <functional>
+#include <string>
+
+#include "platform/process.h"
+#include "platform/worker.h"
+
+namespace terminal {
+
+class TerminalOffload final {
+ public:
+  TerminalOffload(void* ui_window, unsigned int completion_message)
+      : worker_(ui_window, completion_message) {}
+
+  using OnCapture = std::function<void(const process::RunResult&)>;
+
+  // The work lambda blocks (RunCapture); the delivery runs on the UI thread
+  // when the window routes the completion message to Settle().
+  worker::JobHandle RunCaptureAsync(std::wstring command_line, OnCapture on_done,
+                                    std::uint64_t generation = 0) {
+    return worker_.Submit(
+        [command_line = std::move(command_line)](const std::atomic<bool>&) {
+          auto result = std::make_shared<process::RunResult>();
+          const core::Status status = process::RunCapture(command_line, L"", 10000, result.get());
+          (void)status;  // the RunResult carries timed_out/exit_code to the UI
+          return std::static_pointer_cast<void>(result);
+        },
+        [on_done = std::move(on_done)](std::shared_ptr<void> cargo) {
+          on_done(*std::static_pointer_cast<process::RunResult>(cargo));
+        },
+        generation);
+  }
+
+  worker::Worker& worker() { return worker_; }
+
+ private:
+  worker::Worker worker_;
+};
+
+}  // namespace terminal

--- a/src/modules/terminal/terminal_state.cpp
+++ b/src/modules/terminal/terminal_state.cpp
@@ -1,0 +1,83 @@
+#include "modules/terminal/terminal_state.h"
+
+#include <windows.h>
+
+#include "core/json.h"
+
+namespace terminal {
+namespace {
+
+constexpr std::wstring_view kRecentKey = L"recent_folders";
+constexpr std::size_t kRecentCap = 10;
+
+bool FileExists(const std::wstring& path) {
+  return GetFileAttributesW(path.c_str()) != INVALID_FILE_ATTRIBUTES;
+}
+
+}  // namespace
+
+void RecentFolders::Add(std::wstring folder) {
+  std::vector<std::wstring> next;
+  next.push_back(folder);
+  for (const std::wstring& existing : folders_) {
+    if (existing != folder) next.push_back(existing);
+    if (next.size() >= kRecentCap) break;
+  }
+  folders_ = std::move(next);
+}
+
+void RecentFolders::Remove(const std::wstring& folder) {
+  for (std::size_t i = 0; i < folders_.size(); ++i) {
+    if (folders_[i] == folder) {
+      folders_.erase(folders_.begin() + static_cast<std::ptrdiff_t>(i));
+      return;
+    }
+  }
+}
+
+void RecentFolders::Load(modules::ModuleHost& host) {
+  std::wstring stored;
+  if (!host.SettingsRead(kRecentKey, &stored).ok() || stored.empty()) return;
+  json::Value parsed;
+  if (!json::Parse(stored, &parsed).ok() || !parsed.is_array()) return;
+  folders_.clear();
+  for (const json::Value& item : parsed.items()) {
+    if (item.is_string()) folders_.push_back(item.AsString());
+  }
+}
+
+void RecentFolders::Save(modules::ModuleHost& host) const {
+  json::Value array = json::Value::Array();
+  for (const std::wstring& folder : folders_) {
+    array.Append(json::Value::String(folder));
+  }
+  const core::Status saved = host.SettingsWrite(kRecentKey, json::Serialize(array, false));
+  (void)saved;  // persistence is best-effort; a failed write keeps the session list
+}
+
+bool DetectVenv(const std::wstring& folder) {
+  return FileExists(folder + L"\\Scripts\\activate.bat") ||
+         FileExists(folder + L"\\bin\\activate");
+}
+
+std::wstring VenvActivatePath(const std::wstring& folder) {
+  if (FileExists(folder + L"\\Scripts\\activate.bat")) {
+    return folder + L"\\Scripts\\activate.bat";
+  }
+  return folder + L"\\bin\\activate";
+}
+
+core::Status ValidateFolder(const std::wstring& folder) {
+  const DWORD attributes = GetFileAttributesW(folder.c_str());
+  if (attributes == INVALID_FILE_ATTRIBUTES) {
+    return core::Err(core::ErrorCode::NotFound,
+                     L"folder does not exist: " + folder);
+  }
+  if ((attributes & FILE_ATTRIBUTE_DIRECTORY) == 0) {
+    return core::Err(core::ErrorCode::InvalidArgument,
+                     L"not a directory: " + folder);
+  }
+  return core::Ok();
+}
+
+}  // namespace terminal

--- a/src/modules/terminal/terminal_state.h
+++ b/src/modules/terminal/terminal_state.h
@@ -1,0 +1,38 @@
+// Terminal module state (P4-04): recent-folder history persisted in the
+// module's OWN settings section (default reach), venv detection/toggle,
+// folder validation. Filesystem probes are blocking — callers run them on
+// a worker (P4-05).
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "core/status.h"
+#include "modules/contract/module_contract.h"
+
+namespace terminal {
+
+// Most-recent-first, deduped, capped at 10. Persists as a JSON array under
+// "recent_folders" in the module's own settings section.
+class RecentFolders final {
+ public:
+  void Add(std::wstring folder);
+  void Remove(const std::wstring& folder);
+  const std::vector<std::wstring>& List() const { return folders_; }
+
+  void Load(modules::ModuleHost& host);
+  void Save(modules::ModuleHost& host) const;
+
+ private:
+  std::vector<std::wstring> folders_;
+};
+
+// Standard virtualenv layouts: <folder>/Scripts/activate.bat (Windows) or
+// <folder>/bin/activate (posix-style checkout). Pure filesystem probes.
+bool DetectVenv(const std::wstring& folder);
+std::wstring VenvActivatePath(const std::wstring& folder);
+
+// Exists + is a directory; human-friendly Status on failure.
+core::Status ValidateFolder(const std::wstring& folder);
+
+}  // namespace terminal

--- a/tests/modules/terminal/offload_test.cpp
+++ b/tests/modules/terminal/offload_test.cpp
@@ -1,0 +1,131 @@
+#include "modules/terminal/terminal_offload.h"
+
+#include <windows.h>
+
+#include <atomic>
+#include <chrono>
+#include <memory>
+#include <thread>
+#include <vector>
+
+#include "framework/test_case.h"
+
+namespace {
+
+struct RigState {
+  unsigned int completion_message = 0;
+  unsigned int ping_message = 0;
+  std::atomic<int> pings{0};
+  std::chrono::steady_clock::time_point ping_received;
+};
+
+RigState* g_rig = nullptr;
+
+LRESULT CALLBACK RigProc(HWND window, UINT message, WPARAM wparam, LPARAM lparam) {
+  if (g_rig != nullptr && message == g_rig->completion_message) {
+    worker::Worker::Settle(lparam);
+    return 0;
+  }
+  if (g_rig != nullptr && message == g_rig->ping_message) {
+    g_rig->ping_received = std::chrono::steady_clock::now();
+    ++g_rig->pings;
+    return 0;
+  }
+  return DefWindowProcW(window, message, wparam, lparam);
+}
+
+struct Rig {
+  HWND hwnd = nullptr;
+  RigState state;
+
+  Rig() {
+    g_rig = &state;
+    WNDCLASSW window_class{};
+    window_class.lpfnWndProc = RigProc;
+    window_class.hInstance = GetModuleHandleW(nullptr);
+    window_class.lpszClassName = L"dhepz.offload.test";
+    RegisterClassW(&window_class);
+    state.completion_message = RegisterWindowMessageW(L"dhepz.offload.test.completion");
+    state.ping_message = RegisterWindowMessageW(L"dhepz.offload.test.ping");
+    hwnd = CreateWindowExW(0, window_class.lpszClassName, L"", WS_POPUP, 0, 0, 16, 16, nullptr,
+                           nullptr, window_class.hInstance, nullptr);
+    DHEPZ_CHECK(hwnd != nullptr);
+  }
+  ~Rig() {
+    if (hwnd != nullptr) DestroyWindow(hwnd);
+    g_rig = nullptr;
+  }
+};
+
+template <typename Pred>
+void PumpUntil(Pred predicate, int timeout_ms) {
+  const auto deadline = std::chrono::steady_clock::now() +
+                        std::chrono::milliseconds(timeout_ms);
+  while (std::chrono::steady_clock::now() < deadline) {
+    MSG msg;
+    while (PeekMessageW(&msg, nullptr, 0, 0, PM_REMOVE)) {
+      TranslateMessage(&msg);
+      DispatchMessageW(&msg);
+    }
+    if (predicate()) return;
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }
+}
+
+}  // namespace
+
+DHEPZ_TEST(TerminalOffload, CaptureRunsOffUiThreadAndDeliversOnIt) {
+  Rig rig;
+  terminal::TerminalOffload offload(rig.hwnd, rig.state.completion_message);
+
+  std::atomic<bool> delivered{false};
+  std::atomic<unsigned long> work_thread{0};
+  const unsigned long main_thread = GetCurrentThreadId();
+
+  // Custom Submit so the test can observe the worker thread id.
+  offload.worker().Submit(
+      [&work_thread](const std::atomic<bool>&) {
+        work_thread = GetCurrentThreadId();
+        auto result = std::make_shared<process::RunResult>();
+        const core::Status status =
+            process::RunCapture(L"cmd.exe /c echo offload-ok", L"", 10000, result.get());
+        (void)status;
+        return std::static_pointer_cast<void>(result);
+      },
+      [&](std::shared_ptr<void> cargo) {
+        const auto& result = *std::static_pointer_cast<process::RunResult>(cargo);
+        DHEPZ_CHECK(result.output.find(L"offload-ok") != std::wstring::npos);
+        delivered = true;
+      });
+
+  PumpUntil([&] { return delivered.load(); }, 10000);
+  DHEPZ_CHECK(delivered.load());
+  DHEPZ_CHECK(work_thread.load() != 0);
+  DHEPZ_CHECK(work_thread.load() != main_thread);
+  offload.worker().Shutdown();
+}
+
+DHEPZ_TEST(TerminalOffload, UiStaysResponsiveWhileWorkerBlocks) {
+  Rig rig;
+  terminal::TerminalOffload offload(rig.hwnd, rig.state.completion_message);
+
+  std::atomic<bool> delivered{false};
+  offload.RunCaptureAsync(L"cmd.exe /c timeout /t 2 /nobreak >nul",
+                          [&](const process::RunResult&) { delivered = true; });
+
+  // While the worker blocks for ~2 s, an unrelated message must round-trip
+  // fast — the UI thread never blocks on the child.
+  std::this_thread::sleep_for(std::chrono::milliseconds(200));
+  const auto sent = std::chrono::steady_clock::now();
+  PostMessageW(rig.hwnd, rig.state.ping_message, 0, 0);
+  PumpUntil([&] { return rig.state.pings.load() > 0; }, 2000);
+  const double ms = std::chrono::duration<double, std::milli>(
+                        rig.state.ping_received - sent)
+                        .count();
+  DHEPZ_CHECK(rig.state.pings.load() > 0);
+  DHEPZ_CHECK(ms < 100.0);
+
+  PumpUntil([&] { return delivered.load(); }, 10000);
+  DHEPZ_CHECK(delivered.load());
+  offload.worker().Shutdown();
+}

--- a/tests/modules/terminal/terminal_state_test.cpp
+++ b/tests/modules/terminal/terminal_state_test.cpp
@@ -1,0 +1,110 @@
+#include "modules/terminal/terminal_state.h"
+
+#include <windows.h>
+
+#include <cstdio>
+
+#include <map>
+#include <string>
+
+#include "framework/test_case.h"
+
+namespace {
+
+class FakeHost final : public modules::ModuleHost {
+ public:
+  modules::ModuleSurface Surface() override { return {}; }
+  core::Status SettingsRead(std::wstring_view key, std::wstring* out) override {
+    const auto it = settings.find(std::wstring(key));
+    if (it == settings.end()) return core::Err(core::ErrorCode::NotFound, L"no key");
+    *out = it->second;
+    return core::Ok();
+  }
+  core::Status SettingsReadGlobal(std::wstring_view, std::wstring*) override {
+    return core::Err(core::ErrorCode::NotFound, L"no global");
+  }
+  core::Status SettingsWrite(std::wstring_view key, std::wstring_view value) override {
+    settings[std::wstring(key)] = std::wstring(value);
+    return core::Ok();
+  }
+  core::Status StorageWrite(std::wstring_view, std::wstring_view) override { return core::Ok(); }
+  core::Status StorageRead(std::wstring_view, std::wstring*) override {
+    return core::Err(core::ErrorCode::NotFound, L"no blob");
+  }
+  core::Status ProcessRun(std::wstring_view, std::wstring*) override {
+    return core::Err(core::ErrorCode::Unsupported, L"not here");
+  }
+  void ReportStatus(const core::Status&) override {}
+  void Log(std::wstring_view, std::wstring_view) override {}
+  core::Status RequestRoute(std::wstring_view) override { return core::Ok(); }
+  std::vector<modules::PeerInfo> Peers() override { return {}; }
+
+  std::map<std::wstring, std::wstring> settings;
+};
+
+std::wstring TempDir(const wchar_t* name) {
+  wchar_t base[MAX_PATH]{};
+  GetTempPathW(MAX_PATH, base);
+  std::wstring path = std::wstring(base) + L"dhepz-p4-" + name + L"-" +
+                    std::to_wstring(GetTickCount());
+  CreateDirectoryW(path.c_str(), nullptr);
+  return path;
+}
+
+}  // namespace
+
+DHEPZ_TEST(TerminalState, RecentFoldersDedupeCapAndOrder) {
+  terminal::RecentFolders recent;
+  for (int i = 0; i < 12; ++i) {
+    recent.Add(L"C:\\work\\" + std::to_wstring(i));
+  }
+  DHEPZ_CHECK_EQ(recent.List().size(), static_cast<std::size_t>(10));
+  DHEPZ_CHECK_EQ(recent.List()[0], std::wstring(L"C:\\work\\11"));
+
+  recent.Add(L"C:\\work\\5");  // dedupe moves to front
+  DHEPZ_CHECK_EQ(recent.List()[0], std::wstring(L"C:\\work\\5"));
+  DHEPZ_CHECK_EQ(recent.List().size(), static_cast<std::size_t>(10));
+
+  recent.Remove(L"C:\\work\\5");
+  DHEPZ_CHECK_EQ(recent.List()[0], std::wstring(L"C:\\work\\11"));
+}
+
+DHEPZ_TEST(TerminalState, RecentFoldersPersistThroughOwnSection) {
+  FakeHost host;
+  terminal::RecentFolders recent;
+  recent.Add(L"C:\\a");
+  recent.Add(L"C:\\b");
+  recent.Save(host);
+
+  terminal::RecentFolders loaded;
+  loaded.Load(host);
+  DHEPZ_CHECK_EQ(loaded.List().size(), static_cast<std::size_t>(2));
+  DHEPZ_CHECK_EQ(loaded.List()[0], std::wstring(L"C:\\b"));
+}
+
+DHEPZ_TEST(TerminalState, VenvDetectionOnStandardLayouts) {
+  const std::wstring folder = TempDir(L"venv");
+  DHEPZ_CHECK(!terminal::DetectVenv(folder));
+  CreateDirectoryW((folder + L"\\Scripts").c_str(), nullptr);
+  HANDLE file = CreateFileW((folder + L"\\Scripts\\activate.bat").c_str(), GENERIC_WRITE, 0,
+                            nullptr, CREATE_NEW, FILE_ATTRIBUTE_NORMAL, nullptr);
+  DHEPZ_CHECK(file != INVALID_HANDLE_VALUE);
+  CloseHandle(file);
+  DHEPZ_CHECK(terminal::DetectVenv(folder));
+  DHEPZ_CHECK(terminal::VenvActivatePath(folder).find(L"activate.bat") != std::wstring::npos);
+}
+
+DHEPZ_TEST(TerminalState, ValidateFolderDiagnostics) {
+  const std::wstring folder = TempDir(L"valid");
+  DHEPZ_CHECK(terminal::ValidateFolder(folder).ok());
+
+  const core::Status missing = terminal::ValidateFolder(folder + L"\\nope");
+  DHEPZ_CHECK(!missing.ok());
+
+  const std::wstring file_path = folder + L"\\file.txt";
+  HANDLE file = CreateFileW(file_path.c_str(), GENERIC_WRITE, 0, nullptr, CREATE_NEW,
+                            FILE_ATTRIBUTE_NORMAL, nullptr);
+  CloseHandle(file);
+  const core::Status not_dir = terminal::ValidateFolder(file_path);
+  DHEPZ_CHECK(!not_dir.ok());
+}


### PR DESCRIPTION
P4-05: TerminalOffload (RunCaptureAsync via worker::Worker, message-based delivery). Tests: off-UI-thread execution, UI responsiveness <100ms under a 2s blocking worker job.