### PR TITLE
feat(contract): add typed async host operations (#105)

### DIFF
--- a/docs/adr/0001-module-contract.md
+++ b/docs/adr/0001-module-contract.md
@@ -1,4 +1,4 @@
-# ADR 0001 — The module contract is append-only
+# ADR 0001 — The module contract and parent-owned services
 
 Status: accepted (Phase 3, issue #81). Links: `.docs/plan.md` Part 3.
 
@@ -13,9 +13,13 @@ types, every signature and semantic becomes a contract.
 ## Decision
 
 1. `ModuleHost` and `ModuleDescriptor` (src/modules/contract/module_contract.h)
-   are **append-only**. Adding a member is allowed; removing one, changing a
-   signature, or re-semanticising behaviour is a major-version event and must
-   amend this ADR first.
+   are **append-only** after the Integration Checkpoint contract freeze.
+   Before any production module path shipped, the synchronous `ProcessRun`
+   member was removed as a one-time breaking correction: its signature made
+   blocking process work legal on the UI thread. The typed asynchronous
+   operations below are its complete replacement. Further removals, signature
+   changes, or semantic changes are major-version events and must amend this
+   ADR first.
 2. Reach beyond the default surface exists only as capabilities declared in
    `module.json` and granted by the gate: `settings:all` (single claimant) and
    `config:write` (writes only through the gate's validate-then-swap path).
@@ -24,6 +28,31 @@ types, every signature and semantic becomes a contract.
    only — never handles. Sibling calls are structurally impossible.
 4. `module.json` is strict: unknown fields are diagnostics, not ignored, so a
    typo can never silently become "supported later".
+5. Process reach is parent-owned and structured. A child supplies an executable,
+   an argument vector, working directory, operation kind (normal launch,
+   elevated launch, or capture), and capture timeout. It never supplies a raw,
+   prequoted command line. The parent applies `str::QuoteArg` and is the only
+   layer that calls `process::Launch`, `ShellLaunch`, or `RunCapture` for this
+   service.
+6. Folder reach is a metadata-only probe: the child supplies one absolute
+   directory and a list of safe relative file names. Completion reports the
+   normalized directory, directory presence, and presence of exactly those
+   files. It never exposes file contents or general filesystem access.
+7. Starting either operation is nonblocking. A successful start returns a
+   parent-issued request token; malformed input is rejected synchronously with
+   `Status`. OS work runs on a run-once worker. Completion is posted to the UI
+   thread and carries token, host-lifetime generation, operation kind, `Status`,
+   and the kind-appropriate result.
+8. Cancellation is best-effort for an operation already applying an external
+   effect: capture is terminated through its cancellation flag, while a child
+   process successfully launched before cancellation is not killed. In every
+   case cancellation suppresses delivery. Invalidating the module-host
+   generation suppresses queued and future completions, including completions
+   already posted when the owner begins teardown.
+9. An asynchronous module publishes a view-state patch only through
+   `ModuleHost::PublishStatePatch` from its UI-thread completion. The parent
+   owns the patch sink and presenter routing; calling the seam from another
+   thread is an error.
 
 ## Consequences
 
@@ -31,5 +60,8 @@ types, every signature and semantic becomes a contract.
   cannot drift per-module.
 - The gate (P3-03) is the single enforcement point; nothing else mounts,
   registers, or swaps config.
+- Process/folder IO is structurally outside the UI thread, and worker delivery
+  state outlives a queued message safely during teardown without retaining a
+  worker thread at idle.
 - Cost: adding a genuinely new service means growing `ModuleHost` for all
   modules — deliberately expensive, so it happens rarely and reviewed.

--- a/src/modules/contract/module_contract.h
+++ b/src/modules/contract/module_contract.h
@@ -11,12 +11,15 @@
 //      the gate (P3-03), never a backdoor.
 //
 // APPEND-ONLY RULE: once a module ships against this header, removing or
-// re-semanticising a member breaks every module. Additions only; a removal
-// is a major-version event documented in the ADR.
+// re-semanticising a member breaks every module. The synchronous predecessor's
+// removal is the one pre-shipping correction recorded by ADR 0001; additions
+// only after that contract freeze.
 //
 // This header is standard library + core/render only; no windows.h.
 #pragma once
 
+#include <cstdint>
+#include <functional>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -46,6 +49,58 @@ struct PeerInfo {
   std::wstring settings_route;  // empty when the peer ships no settings screen
 };
 
+enum class ProcessOperation { Launch, ElevatedLaunch, Capture };
+
+enum class HostOperationKind { Launch, ElevatedLaunch, Capture, FolderProbe };
+
+struct AsyncRequestToken {
+  std::uint64_t value = 0;
+
+  explicit operator bool() const { return value != 0; }
+  friend bool operator==(const AsyncRequestToken&, const AsyncRequestToken&) = default;
+};
+
+struct ProcessRequest {
+  ProcessOperation operation = ProcessOperation::Launch;
+  std::wstring executable;
+  std::vector<std::wstring> arguments;
+  std::wstring working_directory;
+  unsigned long timeout_ms = 10000;
+};
+
+struct ProcessOperationResult {
+  int exit_code = 0;
+  std::wstring output;
+  bool timed_out = false;
+};
+
+struct FolderProbeRequest {
+  std::wstring directory;
+  std::vector<std::wstring> relative_files;
+};
+
+struct RelativeFilePresence {
+  std::wstring relative_path;
+  bool present = false;
+};
+
+struct FolderProbeResult {
+  std::wstring normalized_directory;
+  bool directory_exists = false;
+  std::vector<RelativeFilePresence> files;
+};
+
+struct HostOperationCompletion {
+  AsyncRequestToken token;
+  std::uint64_t generation = 0;
+  HostOperationKind kind = HostOperationKind::Launch;
+  core::Status status;
+  ProcessOperationResult process;
+  FolderProbeResult folder;
+};
+
+using HostOperationCallback = std::function<void(const HostOperationCompletion& completion)>;
+
 // Parent hands down. Nothing else is reachable from a child.
 class ModuleHost {
  public:
@@ -60,8 +115,21 @@ class ModuleHost {
   // Bulk/blob data scoped to this moduleId only.
   virtual core::Status StorageWrite(std::wstring_view name, std::wstring_view data) = 0;
   virtual core::Status StorageRead(std::wstring_view name, std::wstring* out) = 0;
-  // Goes to a worker; never blocks the UI thread (implementation in P3-03+).
-  virtual core::Status ProcessRun(std::wstring_view command_line, std::wstring* captured) = 0;
+  // Starts immediately and returns a parent-issued token. The callback is
+  // delivered on the UI thread with this host lifetime's generation. Modules
+  // pass argv, never a prequoted command line; the parent owns quoting.
+  virtual core::Status StartProcess(const ProcessRequest& request,
+                                    HostOperationCallback callback,
+                                    AsyncRequestToken* token) = 0;
+  // Metadata-only directory inspection. relative_files are checked for
+  // presence; file contents are never exposed to a module.
+  virtual core::Status StartFolderProbe(const FolderProbeRequest& request,
+                                        HostOperationCallback callback,
+                                        AsyncRequestToken* token) = 0;
+  virtual void CancelRequest(AsyncRequestToken token) = 0;
+  // Called only from the UI-thread completion path. The parent owns routing
+  // the patch to the presenter; a module never reaches frontend types.
+  virtual core::Status PublishStatePatch(const json::Value& patch) = 0;
   // Report success/error; the parent decides how to show it.
   virtual void ReportStatus(const core::Status& status) = 0;
   virtual void Log(std::wstring_view level, std::wstring_view text) = 0;

--- a/src/modules/gate/app_gate.cpp
+++ b/src/modules/gate/app_gate.cpp
@@ -1,12 +1,10 @@
 #include "modules/gate/app_gate.h"
 
 #include <algorithm>
-#include <map>
-#include <mutex>
 
 #include "core/json.h"
+#include "modules/gate/gate_host.h"
 #include "modules/registry/module_registry.h"
-#include "platform/process.h"
 #include "ui/config/config_store.h"
 
 namespace modules {
@@ -23,84 +21,6 @@ const std::vector<RejectEntry>& CurrentRejects() {
   return g_rejects != nullptr ? *g_rejects : empty;
 }
 
-// Per-module host view. Settings reach is narrowed here by construction:
-// writes land only in the module's own section; global is read-only.
-class GateHost final : public ModuleHost {
- public:
-  GateHost(AppGate* gate, std::wstring module_id)
-      : gate_(gate), module_id_(std::move(module_id)) {}
-
-  ModuleSurface Surface() override { return surface_; }
-
-  core::Status SettingsRead(std::wstring_view key, std::wstring* out) override {
-    std::lock_guard lock(mutex_);
-    const auto& section = settings_[std::wstring(module_id_)];
-    const auto it = section.find(std::wstring(key));
-    if (it == section.end()) return core::Err(core::ErrorCode::NotFound, L"no such key");
-    *out = it->second;
-    return core::Ok();
-  }
-
-  core::Status SettingsReadGlobal(std::wstring_view key, std::wstring* out) override {
-    std::lock_guard lock(mutex_);
-    const auto it = global_.find(std::wstring(key));
-    if (it == global_.end()) return core::Err(core::ErrorCode::NotFound, L"no such key");
-    *out = it->second;
-    return core::Ok();
-  }
-
-  core::Status SettingsWrite(std::wstring_view key, std::wstring_view value) override {
-    std::lock_guard lock(mutex_);
-    settings_[std::wstring(module_id_)][std::wstring(key)] = std::wstring(value);
-    return core::Ok();
-  }
-
-  core::Status StorageWrite(std::wstring_view name, std::wstring_view data) override {
-    std::lock_guard lock(mutex_);
-    storage_[std::wstring(name)] = std::wstring(data);
-    return core::Ok();
-  }
-
-  core::Status StorageRead(std::wstring_view name, std::wstring* out) override {
-    std::lock_guard lock(mutex_);
-    const auto it = storage_.find(std::wstring(name));
-    if (it == storage_.end()) return core::Err(core::ErrorCode::NotFound, L"no such blob");
-    *out = it->second;
-    return core::Ok();
-  }
-
-  core::Status ProcessRun(std::wstring_view command_line, std::wstring* captured) override {
-    process::RunResult result;
-    const core::Status status = process::RunCapture(command_line, L"", 10000, &result);
-    if (!status.ok()) return status;
-    if (result.timed_out) {
-      return core::Err(core::ErrorCode::Cancelled, L"process timed out");
-    }
-    if (captured != nullptr) *captured = result.output;
-    return core::Ok();
-  }
-
-  void ReportStatus(const core::Status& status) override { last_status_ = status; }
-  void Log(std::wstring_view level, std::wstring_view text) override {
-    std::lock_guard lock(mutex_);
-    log_.push_back(std::wstring(level) + L": " + std::wstring(text));
-  }
-
-  core::Status RequestRoute(std::wstring_view route_id) override;
-  std::vector<PeerInfo> Peers() override;
-
- private:
-  AppGate* gate_;
-  std::wstring module_id_;
-  ModuleSurface surface_;
-  std::mutex mutex_;
-  std::map<std::wstring, std::map<std::wstring, std::wstring>> settings_;
-  std::map<std::wstring, std::wstring> global_;
-  std::map<std::wstring, std::wstring> storage_;
-  std::vector<std::wstring> log_;
-  core::Status last_status_;
-};
-
 AppGate::AppGate() = default;
 AppGate::~AppGate() = default;
 
@@ -114,6 +34,23 @@ core::Status AppGate::Start(std::wstring_view override_path) {
 core::Status AppGate::StartWithEmbedded(std::wstring_view embedded_text,
                                         std::wstring_view override_text) {
   return PairAndMount(embedded_text, override_text);
+}
+
+core::Status AppGate::ConfigureHostOperations(void* ui_window,
+                                              unsigned int completion_message,
+                                              HostStatePatchHandler state_patch_handler) {
+  if (!mounted_.empty()) {
+    return core::Err(core::ErrorCode::AlreadyExists,
+                     L"Host operations must be configured before gate start");
+  }
+  if (ui_window == nullptr || completion_message == 0) {
+    return core::Err(core::ErrorCode::InvalidArgument,
+                     L"Host operations require a UI window and completion message");
+  }
+  operation_window_ = ui_window;
+  operation_message_ = completion_message;
+  state_patch_handler_ = std::move(state_patch_handler);
+  return core::Ok();
 }
 
 core::Status AppGate::PairAndMount(std::wstring_view embedded_text,
@@ -257,7 +194,11 @@ core::Status AppGate::PairAndMount(std::wstring_view embedded_text,
         action_map_.emplace_back(action, module.manifest.module_id);
       }
       module.descriptor = std::move(descriptor);
-      module.host = std::make_unique<GateHost>(this, module.manifest.module_id);
+      module.host = std::make_unique<GateHost>(
+          module.manifest.module_id,
+          [this](std::wstring_view route_id) { return RequestRoute(route_id); },
+          [this]() { return Peers(); }, operation_window_, operation_message_,
+          state_patch_handler_);
       mounted_.push_back(std::move(module));
     }
   }
@@ -340,11 +281,5 @@ std::vector<PeerInfo> AppGate::Peers() const {
   }
   return peers;
 }
-
-core::Status GateHost::RequestRoute(std::wstring_view route_id) {
-  return gate_->RequestRoute(route_id);
-}
-
-std::vector<PeerInfo> GateHost::Peers() { return gate_->Peers(); }
 
 }  // namespace modules

--- a/src/modules/gate/app_gate.h
+++ b/src/modules/gate/app_gate.h
@@ -16,6 +16,7 @@
 
 #include "modules/contract/module_contract.h"
 #include "modules/contract/module_manifest.h"
+#include "modules/gate/gate_host.h"
 #include "ui/config/resolved_ui_document.h"
 
 namespace modules {
@@ -29,8 +30,6 @@ struct RejectEntry {
 // this; there is exactly one gate (single choke point).
 const std::vector<RejectEntry>& CurrentRejects();
 
-class GateHost;
-
 class AppGate final {
  public:
   AppGate();
@@ -43,6 +42,11 @@ class AppGate final {
   // Test path: explicit texts.
   core::Status StartWithEmbedded(std::wstring_view embedded_text,
                                  std::wstring_view override_text = {});
+
+  // Must be configured before Start. The window procedure routes the supplied
+  // completion message to worker::Worker::Settle.
+  core::Status ConfigureHostOperations(void* ui_window, unsigned int completion_message,
+                                       HostStatePatchHandler state_patch_handler);
 
   const ui::config::ResolvedUiDocument* document() const { return document_.get(); }
   std::vector<PeerInfo> Peers() const;
@@ -75,6 +79,9 @@ class AppGate final {
   std::vector<RejectEntry> rejects_;
   std::vector<std::pair<std::wstring, std::wstring>> action_map_;  // action -> moduleId
   std::wstring current_route_;
+  void* operation_window_ = nullptr;
+  unsigned int operation_message_ = 0;
+  HostStatePatchHandler state_patch_handler_;
 };
 
 }  // namespace modules

--- a/src/modules/gate/gate_host.cpp
+++ b/src/modules/gate/gate_host.cpp
@@ -1,0 +1,129 @@
+#include "modules/gate/gate_host.h"
+
+#include <utility>
+
+#include "modules/gate/host_operation_dispatcher.h"
+
+namespace modules {
+
+GateHost::GateHost(std::wstring module_id,
+                   HostRouteRequestHandler route_request_handler,
+                   HostPeersHandler peers_handler, void* operation_window,
+                   unsigned int operation_message,
+                   HostStatePatchHandler state_patch_handler)
+    : module_id_(std::move(module_id)),
+      route_request_handler_(std::move(route_request_handler)),
+      peers_handler_(std::move(peers_handler)) {
+  if (operation_window == nullptr || operation_message == 0) return;
+
+  StatePatchSink sink;
+  if (state_patch_handler) {
+    sink = [module_id = module_id_, handler = std::move(state_patch_handler)](
+               const json::Value& patch) { return handler(module_id, patch); };
+  }
+  operations_ = std::make_unique<HostOperationDispatcher>(
+      operation_window, operation_message, std::move(sink));
+}
+
+GateHost::~GateHost() = default;
+
+ModuleSurface GateHost::Surface() { return surface_; }
+
+core::Status GateHost::SettingsRead(std::wstring_view key, std::wstring* out) {
+  std::lock_guard lock(mutex_);
+  const auto& section = settings_[module_id_];
+  const auto it = section.find(std::wstring(key));
+  if (it == section.end()) {
+    return core::Err(core::ErrorCode::NotFound, L"no such key");
+  }
+  *out = it->second;
+  return core::Ok();
+}
+
+core::Status GateHost::SettingsReadGlobal(std::wstring_view key,
+                                          std::wstring* out) {
+  std::lock_guard lock(mutex_);
+  const auto it = global_.find(std::wstring(key));
+  if (it == global_.end()) {
+    return core::Err(core::ErrorCode::NotFound, L"no such key");
+  }
+  *out = it->second;
+  return core::Ok();
+}
+
+core::Status GateHost::SettingsWrite(std::wstring_view key,
+                                     std::wstring_view value) {
+  std::lock_guard lock(mutex_);
+  settings_[module_id_][std::wstring(key)] = std::wstring(value);
+  return core::Ok();
+}
+
+core::Status GateHost::StorageWrite(std::wstring_view name,
+                                    std::wstring_view data) {
+  std::lock_guard lock(mutex_);
+  storage_[std::wstring(name)] = std::wstring(data);
+  return core::Ok();
+}
+
+core::Status GateHost::StorageRead(std::wstring_view name, std::wstring* out) {
+  std::lock_guard lock(mutex_);
+  const auto it = storage_.find(std::wstring(name));
+  if (it == storage_.end()) {
+    return core::Err(core::ErrorCode::NotFound, L"no such blob");
+  }
+  *out = it->second;
+  return core::Ok();
+}
+
+core::Status GateHost::StartProcess(const ProcessRequest& request,
+                                    HostOperationCallback callback,
+                                    AsyncRequestToken* token) {
+  if (!operations_) {
+    return core::Err(core::ErrorCode::Unsupported,
+                     L"async process host is not configured");
+  }
+  return operations_->StartProcess(request, std::move(callback), token);
+}
+
+core::Status GateHost::StartFolderProbe(const FolderProbeRequest& request,
+                                        HostOperationCallback callback,
+                                        AsyncRequestToken* token) {
+  if (!operations_) {
+    return core::Err(core::ErrorCode::Unsupported,
+                     L"async folder host is not configured");
+  }
+  return operations_->StartFolderProbe(request, std::move(callback), token);
+}
+
+void GateHost::CancelRequest(AsyncRequestToken token) {
+  if (operations_) operations_->CancelRequest(token);
+}
+
+core::Status GateHost::PublishStatePatch(const json::Value& patch) {
+  if (!operations_) {
+    return core::Err(core::ErrorCode::Unsupported,
+                     L"state patch sink is not configured");
+  }
+  return operations_->PublishStatePatch(patch);
+}
+
+void GateHost::ReportStatus(const core::Status& status) { last_status_ = status; }
+
+void GateHost::Log(std::wstring_view level, std::wstring_view text) {
+  std::lock_guard lock(mutex_);
+  log_.push_back(std::wstring(level) + L": " + std::wstring(text));
+}
+
+core::Status GateHost::RequestRoute(std::wstring_view route_id) {
+  if (!route_request_handler_) {
+    return core::Err(core::ErrorCode::Unsupported,
+                     L"route requests are not configured");
+  }
+  return route_request_handler_(route_id);
+}
+
+std::vector<PeerInfo> GateHost::Peers() {
+  return peers_handler_ ? peers_handler_() : std::vector<PeerInfo>{};
+}
+
+}  // namespace modules

--- a/src/modules/gate/gate_host.h
+++ b/src/modules/gate/gate_host.h
@@ -1,0 +1,68 @@
+// Parent-side ModuleHost adapter. Modules only see ModuleHost; this adapter
+// translates that contract into the services owned by the application.
+#pragma once
+
+#include <functional>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "modules/contract/module_contract.h"
+
+namespace modules {
+
+class HostOperationDispatcher;
+
+using HostStatePatchHandler =
+    std::function<core::Status(std::wstring_view module_id,
+                               const json::Value& patch)>;
+using HostRouteRequestHandler =
+    std::function<core::Status(std::wstring_view route_id)>;
+using HostPeersHandler = std::function<std::vector<PeerInfo>()>;
+
+class GateHost final : public ModuleHost {
+ public:
+  GateHost(std::wstring module_id,
+           HostRouteRequestHandler route_request_handler,
+           HostPeersHandler peers_handler, void* operation_window,
+           unsigned int operation_message,
+           HostStatePatchHandler state_patch_handler);
+  ~GateHost() override;
+
+  ModuleSurface Surface() override;
+  core::Status SettingsRead(std::wstring_view key, std::wstring* out) override;
+  core::Status SettingsReadGlobal(std::wstring_view key, std::wstring* out) override;
+  core::Status SettingsWrite(std::wstring_view key, std::wstring_view value) override;
+  core::Status StorageWrite(std::wstring_view name, std::wstring_view data) override;
+  core::Status StorageRead(std::wstring_view name, std::wstring* out) override;
+  core::Status StartProcess(const ProcessRequest& request,
+                            HostOperationCallback callback,
+                            AsyncRequestToken* token) override;
+  core::Status StartFolderProbe(const FolderProbeRequest& request,
+                                HostOperationCallback callback,
+                                AsyncRequestToken* token) override;
+  void CancelRequest(AsyncRequestToken token) override;
+  core::Status PublishStatePatch(const json::Value& patch) override;
+  void ReportStatus(const core::Status& status) override;
+  void Log(std::wstring_view level, std::wstring_view text) override;
+  core::Status RequestRoute(std::wstring_view route_id) override;
+  std::vector<PeerInfo> Peers() override;
+
+ private:
+  std::wstring module_id_;
+  HostRouteRequestHandler route_request_handler_;
+  HostPeersHandler peers_handler_;
+  ModuleSurface surface_;
+  std::mutex mutex_;
+  std::map<std::wstring, std::map<std::wstring, std::wstring>> settings_;
+  std::map<std::wstring, std::wstring> global_;
+  std::map<std::wstring, std::wstring> storage_;
+  std::vector<std::wstring> log_;
+  core::Status last_status_;
+  std::unique_ptr<HostOperationDispatcher> operations_;
+};
+
+}  // namespace modules

--- a/src/modules/gate/host_operation_dispatcher.cpp
+++ b/src/modules/gate/host_operation_dispatcher.cpp
@@ -1,0 +1,323 @@
+#include "modules/gate/host_operation_dispatcher.h"
+
+#include <windows.h>
+
+#include <map>
+#include <mutex>
+#include <utility>
+#include <vector>
+
+#include "platform/paths.h"
+#include "platform/process.h"
+#include "platform/strings.h"
+#include "platform/worker.h"
+
+namespace modules {
+namespace {
+
+HostOperationKind OperationKind(ProcessOperation operation) {
+  switch (operation) {
+    case ProcessOperation::Launch:
+      return HostOperationKind::Launch;
+    case ProcessOperation::ElevatedLaunch:
+      return HostOperationKind::ElevatedLaunch;
+    case ProcessOperation::Capture:
+      return HostOperationKind::Capture;
+  }
+  return HostOperationKind::Launch;
+}
+
+bool ContainsInvalidExecutableCharacter(std::wstring_view executable) {
+  return executable.find_first_of(std::wstring_view(L"\0\"\r\n", 4)) !=
+         std::wstring_view::npos;
+}
+
+std::wstring BuildArgumentList(const std::vector<std::wstring>& arguments) {
+  std::wstring command_line;
+  for (const std::wstring& argument : arguments) {
+    if (!command_line.empty()) command_line.push_back(L' ');
+    command_line.append(str::QuoteArg(argument));
+  }
+  return command_line;
+}
+
+bool SafeRelativeFile(std::wstring_view path) {
+  if (path.empty() || path.front() == L'\\' || path.front() == L'/' ||
+      path.find(L':') != std::wstring_view::npos) {
+    return false;
+  }
+  std::size_t start = 0;
+  while (start <= path.size()) {
+    const std::size_t end = path.find_first_of(L"\\/", start);
+    const std::wstring_view part =
+        path.substr(start, end == std::wstring_view::npos ? path.size() - start : end - start);
+    if (part.empty() || part == L"." || part == L"..") return false;
+    if (end == std::wstring_view::npos) break;
+    start = end + 1;
+  }
+  return true;
+}
+
+core::Status ValidateStart(const HostOperationCallback& callback, AsyncRequestToken* token) {
+  if (token == nullptr) {
+    return DHEPZ_ERR(core::ErrorCode::InvalidArgument, L"A request-token output is required");
+  }
+  *token = {};
+  if (!callback) {
+    return DHEPZ_ERR(core::ErrorCode::InvalidArgument, L"An operation callback is required");
+  }
+  return core::Ok();
+}
+
+}  // namespace
+
+struct HostOperationDispatcher::Impl {
+  Impl(void* ui_window, unsigned int completion_message, StatePatchSink sink)
+      : worker(ui_window, completion_message),
+        generation(worker.CreateGeneration()),
+        ui_thread_id(GetCurrentThreadId()),
+        state_patch_sink(std::move(sink)) {}
+
+  worker::Worker worker;
+  std::uint64_t generation = 0;
+  unsigned long ui_thread_id = 0;
+  StatePatchSink state_patch_sink;
+  std::mutex mutex;
+  std::map<std::uint64_t, worker::JobHandle> requests;
+  std::uint64_t next_token = 1;
+  bool invalidated = false;
+};
+
+core::Status BuildProcessCommandLine(const ProcessRequest& request, std::wstring* out) {
+  if (out == nullptr) {
+    return DHEPZ_ERR(core::ErrorCode::InvalidArgument, L"A command-line output is required");
+  }
+  out->clear();
+  if (request.executable.empty() || ContainsInvalidExecutableCharacter(request.executable)) {
+    return DHEPZ_ERR(core::ErrorCode::InvalidArgument, L"Executable is empty or invalid");
+  }
+  for (const std::wstring& argument : request.arguments) {
+    if (argument.find(L'\0') != std::wstring::npos) {
+      return DHEPZ_ERR(core::ErrorCode::InvalidArgument,
+                       L"Process arguments cannot contain embedded nulls");
+    }
+  }
+
+  out->push_back(L'\"');
+  out->append(request.executable);
+  out->push_back(L'\"');
+  const std::wstring arguments = BuildArgumentList(request.arguments);
+  if (!arguments.empty()) {
+    out->push_back(L' ');
+    out->append(arguments);
+  }
+  return core::Ok();
+}
+
+HostOperationDispatcher::HostOperationDispatcher(void* ui_window,
+                                                 unsigned int completion_message,
+                                                 StatePatchSink state_patch_sink)
+    : impl_(std::make_unique<Impl>(ui_window, completion_message,
+                                  std::move(state_patch_sink))) {}
+
+HostOperationDispatcher::~HostOperationDispatcher() {
+  InvalidateGeneration();
+  impl_->worker.Shutdown();
+}
+
+core::Status HostOperationDispatcher::StartProcess(const ProcessRequest& request,
+                                                   HostOperationCallback callback,
+                                                   AsyncRequestToken* token) {
+  DHEPZ_RETURN_IF_ERROR(ValidateStart(callback, token));
+  std::wstring command_line;
+  DHEPZ_RETURN_IF_ERROR(BuildProcessCommandLine(request, &command_line));
+  if (request.operation == ProcessOperation::Capture && request.timeout_ms == 0) {
+    return DHEPZ_ERR(core::ErrorCode::InvalidArgument,
+                     L"Capture timeout must be greater than zero");
+  }
+
+  AsyncRequestToken issued;
+  {
+    std::lock_guard lock(impl_->mutex);
+    if (impl_->invalidated) {
+      return DHEPZ_ERR(core::ErrorCode::Cancelled, L"Module host generation is invalid");
+    }
+    issued.value = impl_->next_token++;
+  }
+
+  const std::uint64_t generation = impl_->generation;
+  const HostOperationKind kind = OperationKind(request.operation);
+  worker::JobHandle handle = impl_->worker.Submit(
+      [request, command_line = std::move(command_line), issued, generation,
+       kind](const std::atomic<bool>& cancelled) {
+        auto completion = std::make_shared<HostOperationCompletion>();
+        completion->token = issued;
+        completion->generation = generation;
+        completion->kind = kind;
+        if (cancelled.load()) return std::static_pointer_cast<void>(completion);
+
+        if (request.operation == ProcessOperation::Launch) {
+          completion->status = process::Launch(request.executable, command_line,
+                                               request.working_directory,
+                                               process::WindowMode::NewConsole);
+        } else if (request.operation == ProcessOperation::ElevatedLaunch) {
+          completion->status = process::ShellLaunch(L"runas", request.executable,
+                                                    BuildArgumentList(request.arguments),
+                                                    request.working_directory);
+        } else {
+          process::RunResult result;
+          completion->status = process::RunCapture(command_line, request.working_directory,
+                                                    request.timeout_ms, &result, &cancelled);
+          completion->process.exit_code = result.exit_code;
+          completion->process.output = std::move(result.output);
+          completion->process.timed_out = result.timed_out;
+          if (completion->status.ok() && result.timed_out) {
+            completion->status =
+                core::Err(core::ErrorCode::Cancelled, L"Process capture timed out");
+          }
+        }
+        return std::static_pointer_cast<void>(completion);
+      },
+      [this, callback = std::move(callback), issued](std::shared_ptr<void> cargo) {
+        {
+          std::lock_guard lock(impl_->mutex);
+          impl_->requests.erase(issued.value);
+        }
+        callback(*std::static_pointer_cast<HostOperationCompletion>(std::move(cargo)));
+      },
+      generation);
+
+  {
+    std::lock_guard lock(impl_->mutex);
+    if (impl_->invalidated) {
+      impl_->worker.Cancel(handle);
+      return DHEPZ_ERR(core::ErrorCode::Cancelled, L"Module host generation is invalid");
+    }
+    impl_->requests.emplace(issued.value, std::move(handle));
+  }
+  *token = issued;
+  return core::Ok();
+}
+
+core::Status HostOperationDispatcher::StartFolderProbe(const FolderProbeRequest& request,
+                                                       HostOperationCallback callback,
+                                                       AsyncRequestToken* token) {
+  DHEPZ_RETURN_IF_ERROR(ValidateStart(callback, token));
+  for (const std::wstring& relative : request.relative_files) {
+    if (!SafeRelativeFile(relative)) {
+      return DHEPZ_ERR(core::ErrorCode::InvalidArgument,
+                       L"Folder probes require safe relative file paths");
+    }
+  }
+
+  AsyncRequestToken issued;
+  {
+    std::lock_guard lock(impl_->mutex);
+    if (impl_->invalidated) {
+      return DHEPZ_ERR(core::ErrorCode::Cancelled, L"Module host generation is invalid");
+    }
+    issued.value = impl_->next_token++;
+  }
+  const std::uint64_t generation = impl_->generation;
+  worker::JobHandle handle = impl_->worker.Submit(
+      [request, issued, generation](const std::atomic<bool>& cancelled) {
+        auto completion = std::make_shared<HostOperationCompletion>();
+        completion->token = issued;
+        completion->generation = generation;
+        completion->kind = HostOperationKind::FolderProbe;
+        if (cancelled.load()) return std::static_pointer_cast<void>(completion);
+
+        completion->folder.normalized_directory = paths::Normalize(request.directory);
+        if (completion->folder.normalized_directory.empty()) {
+          completion->status =
+              core::Err(core::ErrorCode::InvalidArgument, L"Folder path is not absolute");
+        } else {
+          completion->folder.directory_exists =
+              paths::DirectoryExists(completion->folder.normalized_directory);
+          if (!completion->folder.directory_exists) {
+            completion->status =
+                core::Err(core::ErrorCode::NotFound, L"Folder does not exist or is inaccessible");
+          }
+        }
+        for (const std::wstring& relative : request.relative_files) {
+          RelativeFilePresence presence;
+          presence.relative_path = relative;
+          if (completion->folder.directory_exists) {
+            presence.present = paths::FileExists(
+                paths::Join(completion->folder.normalized_directory, relative));
+          }
+          completion->folder.files.push_back(std::move(presence));
+        }
+        return std::static_pointer_cast<void>(completion);
+      },
+      [this, callback = std::move(callback), issued](std::shared_ptr<void> cargo) {
+        {
+          std::lock_guard lock(impl_->mutex);
+          impl_->requests.erase(issued.value);
+        }
+        callback(*std::static_pointer_cast<HostOperationCompletion>(std::move(cargo)));
+      },
+      generation);
+
+  {
+    std::lock_guard lock(impl_->mutex);
+    if (impl_->invalidated) {
+      impl_->worker.Cancel(handle);
+      return DHEPZ_ERR(core::ErrorCode::Cancelled, L"Module host generation is invalid");
+    }
+    impl_->requests.emplace(issued.value, std::move(handle));
+  }
+  *token = issued;
+  return core::Ok();
+}
+
+void HostOperationDispatcher::CancelRequest(AsyncRequestToken token) {
+  worker::JobHandle handle;
+  {
+    std::lock_guard lock(impl_->mutex);
+    const auto found = impl_->requests.find(token.value);
+    if (found == impl_->requests.end()) return;
+    handle = found->second;
+    impl_->requests.erase(found);
+  }
+  impl_->worker.Cancel(handle);
+}
+
+void HostOperationDispatcher::InvalidateGeneration() {
+  std::vector<worker::JobHandle> handles;
+  {
+    std::lock_guard lock(impl_->mutex);
+    if (impl_->invalidated) return;
+    impl_->invalidated = true;
+    for (const auto& [token, handle] : impl_->requests) {
+      (void)token;
+      handles.push_back(handle);
+    }
+    impl_->requests.clear();
+  }
+  impl_->worker.InvalidateGeneration(impl_->generation);
+  for (const worker::JobHandle& handle : handles) impl_->worker.Cancel(handle);
+}
+
+core::Status HostOperationDispatcher::PublishStatePatch(const json::Value& patch) {
+  if (GetCurrentThreadId() != impl_->ui_thread_id) {
+    return DHEPZ_ERR(core::ErrorCode::InvalidArgument,
+                     L"State patches may only be published on the UI thread");
+  }
+  {
+    std::lock_guard lock(impl_->mutex);
+    if (impl_->invalidated) {
+      return DHEPZ_ERR(core::ErrorCode::Cancelled, L"Module host generation is invalid");
+    }
+  }
+  if (!impl_->state_patch_sink) {
+    return DHEPZ_ERR(core::ErrorCode::Unsupported, L"State patch sink is not configured");
+  }
+  return impl_->state_patch_sink(patch);
+}
+
+void HostOperationDispatcher::ReapFinished() { impl_->worker.JoinFinished(); }
+
+std::size_t HostOperationDispatcher::ThreadCount() const { return impl_->worker.ThreadCount(); }
+
+}  // namespace modules

--- a/src/modules/gate/host_operation_dispatcher.h
+++ b/src/modules/gate/host_operation_dispatcher.h
@@ -1,0 +1,51 @@
+// Parent-owned implementation of ModuleHost's asynchronous process and
+// folder-probe services. Work runs on run-once worker threads; every result is
+// posted back to the configured UI window and guarded by one host generation.
+#pragma once
+
+#include <cstddef>
+#include <functional>
+#include <memory>
+#include <string>
+
+#include "modules/contract/module_contract.h"
+
+namespace modules {
+
+using StatePatchSink = std::function<core::Status(const json::Value& patch)>;
+
+// Builds argv[0] plus the structured arguments with the one parent-owned
+// quoting path used by normal launch and capture.
+core::Status BuildProcessCommandLine(const ProcessRequest& request, std::wstring* out);
+
+class HostOperationDispatcher final {
+ public:
+  HostOperationDispatcher(void* ui_window, unsigned int completion_message,
+                          StatePatchSink state_patch_sink);
+  ~HostOperationDispatcher();
+
+  HostOperationDispatcher(const HostOperationDispatcher&) = delete;
+  HostOperationDispatcher& operator=(const HostOperationDispatcher&) = delete;
+
+  core::Status StartProcess(const ProcessRequest& request, HostOperationCallback callback,
+                            AsyncRequestToken* token);
+  core::Status StartFolderProbe(const FolderProbeRequest& request,
+                                HostOperationCallback callback, AsyncRequestToken* token);
+  void CancelRequest(AsyncRequestToken token);
+
+  // Permanently invalidates this module-host lifetime. Running jobs may finish
+  // their OS work, but no queued or future completion can be delivered.
+  void InvalidateGeneration();
+
+  // Only succeeds on the UI thread captured at construction.
+  core::Status PublishStatePatch(const json::Value& patch);
+
+  void ReapFinished();
+  std::size_t ThreadCount() const;
+
+ private:
+  struct Impl;
+  std::unique_ptr<Impl> impl_;
+};
+
+}  // namespace modules

--- a/src/platform/process.cpp
+++ b/src/platform/process.cpp
@@ -130,7 +130,8 @@ core::Status ShellLaunch(std::wstring_view verb, std::wstring_view file,
 }
 
 core::Status RunCapture(std::wstring_view command_line, std::wstring_view working_dir,
-                        unsigned long timeout_ms, RunResult* out) {
+                        unsigned long timeout_ms, RunResult* out,
+                        const std::atomic<bool>* cancelled) {
   if (out != nullptr) *out = RunResult{};
 
   SECURITY_ATTRIBUTES sa{};
@@ -175,7 +176,12 @@ core::Status RunCapture(std::wstring_view command_line, std::wstring_view workin
   std::string raw;
   char buffer[4096];
   bool timed_out = false;
+  bool was_cancelled = false;
   for (;;) {
+    if (cancelled != nullptr && cancelled->load()) {
+      was_cancelled = true;
+      break;
+    }
     DWORD available = 0;
     if (!PeekNamedPipe(read_end, nullptr, 0, nullptr, &available, nullptr)) break;
     if (available > 0) {
@@ -200,13 +206,16 @@ core::Status RunCapture(std::wstring_view command_line, std::wstring_view workin
   }
   CloseHandle(read_end);
 
-  if (timed_out) {
+  if (timed_out || was_cancelled) {
     TerminateProcess(pi.hProcess, 1);
     WaitForSingleObject(pi.hProcess, 2000);
     CloseHandle(pi.hProcess);
     if (out != nullptr) {
-      out->timed_out = true;
+      out->timed_out = timed_out;
       out->output = DecodeOutput(raw);
+    }
+    if (was_cancelled) {
+      return core::Err(core::ErrorCode::Cancelled, L"Process capture cancelled");
     }
     return core::Ok();
   }

--- a/src/platform/process.h
+++ b/src/platform/process.h
@@ -8,6 +8,7 @@
 // prove the round trip).
 #pragma once
 
+#include <atomic>
 #include <string>
 #include <string_view>
 
@@ -34,9 +35,11 @@ core::Status ShellLaunch(std::wstring_view verb, std::wstring_view file,
 
 // Runs hidden, captures stdout+stderr (merged), bounded by timeout_ms.
 // Timeout is reported in the result (timed_out) with the child terminated;
-// spawn failures are a Status error. Never blocks past the deadline.
+// spawn failures are a Status error. An optional cancellation flag terminates
+// the child and returns Cancelled. Never blocks past the deadline.
 core::Status RunCapture(std::wstring_view command_line, std::wstring_view working_dir,
-                        unsigned long timeout_ms, RunResult* out);
+                        unsigned long timeout_ms, RunResult* out,
+                        const std::atomic<bool>* cancelled = nullptr);
 
 // FormatMessageW for humans.
 std::wstring ErrorMessage(unsigned long code);

--- a/src/platform/worker.cpp
+++ b/src/platform/worker.cpp
@@ -12,10 +12,16 @@
 namespace worker {
 namespace {
 
-// What crosses to the UI thread. The worker pointer lets Settle() re-check
-// the generation without any instance lookup at the window procedure.
+// What crosses to the UI thread. The guard outlives Worker when a posted
+// completion remains in the window queue during owner teardown.
+struct DeliveryGuard {
+  std::mutex mutex;
+  std::uint64_t next_generation = 1;
+  std::map<std::uint64_t, bool> generations;
+};
+
 struct CompletionMessage {
-  Worker* worker = nullptr;
+  std::shared_ptr<DeliveryGuard> guard;
   std::uint64_t generation = 0;
   std::shared_ptr<void> cargo;
   Deliver deliver;
@@ -35,6 +41,14 @@ struct CoalesceSlot {
   std::shared_ptr<std::atomic<bool>> cancel;
 };
 
+bool DeliveryGenerationAlive(const std::shared_ptr<DeliveryGuard>& guard,
+                             std::uint64_t generation) {
+  if (generation == 0) return true;
+  std::lock_guard lock(guard->mutex);
+  const auto found = guard->generations.find(generation);
+  return found != guard->generations.end() && found->second;
+}
+
 }  // namespace
 
 struct Worker::Impl {
@@ -44,8 +58,7 @@ struct Worker::Impl {
 
   mutable std::mutex mutex;
   std::vector<std::unique_ptr<ThreadEntry>> threads;
-  std::uint64_t next_generation = 1;
-  std::map<std::uint64_t, bool> generations;  // id -> alive
+  std::shared_ptr<DeliveryGuard> delivery_guard = std::make_shared<DeliveryGuard>();
   std::map<std::wstring, std::shared_ptr<CoalesceSlot>> slots;
 
   void ReapFinishedLocked() {
@@ -78,7 +91,8 @@ struct Worker::Impl {
     if (generation != 0 && !self->GenerationAlive(generation)) {
       return;
     }
-    auto* message = new CompletionMessage{self, generation, std::move(cargo), std::move(deliver)};
+    auto* message = new CompletionMessage{delivery_guard, generation, std::move(cargo),
+                                          std::move(deliver)};
     if (!PostMessageW(static_cast<HWND>(ui_window), completion_message, 0,
                       reinterpret_cast<LPARAM>(message))) {
       delete message;
@@ -239,27 +253,22 @@ void Worker::Cancel(const JobHandle& handle) {
 }
 
 std::uint64_t Worker::CreateGeneration() {
-  std::lock_guard<std::mutex> guard(impl_->mutex);
-  const std::uint64_t id = impl_->next_generation++;
-  impl_->generations[id] = true;
+  std::lock_guard<std::mutex> guard(impl_->delivery_guard->mutex);
+  const std::uint64_t id = impl_->delivery_guard->next_generation++;
+  impl_->delivery_guard->generations[id] = true;
   return id;
 }
 
 void Worker::InvalidateGeneration(std::uint64_t generation) {
-  std::lock_guard<std::mutex> guard(impl_->mutex);
-  const auto found = impl_->generations.find(generation);
-  if (found != impl_->generations.end()) {
+  std::lock_guard<std::mutex> guard(impl_->delivery_guard->mutex);
+  const auto found = impl_->delivery_guard->generations.find(generation);
+  if (found != impl_->delivery_guard->generations.end()) {
     found->second = false;
   }
 }
 
 bool Worker::GenerationAlive(std::uint64_t generation) const {
-  if (generation == 0) {
-    return true;
-  }
-  std::lock_guard<std::mutex> guard(impl_->mutex);
-  const auto found = impl_->generations.find(generation);
-  return found != impl_->generations.end() && found->second;
+  return DeliveryGenerationAlive(impl_->delivery_guard, generation);
 }
 
 void Worker::JoinFinished() {
@@ -280,9 +289,6 @@ void Worker::Shutdown() {
       return;
     }
     impl_->shutdown = true;
-    for (auto& generation : impl_->generations) {
-      generation.second = false;
-    }
     for (auto& slot : impl_->slots) {
       if (slot.second->cancel) {
         slot.second->cancel->store(true);
@@ -291,6 +297,12 @@ void Worker::Shutdown() {
     }
     to_join = std::move(impl_->threads);
     impl_->threads.clear();
+  }
+  {
+    std::lock_guard<std::mutex> guard(impl_->delivery_guard->mutex);
+    for (auto& generation : impl_->delivery_guard->generations) {
+      generation.second = false;
+    }
   }
   // Join outside the lock: a running body may still call back into the
   // worker (generation checks), and those take the same mutex.
@@ -306,7 +318,7 @@ void Worker::Settle(long long lparam) {
   if (message == nullptr) {
     return;
   }
-  if (message->worker->GenerationAlive(message->generation) && message->deliver) {
+  if (DeliveryGenerationAlive(message->guard, message->generation) && message->deliver) {
     message->deliver(std::move(message->cargo));
   }
   delete message;

--- a/tests/modules/contract/module_contract_test.cpp
+++ b/tests/modules/contract/module_contract_test.cpp
@@ -3,6 +3,7 @@
 
 #include <memory>
 #include <string>
+#include <utility>
 
 #include "framework/test_case.h"
 
@@ -43,7 +44,27 @@ struct TestHost final : modules::ModuleHost {
   }
   core::Status StorageWrite(std::wstring_view, std::wstring_view) override { return core::Ok(); }
   core::Status StorageRead(std::wstring_view, std::wstring*) override { return core::Ok(); }
-  core::Status ProcessRun(std::wstring_view, std::wstring*) override { return core::Ok(); }
+  core::Status StartProcess(const modules::ProcessRequest& request,
+                            modules::HostOperationCallback callback,
+                            modules::AsyncRequestToken* token) override {
+    process_request = request;
+    process_callback = std::move(callback);
+    *token = {17};
+    return core::Ok();
+  }
+  core::Status StartFolderProbe(const modules::FolderProbeRequest& request,
+                                modules::HostOperationCallback callback,
+                                modules::AsyncRequestToken* token) override {
+    folder_request = request;
+    folder_callback = std::move(callback);
+    *token = {18};
+    return core::Ok();
+  }
+  void CancelRequest(modules::AsyncRequestToken token) override { cancelled = token; }
+  core::Status PublishStatePatch(const json::Value& patch) override {
+    published_patch = patch;
+    return core::Ok();
+  }
   void ReportStatus(const core::Status& s) override { reported = !s.ok(); }
   void Log(std::wstring_view, std::wstring_view) override {}
   core::Status RequestRoute(std::wstring_view route) override {
@@ -54,6 +75,12 @@ struct TestHost final : modules::ModuleHost {
 
   std::wstring last_write;
   std::wstring requested;
+  modules::ProcessRequest process_request;
+  modules::FolderProbeRequest folder_request;
+  modules::HostOperationCallback process_callback;
+  modules::HostOperationCallback folder_callback;
+  modules::AsyncRequestToken cancelled;
+  json::Value published_patch;
   bool reported = false;
 };
 
@@ -98,6 +125,40 @@ DHEPZ_TEST(ModuleManifest, ValidManifestParses) {
   DHEPZ_CHECK(manifest.show_in_tabs);
   DHEPZ_CHECK_EQ(manifest.settings_route, std::wstring(L"terminal-settings"));
   DHEPZ_CHECK_EQ(manifest.actions.size(), static_cast<std::size_t>(2));
+}
+
+DHEPZ_TEST(ModuleContract, AsyncOperationsAreTypedAndTokened) {
+  TestHost host;
+  modules::ProcessRequest process;
+  process.operation = modules::ProcessOperation::Capture;
+  process.executable = L"tool.exe";
+  process.arguments = {L"space value", L"&literal"};
+  process.working_directory = L"C:\\work";
+  process.timeout_ms = 2500;
+
+  modules::AsyncRequestToken process_token;
+  DHEPZ_CHECK(host.StartProcess(process, {}, &process_token).ok());
+  DHEPZ_CHECK_EQ(process_token.value, static_cast<std::uint64_t>(17));
+  DHEPZ_CHECK(host.process_request.operation == modules::ProcessOperation::Capture);
+  DHEPZ_CHECK_EQ(host.process_request.arguments[0], std::wstring(L"space value"));
+
+  modules::FolderProbeRequest probe;
+  probe.directory = L"C:\\work";
+  probe.relative_files = {L"Scripts\\Activate.ps1", L"Scripts\\activate.bat"};
+  modules::AsyncRequestToken probe_token;
+  DHEPZ_CHECK(host.StartFolderProbe(probe, {}, &probe_token).ok());
+  DHEPZ_CHECK_EQ(probe_token.value, static_cast<std::uint64_t>(18));
+  DHEPZ_CHECK_EQ(host.folder_request.relative_files.size(), static_cast<std::size_t>(2));
+
+  host.CancelRequest(process_token);
+  DHEPZ_CHECK(host.cancelled == process_token);
+
+  json::Value patch = json::Value::Object();
+  patch.Set(L"busy", json::Value::Bool(false));
+  DHEPZ_CHECK(host.PublishStatePatch(patch).ok());
+  const json::Value* busy = host.published_patch.Find(L"busy");
+  DHEPZ_CHECK(busy != nullptr);
+  DHEPZ_CHECK(!busy->AsBool(true));
 }
 
 DHEPZ_TEST(ModuleManifest, MissingRequiredFieldsAreDiagnostics) {

--- a/tests/modules/gate/host_operation_dispatcher_test.cpp
+++ b/tests/modules/gate/host_operation_dispatcher_test.cpp
@@ -1,0 +1,347 @@
+#include "modules/gate/host_operation_dispatcher.h"
+
+#include <windows.h>
+#include <shellapi.h>
+
+#include <atomic>
+#include <chrono>
+#include <string>
+#include <thread>
+
+#include "framework/test_case.h"
+#include "modules/gate/app_gate.h"
+#include "modules/registry/module_registry.h"
+#include "platform/worker.h"
+
+namespace {
+
+struct RigState {
+  unsigned int completion_message = 0;
+  unsigned int ping_message = 0;
+  std::atomic<int> pings{0};
+};
+
+RigState* g_state = nullptr;
+
+LRESULT CALLBACK HostRigProc(HWND window, UINT message, WPARAM wparam, LPARAM lparam) {
+  if (g_state != nullptr && message == g_state->completion_message) {
+    worker::Worker::Settle(lparam);
+    return 0;
+  }
+  if (g_state != nullptr && message == g_state->ping_message) {
+    ++g_state->pings;
+    return 0;
+  }
+  return DefWindowProcW(window, message, wparam, lparam);
+}
+
+struct Rig {
+  HWND window = nullptr;
+  RigState state;
+
+  Rig() {
+    g_state = &state;
+    WNDCLASSW cls{};
+    cls.lpfnWndProc = HostRigProc;
+    cls.hInstance = GetModuleHandleW(nullptr);
+    cls.lpszClassName = L"dhepz.host-operation.test";
+    RegisterClassW(&cls);
+    state.completion_message = RegisterWindowMessageW(L"dhepz.host-operation.completion");
+    state.ping_message = RegisterWindowMessageW(L"dhepz.host-operation.ping");
+    window = CreateWindowExW(0, cls.lpszClassName, L"", WS_POPUP, 0, 0, 16, 16, nullptr,
+                             nullptr, cls.hInstance, nullptr);
+    DHEPZ_CHECK(window != nullptr);
+  }
+
+  ~Rig() {
+    if (window != nullptr) DestroyWindow(window);
+    g_state = nullptr;
+  }
+};
+
+template <typename Predicate>
+void PumpUntil(Predicate predicate, int timeout_ms) {
+  const auto deadline = std::chrono::steady_clock::now() +
+                        std::chrono::milliseconds(timeout_ms);
+  while (std::chrono::steady_clock::now() < deadline) {
+    MSG message;
+    while (PeekMessageW(&message, nullptr, 0, 0, PM_REMOVE)) {
+      TranslateMessage(&message);
+      DispatchMessageW(&message);
+    }
+    if (predicate()) return;
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }
+}
+
+std::wstring TempDir() {
+  wchar_t base[MAX_PATH]{};
+  GetTempPathW(MAX_PATH, base);
+  const std::wstring path = std::wstring(base) + L"dhepz-host-probe-" +
+                            std::to_wstring(GetTickCount64());
+  CreateDirectoryW(path.c_str(), nullptr);
+  return path;
+}
+
+std::wstring g_gate_probe_directory;
+
+class HostConsumerModule final : public modules::ModuleDescriptor {
+ public:
+  std::wstring_view ModuleId() const override { return L"host-consumer"; }
+  std::wstring_view TabLabel() const override { return L"Host Consumer"; }
+  int Order() const override { return 10; }
+  bool ShowInTabs() const override { return true; }
+  std::wstring_view SettingsRoute() const override { return {}; }
+  std::vector<std::wstring> DeclaredActions() const override { return {L"host:probe"}; }
+  std::vector<std::wstring> DeclaredBindings() const override { return {}; }
+  std::vector<std::wstring> DeclaredCapabilities() const override { return {}; }
+  core::Status Bind(modules::ModuleHost& host) override {
+    host_ = &host;
+    return core::Ok();
+  }
+  core::Status Handle(std::wstring_view, const json::Value&, json::Value*) override {
+    modules::FolderProbeRequest request;
+    request.directory = g_gate_probe_directory;
+    request.relative_files = {L"present.txt"};
+    return host_->StartFolderProbe(
+        request,
+        [this](const modules::HostOperationCompletion& completion) {
+          json::Value patch = json::Value::Object();
+          patch.Set(L"present", json::Value::Bool(completion.folder.files[0].present));
+          publish_status_ = host_->PublishStatePatch(patch);
+        },
+        &token_);
+  }
+  void Release() override {}
+
+  modules::ModuleHost* host_ = nullptr;
+  modules::AsyncRequestToken token_;
+  core::Status publish_status_;
+};
+
+std::unique_ptr<modules::ModuleDescriptor> MakeHostConsumer() {
+  return std::make_unique<HostConsumerModule>();
+}
+
+std::wstring HostConsumerEmbedded() {
+  return LR"({
+    "core": {
+      "schema": "dhepz.ui.core", "version": 1,
+      "tokens": { "dark": { "text": "#ffffff" }, "light": { "text": "#000000" } },
+      "allows_children": ["screen"],
+      "components": {
+        "screen": { "properties": {
+          "route_id": { "kind": "string", "required": true },
+          "module_id": { "kind": "string" },
+          "tab_label": { "kind": "string" }
+        } }
+      }
+    },
+    "components": [
+      { "type": "screen", "route_id": "host-home", "module_id": "host-consumer",
+        "tab_label": "Host Consumer" }
+    ],
+    "modules": [
+      { "moduleId": "host-consumer", "tabLabel": "Host Consumer",
+        "order": 10, "showInTabs": true, "actions": ["host:probe"] }
+    ]
+  })";
+}
+
+}  // namespace
+
+DHEPZ_TEST(HostOperations, CaptureDoesNotBlockUiAndCompletesOnUiThread) {
+  Rig rig;
+  modules::HostOperationDispatcher dispatcher(rig.window, rig.state.completion_message, {});
+  const unsigned long ui_thread = GetCurrentThreadId();
+  std::atomic<bool> delivered{false};
+  modules::HostOperationCompletion observed;
+  unsigned long delivery_thread = 0;
+
+  modules::ProcessRequest request;
+  request.operation = modules::ProcessOperation::Capture;
+  request.executable = L"powershell.exe";
+  request.arguments = {L"-NoProfile", L"-Command",
+                       L"Start-Sleep -Seconds 2; [Console]::Out.Write('host-ok')"};
+  modules::AsyncRequestToken token;
+  DHEPZ_CHECK(dispatcher.StartProcess(
+                  request,
+                  [&](const modules::HostOperationCompletion& completion) {
+                    observed = completion;
+                    delivery_thread = GetCurrentThreadId();
+                    delivered = true;
+                  },
+                  &token)
+                  .ok());
+  DHEPZ_CHECK(token);
+
+  PostMessageW(rig.window, rig.state.ping_message, 0, 0);
+  PumpUntil([&] { return rig.state.pings.load() == 1; }, 500);
+  DHEPZ_CHECK_EQ(rig.state.pings.load(), 1);
+  DHEPZ_CHECK(!delivered.load());
+
+  PumpUntil([&] { return delivered.load(); }, 10000);
+  DHEPZ_CHECK(delivered.load());
+  DHEPZ_CHECK_EQ(static_cast<std::uint64_t>(delivery_thread),
+                 static_cast<std::uint64_t>(ui_thread));
+  DHEPZ_CHECK(observed.token == token);
+  DHEPZ_CHECK(observed.generation != 0);
+  DHEPZ_CHECK(observed.kind == modules::HostOperationKind::Capture);
+  DHEPZ_CHECK(observed.status.ok());
+  DHEPZ_CHECK(observed.process.output.find(L"host-ok") != std::wstring::npos);
+
+  PumpUntil(
+      [&] {
+        dispatcher.ReapFinished();
+        return dispatcher.ThreadCount() == 0;
+      },
+      1000);
+  DHEPZ_CHECK_EQ(dispatcher.ThreadCount(), static_cast<std::size_t>(0));
+}
+
+DHEPZ_TEST(HostOperations, AppGateHostDelegatesOperationsAndStatePatches) {
+  Rig rig;
+  modules::ResetRegistryForTests();
+  modules::RegisterModule(L"host-consumer", &MakeHostConsumer);
+  g_gate_probe_directory = TempDir();
+  HANDLE file = CreateFileW((g_gate_probe_directory + L"\\present.txt").c_str(), GENERIC_WRITE,
+                            0, nullptr, CREATE_NEW, FILE_ATTRIBUTE_NORMAL, nullptr);
+  DHEPZ_CHECK(file != INVALID_HANDLE_VALUE);
+  CloseHandle(file);
+
+  std::atomic<bool> published{false};
+  modules::AppGate gate;
+  DHEPZ_CHECK(gate.ConfigureHostOperations(
+                  rig.window, rig.state.completion_message,
+                  [&](std::wstring_view module_id, const json::Value& patch) {
+                    DHEPZ_CHECK_EQ(std::wstring(module_id), std::wstring(L"host-consumer"));
+                    const json::Value* present = patch.Find(L"present");
+                    DHEPZ_CHECK(present != nullptr && present->AsBool());
+                    published = true;
+                    return core::Ok();
+                  })
+                  .ok());
+  DHEPZ_CHECK(gate.StartWithEmbedded(HostConsumerEmbedded()).ok());
+  json::Value payload = json::Value::Object();
+  json::Value immediate = json::Value::Object();
+  DHEPZ_CHECK(gate.Dispatch(L"host:probe", payload, &immediate).ok());
+  PumpUntil([&] { return published.load(); }, 2000);
+  DHEPZ_CHECK(published.load());
+  modules::ResetRegistryForTests();
+}
+
+DHEPZ_TEST(HostOperations, CancelAndGenerationInvalidationSuppressCompletion) {
+  Rig rig;
+  modules::HostOperationDispatcher dispatcher(rig.window, rig.state.completion_message, {});
+  std::atomic<int> deliveries{0};
+  modules::ProcessRequest request;
+  request.operation = modules::ProcessOperation::Capture;
+  request.executable = L"powershell.exe";
+  request.arguments = {L"-NoProfile", L"-Command", L"Start-Sleep -Seconds 5"};
+
+  modules::AsyncRequestToken cancelled;
+  DHEPZ_CHECK(dispatcher.StartProcess(
+                  request,
+                  [&](const modules::HostOperationCompletion&) { ++deliveries; }, &cancelled)
+                  .ok());
+  std::this_thread::sleep_for(std::chrono::milliseconds(150));
+  dispatcher.CancelRequest(cancelled);
+  PumpUntil(
+      [&] {
+        dispatcher.ReapFinished();
+        return dispatcher.ThreadCount() == 0;
+      },
+      1000);
+  DHEPZ_CHECK_EQ(dispatcher.ThreadCount(), static_cast<std::size_t>(0));
+  DHEPZ_CHECK_EQ(deliveries.load(), 0);
+
+  request.arguments = {L"-NoProfile", L"-Command", L"Start-Sleep -Milliseconds 300"};
+  modules::AsyncRequestToken stale;
+  DHEPZ_CHECK(dispatcher.StartProcess(
+                  request,
+                  [&](const modules::HostOperationCompletion&) { ++deliveries; }, &stale)
+                  .ok());
+  dispatcher.InvalidateGeneration();
+  PumpUntil([&] { return false; }, 500);
+  DHEPZ_CHECK_EQ(deliveries.load(), 0);
+}
+
+DHEPZ_TEST(HostOperations, ParentQuotingRoundTripsStructuredArguments) {
+  modules::ProcessRequest request;
+  request.executable = L"C:\\Program Files\\Tool\\tool.exe";
+  request.arguments = {L"space value", L"&literal", L"quote\"value", L"trailing\\"};
+
+  std::wstring command_line;
+  DHEPZ_CHECK(modules::BuildProcessCommandLine(request, &command_line).ok());
+  int count = 0;
+  wchar_t** parsed = CommandLineToArgvW(command_line.c_str(), &count);
+  DHEPZ_CHECK(parsed != nullptr);
+  DHEPZ_CHECK_EQ(count, 5);
+  DHEPZ_CHECK_EQ(std::wstring(parsed[0]), request.executable);
+  for (int i = 1; i < count; ++i) {
+    DHEPZ_CHECK_EQ(std::wstring(parsed[i]), request.arguments[static_cast<std::size_t>(i - 1)]);
+  }
+  LocalFree(parsed);
+}
+
+DHEPZ_TEST(HostOperations, ParentQuotingRejectsEmbeddedNullArguments) {
+  modules::ProcessRequest request;
+  request.executable = L"tool.exe";
+  request.arguments = {std::wstring(L"before\0after", 12)};
+  std::wstring command_line;
+  DHEPZ_CHECK(!modules::BuildProcessCommandLine(request, &command_line).ok());
+  DHEPZ_CHECK(command_line.empty());
+}
+
+DHEPZ_TEST(HostOperations, FolderProbeReturnsOnlyRequestedMetadata) {
+  Rig rig;
+  modules::HostOperationDispatcher dispatcher(rig.window, rig.state.completion_message, {});
+  const std::wstring directory = TempDir();
+  CreateDirectoryW((directory + L"\\Scripts").c_str(), nullptr);
+  HANDLE file = CreateFileW((directory + L"\\Scripts\\Activate.ps1").c_str(), GENERIC_WRITE,
+                            0, nullptr, CREATE_NEW, FILE_ATTRIBUTE_NORMAL, nullptr);
+  DHEPZ_CHECK(file != INVALID_HANDLE_VALUE);
+  CloseHandle(file);
+
+  modules::FolderProbeRequest request;
+  request.directory = directory;
+  request.relative_files = {L"Scripts\\Activate.ps1", L"Scripts\\activate.bat"};
+  modules::HostOperationCompletion observed;
+  std::atomic<bool> delivered{false};
+  modules::AsyncRequestToken token;
+  DHEPZ_CHECK(dispatcher.StartFolderProbe(
+                  request,
+                  [&](const modules::HostOperationCompletion& completion) {
+                    observed = completion;
+                    delivered = true;
+                  },
+                  &token)
+                  .ok());
+  PumpUntil([&] { return delivered.load(); }, 2000);
+  DHEPZ_CHECK(delivered.load());
+  DHEPZ_CHECK(observed.status.ok());
+  DHEPZ_CHECK(observed.kind == modules::HostOperationKind::FolderProbe);
+  DHEPZ_CHECK(observed.folder.directory_exists);
+  DHEPZ_CHECK_EQ(observed.folder.files.size(), static_cast<std::size_t>(2));
+  DHEPZ_CHECK(observed.folder.files[0].present);
+  DHEPZ_CHECK(!observed.folder.files[1].present);
+}
+
+DHEPZ_TEST(HostOperations, StatePatchPublicationIsUiThreadOnly) {
+  Rig rig;
+  std::atomic<int> publications{0};
+  modules::HostOperationDispatcher dispatcher(
+      rig.window, rig.state.completion_message,
+      [&](const json::Value&) {
+        ++publications;
+        return core::Ok();
+      });
+  const json::Value patch = json::Value::Object();
+  DHEPZ_CHECK(dispatcher.PublishStatePatch(patch).ok());
+
+  core::Status background;
+  std::thread other([&] { background = dispatcher.PublishStatePatch(patch); });
+  other.join();
+  DHEPZ_CHECK(!background.ok());
+  DHEPZ_CHECK_EQ(publications.load(), 1);
+}

--- a/tests/modules/terminal/terminal_state_test.cpp
+++ b/tests/modules/terminal/terminal_state_test.cpp
@@ -31,9 +31,17 @@ class FakeHost final : public modules::ModuleHost {
   core::Status StorageRead(std::wstring_view, std::wstring*) override {
     return core::Err(core::ErrorCode::NotFound, L"no blob");
   }
-  core::Status ProcessRun(std::wstring_view, std::wstring*) override {
+  core::Status StartProcess(const modules::ProcessRequest&, modules::HostOperationCallback,
+                            modules::AsyncRequestToken*) override {
     return core::Err(core::ErrorCode::Unsupported, L"not here");
   }
+  core::Status StartFolderProbe(const modules::FolderProbeRequest&,
+                                modules::HostOperationCallback,
+                                modules::AsyncRequestToken*) override {
+    return core::Err(core::ErrorCode::Unsupported, L"not here");
+  }
+  void CancelRequest(modules::AsyncRequestToken) override {}
+  core::Status PublishStatePatch(const json::Value&) override { return core::Ok(); }
   void ReportStatus(const core::Status&) override {}
   void Log(std::wstring_view, std::wstring_view) override {}
   core::Status RequestRoute(std::wstring_view) override { return core::Ok(); }

--- a/tests/platform/worker_test.cpp
+++ b/tests/platform/worker_test.cpp
@@ -251,7 +251,15 @@ DHEPZ_TEST(Worker, SequentialJobsLeaveTheHandleCountFlat) {
         [&](std::shared_ptr<void> cargo) { rig.state.delivered.push_back(std::move(cargo)); });
     PumpUntil([&] { return rig.state.delivered.size() == static_cast<std::size_t>(i + 1); }, 5000);
   }
-  worker.JoinFinished();
+  // Delivery can be pumped a few instructions before the posting thread sets
+  // its final done flag. Settle/reap without making JoinFinished block on a
+  // still-live thread; the bounded check still requires the idle count to be 0.
+  PumpUntil(
+      [&] {
+        worker.JoinFinished();
+        return worker.ThreadCount() == 0;
+      },
+      1000);
 
   DWORD handles_before = 0;
   GetProcessHandleCount(process, &handles_before);
@@ -304,6 +312,25 @@ DHEPZ_TEST(Worker, ShutdownJoinsCleanlyAndDiscardsInFlightCompletions) {
                 [&](std::shared_ptr<void> cargo) { rig.state.delivered.push_back(std::move(cargo)); });
   DHEPZ_CHECK_EQ(worker.ThreadCount(), static_cast<std::size_t>(0));
   PumpUntil([&] { return false; }, 150);
+  DHEPZ_CHECK(rig.state.delivered.empty());
+}
+
+DHEPZ_TEST(Worker, DestroyedOwnerMakesAlreadyQueuedCompletionSafeAndStale) {
+  Rig rig;
+  {
+    worker::Worker worker(rig.hwnd, rig.state.completion_message);
+    const std::uint64_t generation = worker.CreateGeneration();
+    worker.Submit(
+        [](const std::atomic<bool>&) { return MakeInt(9); },
+        [&](std::shared_ptr<void> cargo) { rig.state.delivered.push_back(std::move(cargo)); },
+        generation);
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    worker.JoinFinished();
+    DHEPZ_CHECK_EQ(worker.ThreadCount(), static_cast<std::size_t>(0));
+    // The completion message is intentionally still queued when the owner dies.
+  }
+
+  PumpUntil([&] { return false; }, 100);
   DHEPZ_CHECK(rig.state.delivered.empty());
 }
 


### PR DESCRIPTION
Closes #105.

## What changed
- replaces synchronous `ProcessRun` with typed async process and folder-probe requests
- keeps execution, argv quoting, cancellation, and generation ownership in parent services
- delivers completions and state patches on the UI thread
- extracts the parent-side `GateHost` adapter from `AppGate`; it receives route/peer callbacks and has no concrete AppGate, platform, or Win32 dependency
- guards queued completions against owner teardown

## Focused local verification
- `HostOperations`: 7/7 Debug
- `AppGate`: 5/5 Debug
- `git diff --check`

The GitHub workflow is the sole full regression run for this PR SHA. Phase 5 remains blocked.