### PR TITLE
feat(contract): add typed capability facets (#106)

### DIFF
--- a/docs/adr/0001-module-contract.md
+++ b/docs/adr/0001-module-contract.md
@@ -53,6 +53,23 @@ types, every signature and semantic becomes a contract.
    `ModuleHost::PublishStatePatch` from its UI-thread completion. The parent
    owns the patch sink and presenter routing; calling the seam from another
    thread is an error.
+10. Privileged reach uses two dedicated typed facets. `SettingsAllFacet` is
+    granted only to the module whose id is `settings`; it can read and write
+    global values and every module section and can enumerate inert peer
+    metadata. `ConfigWriteFacet` is granted only to `ui-editor`; it exposes
+    Preview, Save, and Discard rather than a filesystem API. A duplicate claim,
+    a claim by any other module id, or an undeclared facet request is denied by
+    the gate and recorded with module, capability, and source location.
+11. A config Preview resolves the complete candidate before changing the live
+    immutable document. A successful preview issues a monotonically increasing
+    token and reports only changed routes. A newer preview makes older tokens
+    stale. Discard swaps back the exact retained document without I/O. Save is
+    valid only for the active token and queues an atomic write on a parent
+    worker; its completion returns to the UI thread as `ConfigSave`.
+12. Settings and config files are parent-owned. Modules never receive a path or
+    call filesystem APIs. `AppGate` orchestrates grants and document ownership;
+    dedicated parent services implement settings access and config transaction
+    state.
 
 ## Consequences
 
@@ -63,5 +80,8 @@ types, every signature and semantic becomes a contract.
 - Process/folder IO is structurally outside the UI thread, and worker delivery
   state outlives a queued message safely during teardown without retaining a
   worker thread at idle.
+- Capability grants and denials are inspectable gate diagnostics. Config
+  preview remains exact and revertible, while persistence has one atomic,
+  off-UI-thread implementation owned by the parent.
 - Cost: adding a genuinely new service means growing `ModuleHost` for all
   modules — deliberately expensive, so it happens rarely and reviewed.

--- a/src/modules/contract/module_contract.h
+++ b/src/modules/contract/module_contract.h
@@ -51,7 +51,7 @@ struct PeerInfo {
 
 enum class ProcessOperation { Launch, ElevatedLaunch, Capture };
 
-enum class HostOperationKind { Launch, ElevatedLaunch, Capture, FolderProbe };
+enum class HostOperationKind { Launch, ElevatedLaunch, Capture, FolderProbe, ConfigSave };
 
 struct AsyncRequestToken {
   std::uint64_t value = 0;
@@ -101,6 +101,54 @@ struct HostOperationCompletion {
 
 using HostOperationCallback = std::function<void(const HostOperationCompletion& completion)>;
 
+struct ConfigPreviewToken {
+  std::uint64_t value = 0;
+
+  explicit operator bool() const { return value != 0; }
+  friend bool operator==(const ConfigPreviewToken&, const ConfigPreviewToken&) = default;
+};
+
+struct ConfigDiagnostic {
+  std::wstring file;
+  int line = 0;
+  int column = 0;
+  std::wstring message;
+};
+
+struct ConfigPreviewResult {
+  ConfigPreviewToken token;
+  std::vector<std::wstring> affected_routes;
+  std::vector<ConfigDiagnostic> diagnostics;
+};
+
+class SettingsAllFacet {
+ public:
+  virtual ~SettingsAllFacet() = default;
+  virtual core::Status ReadGlobal(std::wstring_view key, std::wstring* out) = 0;
+  virtual core::Status WriteGlobal(std::wstring_view key,
+                                   std::wstring_view value) = 0;
+  virtual core::Status ReadModule(std::wstring_view module_id,
+                                  std::wstring_view key,
+                                  std::wstring* out) = 0;
+  virtual core::Status WriteModule(std::wstring_view module_id,
+                                   std::wstring_view key,
+                                   std::wstring_view value) = 0;
+  virtual std::vector<PeerInfo> Peers() = 0;
+};
+
+class ConfigWriteFacet {
+ public:
+  virtual ~ConfigWriteFacet() = default;
+  virtual core::Status Preview(std::wstring_view candidate,
+                               ConfigPreviewResult* result) = 0;
+  virtual core::Status Save(ConfigPreviewToken preview,
+                            HostOperationCallback callback,
+                            AsyncRequestToken* request) = 0;
+  virtual core::Status Discard(
+      ConfigPreviewToken preview,
+      std::vector<std::wstring>* affected_routes) = 0;
+};
+
 // Parent hands down. Nothing else is reachable from a child.
 class ModuleHost {
  public:
@@ -130,6 +178,10 @@ class ModuleHost {
   // Called only from the UI-thread completion path. The parent owns routing
   // the patch to the presenter; a module never reaches frontend types.
   virtual core::Status PublishStatePatch(const json::Value& patch) = 0;
+  // Capability-specific facets. A host without the matching gate grant sets
+  // the output to null and returns PermissionDenied.
+  virtual core::Status GetSettingsAllFacet(SettingsAllFacet** facet) = 0;
+  virtual core::Status GetConfigWriteFacet(ConfigWriteFacet** facet) = 0;
   // Report success/error; the parent decides how to show it.
   virtual void ReportStatus(const core::Status& status) = 0;
   virtual void Log(std::wstring_view level, std::wstring_view text) = 0;

--- a/src/modules/gate/app_gate.cpp
+++ b/src/modules/gate/app_gate.cpp
@@ -3,7 +3,9 @@
 #include <algorithm>
 
 #include "core/json.h"
+#include "modules/gate/config_transaction_service.h"
 #include "modules/gate/gate_host.h"
+#include "modules/gate/settings_access_service.h"
 #include "modules/registry/module_registry.h"
 #include "ui/config/config_store.h"
 
@@ -21,7 +23,11 @@ const std::vector<RejectEntry>& CurrentRejects() {
   return g_rejects != nullptr ? *g_rejects : empty;
 }
 
-AppGate::AppGate() = default;
+AppGate::AppGate()
+    : settings_service_(
+          std::make_unique<SettingsAccessService>([this]() { return Peers(); })),
+      config_service_(std::make_unique<ConfigTransactionService>(
+          &document_, &document_generation_)) {}
 AppGate::~AppGate() = default;
 
 core::Status AppGate::Start(std::wstring_view override_path) {
@@ -53,8 +59,22 @@ core::Status AppGate::ConfigureHostOperations(void* ui_window,
   return core::Ok();
 }
 
+core::Status AppGate::ConfigureConfigOverridePath(std::wstring path) {
+  if (!mounted_.empty()) {
+    return core::Err(core::ErrorCode::AlreadyExists,
+                     L"Config path must be configured before gate start");
+  }
+  return config_service_->ConfigureOverridePath(std::move(path));
+}
+
 core::Status AppGate::PairAndMount(std::wstring_view embedded_text,
                                    std::wstring_view override_text) {
+  document_.reset();
+  mounted_.clear();
+  rejects_.clear();
+  grants_.clear();
+  action_map_.clear();
+  current_route_.clear();
   json::Value embedded;
   DHEPZ_RETURN_IF_ERROR(json::Parse(embedded_text, &embedded));
   const json::Value* core = embedded.Find(L"core");
@@ -74,10 +94,13 @@ core::Status AppGate::PairAndMount(std::wstring_view embedded_text,
   }
   std::vector<ui::config::Diagnostic> ui_diags;
   DHEPZ_RETURN_IF_ERROR(ui::config::ResolveDocument(*core, sources, &ui_diags, &document_));
+  ++document_generation_;
+  config_service_->ConfigureBase(*core, sources.front());
 
   const std::vector<RegisteredModule> registered = RegistrySnapshot();
   const json::Value* manifests = embedded.Find(L"modules");
-  int settings_all_claimants = 0;
+  bool settings_all_claimed = false;
+  bool config_write_claimed = false;
 
   if (manifests != nullptr && manifests->is_array()) {
     for (const json::Value& manifest_value : manifests->items()) {
@@ -142,21 +165,66 @@ core::Status AppGate::PairAndMount(std::wstring_view embedded_text,
         }
       }
       bool capability_ok = true;
+      bool settings_all_granted = false;
+      bool config_write_granted = false;
+      const json::Value* capabilities_value = manifest_value.Find(L"capabilities");
+      const int capability_line = capabilities_value != nullptr
+                                      ? capabilities_value->line()
+                                      : 1;
+      const int capability_column = capabilities_value != nullptr
+                                        ? capabilities_value->column()
+                                        : 1;
       for (const std::wstring& cap : declared) {
         if (cap == std::wstring(kCapabilitySettingsAll)) {
-          if (++settings_all_claimants > 1) {
-            rejects_.push_back({manifest.module_id,
-                                L"settings:all already claimed by another module"});
+          if (manifest.module_id != L"settings") {
+            rejects_.push_back(
+                {manifest.module_id,
+                 L"settings:all is reserved for module 'settings'",
+                 L"embedded", capability_line, capability_column});
             capability_ok = false;
             break;
           }
-        } else if (cap != std::wstring(kCapabilityConfigWrite)) {
-          rejects_.push_back({manifest.module_id, L"unknown capability '" + cap + L"'"});
+          if (settings_all_claimed) {
+            rejects_.push_back(
+                {manifest.module_id,
+                 L"settings:all already claimed by another module",
+                 L"embedded", capability_line, capability_column});
+            capability_ok = false;
+            break;
+          }
+          settings_all_granted = true;
+        } else if (cap == std::wstring(kCapabilityConfigWrite)) {
+          if (manifest.module_id != L"ui-editor") {
+            rejects_.push_back(
+                {manifest.module_id,
+                 L"config:write is reserved for module 'ui-editor'",
+                 L"embedded", capability_line, capability_column});
+            capability_ok = false;
+            break;
+          }
+          if (config_write_claimed) {
+            rejects_.push_back(
+                {manifest.module_id,
+                 L"config:write already claimed by another module",
+                 L"embedded", capability_line, capability_column});
+            capability_ok = false;
+            break;
+          }
+          config_write_granted = true;
+        } else {
+          rejects_.push_back({manifest.module_id,
+                              L"unknown capability '" + cap + L"'",
+                              L"embedded", capability_line,
+                              capability_column});
           capability_ok = false;
           break;
         }
       }
       if (!capability_ok) continue;
+      for (const std::wstring& capability : declared) {
+        grants_.push_back({manifest.module_id, capability, L"embedded",
+                           capability_line, capability_column});
+      }
 
       if (!manifest.settings_route.empty()) {
         bool ships = false;
@@ -190,6 +258,8 @@ core::Status AppGate::PairAndMount(std::wstring_view embedded_text,
         if (!actions_ok) break;
       }
       if (!actions_ok) continue;
+      if (settings_all_granted) settings_all_claimed = true;
+      if (config_write_granted) config_write_claimed = true;
       for (const std::wstring& action : descriptor->DeclaredActions()) {
         action_map_.emplace_back(action, module.manifest.module_id);
       }
@@ -197,7 +267,9 @@ core::Status AppGate::PairAndMount(std::wstring_view embedded_text,
       module.host = std::make_unique<GateHost>(
           module.manifest.module_id,
           [this](std::wstring_view route_id) { return RequestRoute(route_id); },
-          [this]() { return Peers(); }, operation_window_, operation_message_,
+          [this]() { return Peers(); }, settings_service_.get(),
+          config_service_.get(), settings_all_granted, config_write_granted,
+          operation_window_, operation_message_,
           state_patch_handler_);
       mounted_.push_back(std::move(module));
     }

--- a/src/modules/gate/app_gate.h
+++ b/src/modules/gate/app_gate.h
@@ -10,6 +10,7 @@
 // never depend on any module loading.
 #pragma once
 
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <vector>
@@ -24,11 +25,25 @@ namespace modules {
 struct RejectEntry {
   std::wstring module_id;
   std::wstring reason;
+  std::wstring file;
+  int line = 0;
+  int column = 0;
+};
+
+struct CapabilityGrant {
+  std::wstring module_id;
+  std::wstring capability;
+  std::wstring file;
+  int line = 0;
+  int column = 0;
 };
 
 // Reject list of the most recent gate Start — the diagnostics module reads
 // this; there is exactly one gate (single choke point).
 const std::vector<RejectEntry>& CurrentRejects();
+
+class ConfigTransactionService;
+class SettingsAccessService;
 
 class AppGate final {
  public:
@@ -47,10 +62,13 @@ class AppGate final {
   // completion message to worker::Worker::Settle.
   core::Status ConfigureHostOperations(void* ui_window, unsigned int completion_message,
                                        HostStatePatchHandler state_patch_handler);
+  core::Status ConfigureConfigOverridePath(std::wstring path);
 
   const ui::config::ResolvedUiDocument* document() const { return document_.get(); }
+  std::uint64_t document_generation() const { return document_generation_; }
   std::vector<PeerInfo> Peers() const;
   const std::vector<RejectEntry>& Rejects() const { return rejects_; }
+  const std::vector<CapabilityGrant>& Grants() const { return grants_; }
   bool Mounted(std::wstring_view module_id) const;
 
   // Lazy activation: builds the descriptor and Bind()s it on first visit.
@@ -75,8 +93,12 @@ class AppGate final {
   MountedModule* FindByModule(std::wstring_view module_id);
 
   std::unique_ptr<ui::config::ResolvedUiDocument> document_;
+  std::uint64_t document_generation_ = 0;
+  std::unique_ptr<SettingsAccessService> settings_service_;
+  std::unique_ptr<ConfigTransactionService> config_service_;
   std::vector<MountedModule> mounted_;
   std::vector<RejectEntry> rejects_;
+  std::vector<CapabilityGrant> grants_;
   std::vector<std::pair<std::wstring, std::wstring>> action_map_;  // action -> moduleId
   std::wstring current_route_;
   void* operation_window_ = nullptr;

--- a/src/modules/gate/config_transaction_service.cpp
+++ b/src/modules/gate/config_transaction_service.cpp
@@ -1,0 +1,199 @@
+#include "modules/gate/config_transaction_service.h"
+
+#include <algorithm>
+#include <set>
+#include <utility>
+
+#include "ui/config/config_store.h"
+
+namespace modules {
+namespace {
+
+bool SameNode(const ui::config::ComponentNode& left,
+              const ui::config::ComponentNode& right) {
+  if (left.type_ != right.type_ || left.id_ != right.id_ ||
+      left.properties_.size() != right.properties_.size() ||
+      left.children_.size() != right.children_.size()) {
+    return false;
+  }
+  for (std::size_t i = 0; i < left.properties_.size(); ++i) {
+    if (left.properties_[i].first != right.properties_[i].first ||
+        json::Serialize(left.properties_[i].second) !=
+            json::Serialize(right.properties_[i].second)) {
+      return false;
+    }
+  }
+  for (std::size_t i = 0; i < left.children_.size(); ++i) {
+    if (!SameNode(left.children_[i], right.children_[i])) return false;
+  }
+  return true;
+}
+
+bool SameRoute(const ui::config::Route& left,
+               const ui::config::Route& right) {
+  return left.id == right.id && left.tab_label == right.tab_label &&
+         left.show_in_tabs == right.show_in_tabs &&
+         left.backdrop_kind == right.backdrop_kind &&
+         left.backdrop_value == right.backdrop_value &&
+         SameNode(left.root, right.root);
+}
+
+std::vector<std::wstring> ChangedRoutes(
+    const ui::config::ResolvedUiDocument& before,
+    const ui::config::ResolvedUiDocument& after) {
+  std::set<std::wstring> ids;
+  for (const ui::config::Route& route : before.routes()) ids.insert(route.id);
+  for (const ui::config::Route& route : after.routes()) ids.insert(route.id);
+  std::vector<std::wstring> changed;
+  for (const std::wstring& id : ids) {
+    const ui::config::Route* old_route = before.FindRoute(id);
+    const ui::config::Route* new_route = after.FindRoute(id);
+    if (old_route == nullptr || new_route == nullptr ||
+        !SameRoute(*old_route, *new_route)) {
+      changed.push_back(id);
+    }
+  }
+  return changed;
+}
+
+}  // namespace
+
+ConfigTransactionService::ConfigTransactionService(
+    std::unique_ptr<ui::config::ResolvedUiDocument>* live_document,
+    std::uint64_t* document_generation)
+    : live_document_(live_document),
+      document_generation_(document_generation) {}
+
+void ConfigTransactionService::ConfigureBase(
+    json::Value core_catalog, ui::config::ScreenSource embedded_source) {
+  core_catalog_ = std::move(core_catalog);
+  embedded_source_ = std::move(embedded_source);
+  previous_document_.reset();
+  candidate_.clear();
+  active_preview_ = {};
+  save_pending_ = false;
+}
+
+core::Status ConfigTransactionService::ConfigureOverridePath(std::wstring path) {
+  if (active_preview_ || save_pending_) {
+    return core::Err(core::ErrorCode::AlreadyExists,
+                     L"config transaction is active");
+  }
+  override_path_ = std::move(path);
+  return core::Ok();
+}
+
+core::Status ConfigTransactionService::Preview(std::wstring_view candidate,
+                                               ConfigPreviewResult* result) {
+  if (result == nullptr) {
+    return core::Err(core::ErrorCode::InvalidArgument,
+                     L"preview result is required");
+  }
+  *result = {};
+  if (live_document_ == nullptr || !*live_document_) {
+    return core::Err(core::ErrorCode::InvalidArgument,
+                     L"gate has no resolved document");
+  }
+  if (save_pending_) {
+    return core::Err(core::ErrorCode::AlreadyExists,
+                     L"config save is pending");
+  }
+
+  const std::wstring source_name =
+      override_path_.empty() ? L"config preview" : override_path_;
+  std::vector<ui::config::Diagnostic> diagnostics;
+  std::unique_ptr<ui::config::ResolvedUiDocument> next;
+  const core::Status resolved = ui::config::ResolveDocument(
+      core_catalog_,
+      {embedded_source_, {source_name, std::wstring(candidate)}},
+      &diagnostics, &next);
+  if (!resolved.ok()) {
+    for (const ui::config::Diagnostic& diagnostic : diagnostics) {
+      result->diagnostics.push_back(
+          {source_name, diagnostic.line, diagnostic.column,
+           diagnostic.message});
+    }
+    return resolved;
+  }
+
+  result->affected_routes = ChangedRoutes(**live_document_, *next);
+  if (!previous_document_) {
+    previous_document_ = std::move(*live_document_);
+  }
+  *live_document_ = std::move(next);
+  candidate_ = std::wstring(candidate);
+  active_preview_.value = next_preview_token_++;
+  result->token = active_preview_;
+  ++*document_generation_;
+  return core::Ok();
+}
+
+core::Status ConfigTransactionService::BeginSave(ConfigPreviewToken preview,
+                                                  std::wstring* path,
+                                                  std::wstring* text) {
+  if (path == nullptr || text == nullptr) {
+    return core::Err(core::ErrorCode::InvalidArgument,
+                     L"save outputs are required");
+  }
+  if (!active_preview_ || preview != active_preview_ || !previous_document_) {
+    return core::Err(core::ErrorCode::InvalidArgument,
+                     L"stale config preview token");
+  }
+  if (save_pending_) {
+    return core::Err(core::ErrorCode::AlreadyExists,
+                     L"config save is pending");
+  }
+  if (override_path_.empty()) {
+    return core::Err(core::ErrorCode::InvalidArgument,
+                     L"config override path is not configured");
+  }
+  save_pending_ = true;
+  *path = override_path_;
+  *text = candidate_;
+  return core::Ok();
+}
+
+void ConfigTransactionService::CompleteSave(ConfigPreviewToken preview,
+                                            const core::Status& status) {
+  if (preview != active_preview_) return;
+  save_pending_ = false;
+  if (!status.ok()) return;
+  previous_document_.reset();
+  candidate_.clear();
+  active_preview_ = {};
+}
+
+core::Status ConfigTransactionService::AbortSave(ConfigPreviewToken preview) {
+  if (preview != active_preview_) {
+    return core::Err(core::ErrorCode::InvalidArgument,
+                     L"stale config preview token");
+  }
+  save_pending_ = false;
+  return core::Ok();
+}
+
+core::Status ConfigTransactionService::Discard(
+    ConfigPreviewToken preview,
+    std::vector<std::wstring>* affected_routes) {
+  if (affected_routes == nullptr) {
+    return core::Err(core::ErrorCode::InvalidArgument,
+                     L"affected-routes output is required");
+  }
+  affected_routes->clear();
+  if (!active_preview_ || preview != active_preview_ || !previous_document_) {
+    return core::Err(core::ErrorCode::InvalidArgument,
+                     L"stale config preview token");
+  }
+  if (save_pending_) {
+    return core::Err(core::ErrorCode::AlreadyExists,
+                     L"config save is pending");
+  }
+  *affected_routes = ChangedRoutes(**live_document_, *previous_document_);
+  *live_document_ = std::move(previous_document_);
+  candidate_.clear();
+  active_preview_ = {};
+  ++*document_generation_;
+  return core::Ok();
+}
+
+}  // namespace modules

--- a/src/modules/gate/config_transaction_service.h
+++ b/src/modules/gate/config_transaction_service.h
@@ -1,0 +1,48 @@
+// Parent-owned preview/save/discard transaction for config:write. AppGate owns
+// this service but does not implement its validation or revision state.
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "core/json.h"
+#include "modules/contract/module_contract.h"
+#include "ui/config/resolved_ui_document.h"
+
+namespace modules {
+
+class ConfigTransactionService final {
+ public:
+  ConfigTransactionService(
+      std::unique_ptr<ui::config::ResolvedUiDocument>* live_document,
+      std::uint64_t* document_generation);
+
+  void ConfigureBase(json::Value core_catalog,
+                     ui::config::ScreenSource embedded_source);
+  core::Status ConfigureOverridePath(std::wstring path);
+  core::Status Preview(std::wstring_view candidate,
+                       ConfigPreviewResult* result);
+  core::Status BeginSave(ConfigPreviewToken preview, std::wstring* path,
+                         std::wstring* text);
+  void CompleteSave(ConfigPreviewToken preview, const core::Status& status);
+  core::Status AbortSave(ConfigPreviewToken preview);
+  core::Status Discard(ConfigPreviewToken preview,
+                       std::vector<std::wstring>* affected_routes);
+
+ private:
+  std::unique_ptr<ui::config::ResolvedUiDocument>* live_document_;
+  std::uint64_t* document_generation_;
+  json::Value core_catalog_;
+  ui::config::ScreenSource embedded_source_;
+  std::unique_ptr<ui::config::ResolvedUiDocument> previous_document_;
+  std::wstring candidate_;
+  ConfigPreviewToken active_preview_;
+  std::uint64_t next_preview_token_ = 1;
+  bool save_pending_ = false;
+  std::wstring override_path_;
+};
+
+}  // namespace modules

--- a/src/modules/gate/gate_host.cpp
+++ b/src/modules/gate/gate_host.cpp
@@ -2,18 +2,28 @@
 
 #include <utility>
 
+#include "modules/gate/config_transaction_service.h"
 #include "modules/gate/host_operation_dispatcher.h"
+#include "modules/gate/settings_access_service.h"
 
 namespace modules {
 
 GateHost::GateHost(std::wstring module_id,
                    HostRouteRequestHandler route_request_handler,
-                   HostPeersHandler peers_handler, void* operation_window,
+                   HostPeersHandler peers_handler,
+                   SettingsAccessService* settings_service,
+                   ConfigTransactionService* config_service,
+                   bool settings_all_granted, bool config_write_granted,
+                   void* operation_window,
                    unsigned int operation_message,
                    HostStatePatchHandler state_patch_handler)
     : module_id_(std::move(module_id)),
       route_request_handler_(std::move(route_request_handler)),
-      peers_handler_(std::move(peers_handler)) {
+      peers_handler_(std::move(peers_handler)),
+      settings_service_(settings_service),
+      config_service_(config_service),
+      settings_all_granted_(settings_all_granted),
+      config_write_granted_(config_write_granted) {
   if (operation_window == nullptr || operation_message == 0) return;
 
   StatePatchSink sink;
@@ -30,32 +40,17 @@ GateHost::~GateHost() = default;
 ModuleSurface GateHost::Surface() { return surface_; }
 
 core::Status GateHost::SettingsRead(std::wstring_view key, std::wstring* out) {
-  std::lock_guard lock(mutex_);
-  const auto& section = settings_[module_id_];
-  const auto it = section.find(std::wstring(key));
-  if (it == section.end()) {
-    return core::Err(core::ErrorCode::NotFound, L"no such key");
-  }
-  *out = it->second;
-  return core::Ok();
+  return settings_service_->ReadModule(module_id_, key, out);
 }
 
 core::Status GateHost::SettingsReadGlobal(std::wstring_view key,
                                           std::wstring* out) {
-  std::lock_guard lock(mutex_);
-  const auto it = global_.find(std::wstring(key));
-  if (it == global_.end()) {
-    return core::Err(core::ErrorCode::NotFound, L"no such key");
-  }
-  *out = it->second;
-  return core::Ok();
+  return settings_service_->ReadGlobal(key, out);
 }
 
 core::Status GateHost::SettingsWrite(std::wstring_view key,
                                      std::wstring_view value) {
-  std::lock_guard lock(mutex_);
-  settings_[module_id_][std::wstring(key)] = std::wstring(value);
-  return core::Ok();
+  return settings_service_->WriteModule(module_id_, key, value);
 }
 
 core::Status GateHost::StorageWrite(std::wstring_view name,
@@ -105,6 +100,87 @@ core::Status GateHost::PublishStatePatch(const json::Value& patch) {
                      L"state patch sink is not configured");
   }
   return operations_->PublishStatePatch(patch);
+}
+
+core::Status GateHost::GetSettingsAllFacet(SettingsAllFacet** facet) {
+  if (facet == nullptr) {
+    return core::Err(core::ErrorCode::InvalidArgument,
+                     L"facet output is required");
+  }
+  *facet = settings_all_granted_ ? this : nullptr;
+  return *facet != nullptr
+             ? core::Ok()
+             : core::Err(core::ErrorCode::PermissionDenied,
+                         L"settings:all is not granted");
+}
+
+core::Status GateHost::GetConfigWriteFacet(ConfigWriteFacet** facet) {
+  if (facet == nullptr) {
+    return core::Err(core::ErrorCode::InvalidArgument,
+                     L"facet output is required");
+  }
+  *facet = config_write_granted_ ? this : nullptr;
+  return *facet != nullptr
+             ? core::Ok()
+             : core::Err(core::ErrorCode::PermissionDenied,
+                         L"config:write is not granted");
+}
+
+core::Status GateHost::ReadGlobal(std::wstring_view key, std::wstring* out) {
+  return settings_service_->ReadGlobal(key, out);
+}
+
+core::Status GateHost::WriteGlobal(std::wstring_view key,
+                                   std::wstring_view value) {
+  return settings_service_->WriteGlobal(key, value);
+}
+
+core::Status GateHost::ReadModule(std::wstring_view module_id,
+                                  std::wstring_view key,
+                                  std::wstring* out) {
+  return settings_service_->ReadModule(module_id, key, out);
+}
+
+core::Status GateHost::WriteModule(std::wstring_view module_id,
+                                   std::wstring_view key,
+                                   std::wstring_view value) {
+  return settings_service_->WriteModule(module_id, key, value);
+}
+
+core::Status GateHost::Preview(std::wstring_view candidate,
+                               ConfigPreviewResult* result) {
+  return config_service_->Preview(candidate, result);
+}
+
+core::Status GateHost::Save(ConfigPreviewToken preview,
+                            HostOperationCallback callback,
+                            AsyncRequestToken* request) {
+  if (!operations_) {
+    return core::Err(core::ErrorCode::Unsupported,
+                     L"async config save host is not configured");
+  }
+  std::wstring path;
+  std::wstring text;
+  DHEPZ_RETURN_IF_ERROR(config_service_->BeginSave(preview, &path, &text));
+  const core::Status started = operations_->StartAtomicWrite(
+      std::move(path), std::move(text),
+      [service = config_service_, preview, callback = std::move(callback)](
+          const HostOperationCompletion& completion) {
+        service->CompleteSave(preview, completion.status);
+        callback(completion);
+      },
+      request);
+  if (!started.ok()) {
+    const core::Status aborted = config_service_->AbortSave(preview);
+    (void)aborted;
+  }
+  return started;
+}
+
+core::Status GateHost::Discard(
+    ConfigPreviewToken preview,
+    std::vector<std::wstring>* affected_routes) {
+  return config_service_->Discard(preview, affected_routes);
 }
 
 void GateHost::ReportStatus(const core::Status& status) { last_status_ = status; }

--- a/src/modules/gate/gate_host.h
+++ b/src/modules/gate/gate_host.h
@@ -15,6 +15,8 @@
 namespace modules {
 
 class HostOperationDispatcher;
+class ConfigTransactionService;
+class SettingsAccessService;
 
 using HostStatePatchHandler =
     std::function<core::Status(std::wstring_view module_id,
@@ -23,11 +25,17 @@ using HostRouteRequestHandler =
     std::function<core::Status(std::wstring_view route_id)>;
 using HostPeersHandler = std::function<std::vector<PeerInfo>()>;
 
-class GateHost final : public ModuleHost {
+class GateHost final : public ModuleHost,
+                       public SettingsAllFacet,
+                       public ConfigWriteFacet {
  public:
   GateHost(std::wstring module_id,
            HostRouteRequestHandler route_request_handler,
-           HostPeersHandler peers_handler, void* operation_window,
+           HostPeersHandler peers_handler,
+           SettingsAccessService* settings_service,
+           ConfigTransactionService* config_service,
+           bool settings_all_granted, bool config_write_granted,
+           void* operation_window,
            unsigned int operation_message,
            HostStatePatchHandler state_patch_handler);
   ~GateHost() override;
@@ -46,6 +54,25 @@ class GateHost final : public ModuleHost {
                                 AsyncRequestToken* token) override;
   void CancelRequest(AsyncRequestToken token) override;
   core::Status PublishStatePatch(const json::Value& patch) override;
+  core::Status GetSettingsAllFacet(SettingsAllFacet** facet) override;
+  core::Status GetConfigWriteFacet(ConfigWriteFacet** facet) override;
+  core::Status ReadGlobal(std::wstring_view key, std::wstring* out) override;
+  core::Status WriteGlobal(std::wstring_view key,
+                           std::wstring_view value) override;
+  core::Status ReadModule(std::wstring_view module_id,
+                          std::wstring_view key,
+                          std::wstring* out) override;
+  core::Status WriteModule(std::wstring_view module_id,
+                           std::wstring_view key,
+                           std::wstring_view value) override;
+  core::Status Preview(std::wstring_view candidate,
+                       ConfigPreviewResult* result) override;
+  core::Status Save(ConfigPreviewToken preview,
+                    HostOperationCallback callback,
+                    AsyncRequestToken* request) override;
+  core::Status Discard(
+      ConfigPreviewToken preview,
+      std::vector<std::wstring>* affected_routes) override;
   void ReportStatus(const core::Status& status) override;
   void Log(std::wstring_view level, std::wstring_view text) override;
   core::Status RequestRoute(std::wstring_view route_id) override;
@@ -55,10 +82,12 @@ class GateHost final : public ModuleHost {
   std::wstring module_id_;
   HostRouteRequestHandler route_request_handler_;
   HostPeersHandler peers_handler_;
+  SettingsAccessService* settings_service_;
+  ConfigTransactionService* config_service_;
+  bool settings_all_granted_ = false;
+  bool config_write_granted_ = false;
   ModuleSurface surface_;
   std::mutex mutex_;
-  std::map<std::wstring, std::map<std::wstring, std::wstring>> settings_;
-  std::map<std::wstring, std::wstring> global_;
   std::map<std::wstring, std::wstring> storage_;
   std::vector<std::wstring> log_;
   core::Status last_status_;

--- a/src/modules/gate/host_operation_dispatcher.cpp
+++ b/src/modules/gate/host_operation_dispatcher.cpp
@@ -7,6 +7,7 @@
 #include <utility>
 #include <vector>
 
+#include "platform/files.h"
 #include "platform/paths.h"
 #include "platform/process.h"
 #include "platform/strings.h"
@@ -264,6 +265,61 @@ core::Status HostOperationDispatcher::StartFolderProbe(const FolderProbeRequest&
     if (impl_->invalidated) {
       impl_->worker.Cancel(handle);
       return DHEPZ_ERR(core::ErrorCode::Cancelled, L"Module host generation is invalid");
+    }
+    impl_->requests.emplace(issued.value, std::move(handle));
+  }
+  *token = issued;
+  return core::Ok();
+}
+
+core::Status HostOperationDispatcher::StartAtomicWrite(
+    std::wstring path, std::wstring text, HostOperationCallback callback,
+    AsyncRequestToken* token) {
+  DHEPZ_RETURN_IF_ERROR(ValidateStart(callback, token));
+  if (path.empty()) {
+    return DHEPZ_ERR(core::ErrorCode::InvalidArgument,
+                     L"An atomic-write target is required");
+  }
+
+  AsyncRequestToken issued;
+  {
+    std::lock_guard lock(impl_->mutex);
+    if (impl_->invalidated) {
+      return DHEPZ_ERR(core::ErrorCode::Cancelled,
+                       L"Module host generation is invalid");
+    }
+    issued.value = impl_->next_token++;
+  }
+  const std::uint64_t generation = impl_->generation;
+  worker::JobHandle handle = impl_->worker.Submit(
+      [path = std::move(path), text = std::move(text), issued,
+       generation](const std::atomic<bool>& cancelled) {
+        auto completion = std::make_shared<HostOperationCompletion>();
+        completion->token = issued;
+        completion->generation = generation;
+        completion->kind = HostOperationKind::ConfigSave;
+        if (!cancelled.load()) {
+          completion->status = files::WriteTextAtomic(path, text);
+        }
+        return std::static_pointer_cast<void>(completion);
+      },
+      [this, callback = std::move(callback), issued](
+          std::shared_ptr<void> cargo) {
+        {
+          std::lock_guard lock(impl_->mutex);
+          impl_->requests.erase(issued.value);
+        }
+        callback(*std::static_pointer_cast<HostOperationCompletion>(
+            std::move(cargo)));
+      },
+      generation);
+
+  {
+    std::lock_guard lock(impl_->mutex);
+    if (impl_->invalidated) {
+      impl_->worker.Cancel(handle);
+      return DHEPZ_ERR(core::ErrorCode::Cancelled,
+                       L"Module host generation is invalid");
     }
     impl_->requests.emplace(issued.value, std::move(handle));
   }

--- a/src/modules/gate/host_operation_dispatcher.h
+++ b/src/modules/gate/host_operation_dispatcher.h
@@ -31,6 +31,11 @@ class HostOperationDispatcher final {
                             AsyncRequestToken* token);
   core::Status StartFolderProbe(const FolderProbeRequest& request,
                                 HostOperationCallback callback, AsyncRequestToken* token);
+  // Parent-internal service used by config:write. Modules cannot choose the
+  // destination; the transaction service supplies its configured path.
+  core::Status StartAtomicWrite(std::wstring path, std::wstring text,
+                                HostOperationCallback callback,
+                                AsyncRequestToken* token);
   void CancelRequest(AsyncRequestToken token);
 
   // Permanently invalidates this module-host lifetime. Running jobs may finish

--- a/src/modules/gate/settings_access_service.cpp
+++ b/src/modules/gate/settings_access_service.cpp
@@ -1,0 +1,62 @@
+#include "modules/gate/settings_access_service.h"
+
+namespace modules {
+
+SettingsAccessService::SettingsAccessService(PeersProvider peers_provider)
+    : peers_provider_(std::move(peers_provider)) {}
+
+core::Status SettingsAccessService::ReadGlobal(std::wstring_view key,
+                                               std::wstring* out) {
+  if (out == nullptr) {
+    return core::Err(core::ErrorCode::InvalidArgument,
+                     L"settings output is required");
+  }
+  std::lock_guard lock(mutex_);
+  const auto it = global_.find(std::wstring(key));
+  if (it == global_.end()) {
+    return core::Err(core::ErrorCode::NotFound, L"no such key");
+  }
+  *out = it->second;
+  return core::Ok();
+}
+
+core::Status SettingsAccessService::WriteGlobal(std::wstring_view key,
+                                                std::wstring_view value) {
+  std::lock_guard lock(mutex_);
+  global_[std::wstring(key)] = std::wstring(value);
+  return core::Ok();
+}
+
+core::Status SettingsAccessService::ReadModule(std::wstring_view module_id,
+                                               std::wstring_view key,
+                                               std::wstring* out) {
+  if (out == nullptr) {
+    return core::Err(core::ErrorCode::InvalidArgument,
+                     L"settings output is required");
+  }
+  std::lock_guard lock(mutex_);
+  const auto section = modules_.find(std::wstring(module_id));
+  if (section == modules_.end()) {
+    return core::Err(core::ErrorCode::NotFound, L"no such module settings");
+  }
+  const auto value = section->second.find(std::wstring(key));
+  if (value == section->second.end()) {
+    return core::Err(core::ErrorCode::NotFound, L"no such key");
+  }
+  *out = value->second;
+  return core::Ok();
+}
+
+core::Status SettingsAccessService::WriteModule(std::wstring_view module_id,
+                                                std::wstring_view key,
+                                                std::wstring_view value) {
+  std::lock_guard lock(mutex_);
+  modules_[std::wstring(module_id)][std::wstring(key)] = std::wstring(value);
+  return core::Ok();
+}
+
+std::vector<PeerInfo> SettingsAccessService::Peers() const {
+  return peers_provider_ ? peers_provider_() : std::vector<PeerInfo>{};
+}
+
+}  // namespace modules

--- a/src/modules/gate/settings_access_service.h
+++ b/src/modules/gate/settings_access_service.h
@@ -1,0 +1,37 @@
+// Parent-owned settings view used by ModuleHost capability facets. Physical
+// persistence replaces this in IC-03 without widening the child contract.
+#pragma once
+
+#include <functional>
+#include <map>
+#include <mutex>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "modules/contract/module_contract.h"
+
+namespace modules {
+
+class SettingsAccessService final {
+ public:
+  using PeersProvider = std::function<std::vector<PeerInfo>()>;
+
+  explicit SettingsAccessService(PeersProvider peers_provider);
+
+  core::Status ReadGlobal(std::wstring_view key, std::wstring* out);
+  core::Status WriteGlobal(std::wstring_view key, std::wstring_view value);
+  core::Status ReadModule(std::wstring_view module_id, std::wstring_view key,
+                          std::wstring* out);
+  core::Status WriteModule(std::wstring_view module_id, std::wstring_view key,
+                           std::wstring_view value);
+  std::vector<PeerInfo> Peers() const;
+
+ private:
+  PeersProvider peers_provider_;
+  mutable std::mutex mutex_;
+  std::map<std::wstring, std::map<std::wstring, std::wstring>> modules_;
+  std::map<std::wstring, std::wstring> global_;
+};
+
+}  // namespace modules

--- a/tests/modules/contract/module_contract_test.cpp
+++ b/tests/modules/contract/module_contract_test.cpp
@@ -65,6 +65,14 @@ struct TestHost final : modules::ModuleHost {
     published_patch = patch;
     return core::Ok();
   }
+  core::Status GetSettingsAllFacet(modules::SettingsAllFacet** facet) override {
+    *facet = nullptr;
+    return core::Err(core::ErrorCode::PermissionDenied, L"not granted");
+  }
+  core::Status GetConfigWriteFacet(modules::ConfigWriteFacet** facet) override {
+    *facet = nullptr;
+    return core::Err(core::ErrorCode::PermissionDenied, L"not granted");
+  }
   void ReportStatus(const core::Status& s) override { reported = !s.ok(); }
   void Log(std::wstring_view, std::wstring_view) override {}
   core::Status RequestRoute(std::wstring_view route) override {
@@ -125,6 +133,24 @@ DHEPZ_TEST(ModuleManifest, ValidManifestParses) {
   DHEPZ_CHECK(manifest.show_in_tabs);
   DHEPZ_CHECK_EQ(manifest.settings_route, std::wstring(L"terminal-settings"));
   DHEPZ_CHECK_EQ(manifest.actions.size(), static_cast<std::size_t>(2));
+}
+
+DHEPZ_TEST(ModuleContract, PrivilegedCapabilitiesUseDedicatedTypedFacets) {
+  TestHost host;
+  modules::SettingsAllFacet* settings = reinterpret_cast<modules::SettingsAllFacet*>(1);
+  const core::Status settings_status = host.GetSettingsAllFacet(&settings);
+  DHEPZ_CHECK(!settings_status.ok());
+  DHEPZ_CHECK(settings == nullptr);
+
+  modules::ConfigWriteFacet* config = reinterpret_cast<modules::ConfigWriteFacet*>(1);
+  const core::Status config_status = host.GetConfigWriteFacet(&config);
+  DHEPZ_CHECK(!config_status.ok());
+  DHEPZ_CHECK(config == nullptr);
+
+  modules::ConfigPreviewResult preview;
+  DHEPZ_CHECK(!preview.token);
+  DHEPZ_CHECK(preview.affected_routes.empty());
+  DHEPZ_CHECK(preview.diagnostics.empty());
 }
 
 DHEPZ_TEST(ModuleContract, AsyncOperationsAreTypedAndTokened) {

--- a/tests/modules/gate/app_gate_test.cpp
+++ b/tests/modules/gate/app_gate_test.cpp
@@ -56,12 +56,7 @@ struct Mismatch {
   static std::vector<std::wstring> Caps() { return {L"config:write"}; }
 };
 struct ClaimA {
-  static std::wstring_view Id() { return L"claim-a"; }
-  static std::vector<std::wstring> Actions() { return {}; }
-  static std::vector<std::wstring> Caps() { return {L"settings:all"}; }
-};
-struct ClaimB {
-  static std::wstring_view Id() { return L"claim-b"; }
+  static std::wstring_view Id() { return L"settings"; }
   static std::vector<std::wstring> Actions() { return {}; }
   static std::vector<std::wstring> Caps() { return {L"settings:all"}; }
 };
@@ -78,10 +73,6 @@ std::unique_ptr<modules::ModuleDescriptor> MakeMismatch() {
 std::unique_ptr<modules::ModuleDescriptor> MakeClaimA() {
   return std::make_unique<SimpleModule<ClaimA>>();
 }
-std::unique_ptr<modules::ModuleDescriptor> MakeClaimB() {
-  return std::make_unique<SimpleModule<ClaimB>>();
-}
-
 const char* kCore = R"({
   "schema": "dhepz.ui.core",
   "version": 1,
@@ -185,21 +176,19 @@ DHEPZ_TEST(AppGate, CapabilityMismatchBetweenCodeAndManifestRejected) {
 
 DHEPZ_TEST(AppGate, SettingsAllIsSingleClaimant) {
   modules::ResetRegistryForTests();
-  modules::RegisterModule(L"claim-a", &MakeClaimA);
-  modules::RegisterModule(L"claim-b", &MakeClaimB);
+  modules::RegisterModule(L"settings", &MakeClaimA);
   modules::AppGate gate;
   const std::wstring screens =
-      L"{ \"type\": \"screen\", \"route_id\": \"a-home\", \"module_id\": \"claim-a\","
-        L" \"children\": [ { \"type\": \"text\", \"text\": \"a\" } ] },"
-        L"{ \"type\": \"screen\", \"route_id\": \"b-home\", \"module_id\": \"claim-b\","
-        L" \"children\": [ { \"type\": \"text\", \"text\": \"b\" } ] }";
+      L"{ \"type\": \"screen\", \"route_id\": \"settings-home\", \"module_id\": \"settings\","
+        L" \"children\": [ { \"type\": \"text\", \"text\": \"a\" } ] }";
   const std::wstring manifests =
-      ManifestFor(L"claim-a", L"\"settings:all\"") + L", " +
-      ManifestFor(L"claim-b", L"\"settings:all\"");
+      ManifestFor(L"settings", L"\"settings:all\"") + L", " +
+      ManifestFor(L"settings", L"\"settings:all\"");
   DHEPZ_CHECK(gate.StartWithEmbedded(EmbeddedWith(screens, manifests)).ok());
-  DHEPZ_CHECK(gate.Mounted(L"claim-a"));
-  DHEPZ_CHECK(!gate.Mounted(L"claim-b"));
+  DHEPZ_CHECK(gate.Mounted(L"settings"));
   DHEPZ_CHECK_EQ(gate.Rejects().size(), static_cast<std::size_t>(1));
   DHEPZ_CHECK(gate.Rejects()[0].reason.find(L"already claimed") != std::wstring::npos);
+  DHEPZ_CHECK(!gate.Rejects()[0].file.empty());
+  DHEPZ_CHECK(gate.Rejects()[0].line > 0);
   modules::ResetRegistryForTests();
 }

--- a/tests/modules/gate/capability_facets_test.cpp
+++ b/tests/modules/gate/capability_facets_test.cpp
@@ -1,0 +1,357 @@
+#include "modules/gate/app_gate.h"
+
+#include <windows.h>
+
+#include <atomic>
+#include <chrono>
+#include <memory>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "framework/test_case.h"
+#include "modules/registry/module_registry.h"
+#include "platform/files.h"
+#include "platform/worker.h"
+
+namespace {
+
+modules::SettingsAllFacet* g_settings_facet = nullptr;
+modules::ConfigWriteFacet* g_config_facet = nullptr;
+modules::ModuleHost* g_alpha_host = nullptr;
+
+class SettingsModule final : public modules::ModuleDescriptor {
+ public:
+  std::wstring_view ModuleId() const override { return L"settings"; }
+  std::wstring_view TabLabel() const override { return L"Settings"; }
+  int Order() const override { return 10; }
+  bool ShowInTabs() const override { return true; }
+  std::wstring_view SettingsRoute() const override { return {}; }
+  std::vector<std::wstring> DeclaredActions() const override { return {}; }
+  std::vector<std::wstring> DeclaredBindings() const override { return {}; }
+  std::vector<std::wstring> DeclaredCapabilities() const override {
+    return {std::wstring(modules::kCapabilitySettingsAll)};
+  }
+  core::Status Bind(modules::ModuleHost& host) override {
+    return host.GetSettingsAllFacet(&g_settings_facet);
+  }
+  core::Status Handle(std::wstring_view, const json::Value&, json::Value*) override {
+    return core::Ok();
+  }
+  void Release() override {}
+};
+
+class EditorModule final : public modules::ModuleDescriptor {
+ public:
+  std::wstring_view ModuleId() const override { return L"ui-editor"; }
+  std::wstring_view TabLabel() const override { return L"UI Editor"; }
+  int Order() const override { return 20; }
+  bool ShowInTabs() const override { return true; }
+  std::wstring_view SettingsRoute() const override { return {}; }
+  std::vector<std::wstring> DeclaredActions() const override { return {}; }
+  std::vector<std::wstring> DeclaredBindings() const override { return {}; }
+  std::vector<std::wstring> DeclaredCapabilities() const override {
+    return {std::wstring(modules::kCapabilityConfigWrite)};
+  }
+  core::Status Bind(modules::ModuleHost& host) override {
+    return host.GetConfigWriteFacet(&g_config_facet);
+  }
+  core::Status Handle(std::wstring_view, const json::Value&, json::Value*) override {
+    return core::Ok();
+  }
+  void Release() override {}
+};
+
+class AlphaModule final : public modules::ModuleDescriptor {
+ public:
+  std::wstring_view ModuleId() const override { return L"alpha"; }
+  std::wstring_view TabLabel() const override { return L"Alpha"; }
+  int Order() const override { return 30; }
+  bool ShowInTabs() const override { return true; }
+  std::wstring_view SettingsRoute() const override { return {}; }
+  std::vector<std::wstring> DeclaredActions() const override { return {}; }
+  std::vector<std::wstring> DeclaredBindings() const override { return {}; }
+  std::vector<std::wstring> DeclaredCapabilities() const override { return {}; }
+  core::Status Bind(modules::ModuleHost& host) override {
+    g_alpha_host = &host;
+    return core::Ok();
+  }
+  core::Status Handle(std::wstring_view, const json::Value&, json::Value*) override {
+    return core::Ok();
+  }
+  void Release() override {}
+};
+
+class IntruderModule final : public modules::ModuleDescriptor {
+ public:
+  std::wstring_view ModuleId() const override { return L"intruder"; }
+  std::wstring_view TabLabel() const override { return L"Intruder"; }
+  int Order() const override { return 40; }
+  bool ShowInTabs() const override { return true; }
+  std::wstring_view SettingsRoute() const override { return {}; }
+  std::vector<std::wstring> DeclaredActions() const override { return {}; }
+  std::vector<std::wstring> DeclaredBindings() const override { return {}; }
+  std::vector<std::wstring> DeclaredCapabilities() const override {
+    return {std::wstring(modules::kCapabilitySettingsAll)};
+  }
+  core::Status Bind(modules::ModuleHost&) override { return core::Ok(); }
+  core::Status Handle(std::wstring_view, const json::Value&, json::Value*) override {
+    return core::Ok();
+  }
+  void Release() override {}
+};
+
+std::unique_ptr<modules::ModuleDescriptor> MakeSettings() {
+  return std::make_unique<SettingsModule>();
+}
+std::unique_ptr<modules::ModuleDescriptor> MakeEditor() {
+  return std::make_unique<EditorModule>();
+}
+std::unique_ptr<modules::ModuleDescriptor> MakeAlpha() {
+  return std::make_unique<AlphaModule>();
+}
+std::unique_ptr<modules::ModuleDescriptor> MakeIntruder() {
+  return std::make_unique<IntruderModule>();
+}
+
+std::wstring Core() {
+  return LR"({
+    "schema": "dhepz.ui.core", "version": 1,
+    "tokens": { "dark": { "text": "#ffffff" }, "light": { "text": "#000000" } },
+    "allows_children": ["screen"],
+    "components": {
+      "screen": { "properties": {
+        "route_id": { "kind": "string", "required": true },
+        "module_id": { "kind": "string" },
+        "tab_label": { "kind": "string" }
+      } }
+    }
+  })";
+}
+
+std::wstring Screen(std::wstring_view id, std::wstring_view label) {
+  return L"{ \"type\": \"screen\", \"route_id\": \"" + std::wstring(id) +
+         L"-home\", \"module_id\": \"" + std::wstring(id) + L"\", \"tab_label\": \"" +
+         std::wstring(label) + L"\" }";
+}
+
+std::wstring Manifest(std::wstring_view id, std::wstring_view label,
+                      std::wstring_view capability = {}) {
+  const std::wstring caps = capability.empty()
+                                ? L"[]"
+                                : L"[ \"" + std::wstring(capability) + L"\" ]";
+  return L"{ \"moduleId\": \"" + std::wstring(id) + L"\", \"tabLabel\": \"" +
+         std::wstring(label) + L"\", \"capabilities\": " + caps + L" }";
+}
+
+std::wstring Embedded(const std::vector<std::wstring>& screens,
+                      const std::vector<std::wstring>& manifests) {
+  std::wstring result = L"{ \"core\": " + Core() + L", \"components\": [";
+  for (std::size_t i = 0; i < screens.size(); ++i) {
+    if (i != 0) result.append(L",");
+    result.append(screens[i]);
+  }
+  result.append(L"], \"modules\": [");
+  for (std::size_t i = 0; i < manifests.size(); ++i) {
+    if (i != 0) result.append(L",");
+    result.append(manifests[i]);
+  }
+  result.append(L"] }");
+  return result;
+}
+
+struct RigState {
+  unsigned int completion_message = 0;
+};
+RigState* g_rig = nullptr;
+
+LRESULT CALLBACK FacetRigProc(HWND window, UINT message, WPARAM wparam, LPARAM lparam) {
+  if (g_rig != nullptr && message == g_rig->completion_message) {
+    worker::Worker::Settle(lparam);
+    return 0;
+  }
+  return DefWindowProcW(window, message, wparam, lparam);
+}
+
+struct Rig {
+  HWND window = nullptr;
+  RigState state;
+  Rig() {
+    g_rig = &state;
+    WNDCLASSW cls{};
+    cls.lpfnWndProc = FacetRigProc;
+    cls.hInstance = GetModuleHandleW(nullptr);
+    cls.lpszClassName = L"dhepz.capability-facet.test";
+    RegisterClassW(&cls);
+    state.completion_message = RegisterWindowMessageW(L"dhepz.capability-facet.completion");
+    window = CreateWindowExW(0, cls.lpszClassName, L"", WS_POPUP, 0, 0, 16, 16, nullptr,
+                             nullptr, cls.hInstance, nullptr);
+    DHEPZ_CHECK(window != nullptr);
+  }
+  ~Rig() {
+    if (window != nullptr) DestroyWindow(window);
+    g_rig = nullptr;
+  }
+};
+
+template <typename Predicate>
+void PumpUntil(Predicate predicate, int timeout_ms) {
+  const auto deadline = std::chrono::steady_clock::now() +
+                        std::chrono::milliseconds(timeout_ms);
+  while (std::chrono::steady_clock::now() < deadline) {
+    MSG message;
+    while (PeekMessageW(&message, nullptr, 0, 0, PM_REMOVE)) {
+      TranslateMessage(&message);
+      DispatchMessageW(&message);
+    }
+    if (predicate()) return;
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }
+}
+
+std::wstring TempFile() {
+  wchar_t base[MAX_PATH]{};
+  GetTempPathW(MAX_PATH, base);
+  return std::wstring(base) + L"dhepz-config-preview-" +
+         std::to_wstring(GetTickCount64()) + L".json";
+}
+
+void ResetGlobals() {
+  g_settings_facet = nullptr;
+  g_config_facet = nullptr;
+  g_alpha_host = nullptr;
+}
+
+}  // namespace
+
+DHEPZ_TEST(CapabilityFacets, SettingsAllIsTypedSharedAndRestrictedToSettingsModule) {
+  modules::ResetRegistryForTests();
+  ResetGlobals();
+  modules::RegisterModule(L"settings", &MakeSettings);
+  modules::RegisterModule(L"alpha", &MakeAlpha);
+  modules::RegisterModule(L"intruder", &MakeIntruder);
+  modules::AppGate gate;
+  const std::wstring embedded = Embedded(
+      {Screen(L"settings", L"Settings"), Screen(L"alpha", L"Alpha"),
+       Screen(L"intruder", L"Intruder")},
+      {Manifest(L"settings", L"Settings", modules::kCapabilitySettingsAll),
+       Manifest(L"alpha", L"Alpha"),
+       Manifest(L"intruder", L"Intruder", modules::kCapabilitySettingsAll)});
+  DHEPZ_CHECK(gate.StartWithEmbedded(embedded).ok());
+  DHEPZ_CHECK(gate.Mounted(L"settings"));
+  DHEPZ_CHECK(gate.Mounted(L"alpha"));
+  DHEPZ_CHECK(!gate.Mounted(L"intruder"));
+  DHEPZ_CHECK_EQ(gate.Grants().size(), static_cast<std::size_t>(1));
+  DHEPZ_CHECK_EQ(gate.Grants()[0].module_id, std::wstring(L"settings"));
+  DHEPZ_CHECK_EQ(gate.Grants()[0].capability,
+                 std::wstring(modules::kCapabilitySettingsAll));
+  DHEPZ_CHECK_EQ(gate.Rejects().size(), static_cast<std::size_t>(1));
+  DHEPZ_CHECK(gate.Rejects()[0].reason.find(L"settings:all") != std::wstring::npos);
+  DHEPZ_CHECK(!gate.Rejects()[0].file.empty());
+  DHEPZ_CHECK(gate.Rejects()[0].line > 0);
+
+  DHEPZ_CHECK(gate.Activate(L"settings-home").ok());
+  DHEPZ_CHECK(gate.Activate(L"alpha-home").ok());
+  DHEPZ_CHECK(g_settings_facet != nullptr);
+  DHEPZ_CHECK(g_alpha_host != nullptr);
+  modules::SettingsAllFacet* denied_settings = g_settings_facet;
+  modules::ConfigWriteFacet* denied_config =
+      reinterpret_cast<modules::ConfigWriteFacet*>(g_settings_facet);
+  DHEPZ_CHECK(!g_alpha_host->GetSettingsAllFacet(&denied_settings).ok());
+  DHEPZ_CHECK(denied_settings == nullptr);
+  DHEPZ_CHECK(!g_alpha_host->GetConfigWriteFacet(&denied_config).ok());
+  DHEPZ_CHECK(denied_config == nullptr);
+  DHEPZ_CHECK(g_settings_facet->WriteGlobal(L"theme", L"dark").ok());
+  DHEPZ_CHECK(g_settings_facet->WriteModule(L"alpha", L"value", L"shared").ok());
+  std::wstring value;
+  DHEPZ_CHECK(g_alpha_host->SettingsReadGlobal(L"theme", &value).ok());
+  DHEPZ_CHECK_EQ(value, std::wstring(L"dark"));
+  DHEPZ_CHECK(g_alpha_host->SettingsRead(L"value", &value).ok());
+  DHEPZ_CHECK_EQ(value, std::wstring(L"shared"));
+  DHEPZ_CHECK_EQ(g_settings_facet->Peers().size(), static_cast<std::size_t>(2));
+  modules::ResetRegistryForTests();
+}
+
+DHEPZ_TEST(CapabilityFacets, ConfigPreviewRejectsInvalidAndUsesRevisionedSaveDiscard) {
+  Rig rig;
+  modules::ResetRegistryForTests();
+  ResetGlobals();
+  modules::RegisterModule(L"ui-editor", &MakeEditor);
+  modules::AppGate gate;
+  const std::wstring path = TempFile();
+  DHEPZ_CHECK(gate.ConfigureHostOperations(rig.window, rig.state.completion_message, {}).ok());
+  DHEPZ_CHECK(gate.ConfigureConfigOverridePath(path).ok());
+  DHEPZ_CHECK(gate.StartWithEmbedded(
+                  Embedded({Screen(L"ui-editor", L"UI Editor")},
+                           {Manifest(L"ui-editor", L"UI Editor",
+                                     modules::kCapabilityConfigWrite)}))
+                  .ok());
+  DHEPZ_CHECK(gate.Activate(L"ui-editor-home").ok());
+  DHEPZ_CHECK(g_config_facet != nullptr);
+  DHEPZ_CHECK_EQ(gate.Grants().size(), static_cast<std::size_t>(1));
+  DHEPZ_CHECK_EQ(gate.Grants()[0].capability,
+                 std::wstring(modules::kCapabilityConfigWrite));
+
+  const ui::config::ResolvedUiDocument* original = gate.document();
+  const std::uint64_t original_generation = gate.document_generation();
+  modules::ConfigPreviewResult invalid;
+  const core::Status invalid_status = g_config_facet->Preview(
+      LR"({
+        "components": [
+          { "type": "screen", "route_id": "ui-editor-home",
+            "module_id": "ui-editor", "unknown": true }
+        ]
+      })",
+      &invalid);
+  DHEPZ_CHECK(!invalid_status.ok());
+  DHEPZ_CHECK(!invalid.diagnostics.empty());
+  DHEPZ_CHECK(invalid.diagnostics[0].line > 0);
+  DHEPZ_CHECK(gate.document() == original);
+  DHEPZ_CHECK_EQ(gate.document_generation(), original_generation);
+
+  const std::wstring candidate_a =
+      LR"({ "components": [ { "type": "screen", "route_id": "ui-editor-home",
+              "module_id": "ui-editor", "tab_label": "Preview A" } ] })";
+  modules::ConfigPreviewResult preview_a;
+  DHEPZ_CHECK(g_config_facet->Preview(candidate_a, &preview_a).ok());
+  DHEPZ_CHECK(preview_a.token);
+  DHEPZ_CHECK(gate.document() != original);
+  DHEPZ_CHECK_EQ(gate.document()->FindRoute(L"ui-editor-home")->tab_label,
+                 std::wstring(L"Preview A"));
+
+  const std::wstring candidate_b =
+      LR"({ "components": [ { "type": "screen", "route_id": "ui-editor-home",
+              "module_id": "ui-editor", "tab_label": "Preview B" } ] })";
+  modules::ConfigPreviewResult preview_b;
+  DHEPZ_CHECK(g_config_facet->Preview(candidate_b, &preview_b).ok());
+  DHEPZ_CHECK(preview_b.token != preview_a.token);
+  modules::AsyncRequestToken stale_request;
+  DHEPZ_CHECK(!g_config_facet->Save(preview_a.token, [](const auto&) {}, &stale_request).ok());
+
+  std::vector<std::wstring> discard_routes;
+  DHEPZ_CHECK(g_config_facet->Discard(preview_b.token, &discard_routes).ok());
+  DHEPZ_CHECK(gate.document() == original);
+  DHEPZ_CHECK(!discard_routes.empty());
+
+  modules::ConfigPreviewResult saved_preview;
+  DHEPZ_CHECK(g_config_facet->Preview(candidate_b, &saved_preview).ok());
+  std::atomic<bool> saved{false};
+  modules::HostOperationCompletion save_completion;
+  modules::AsyncRequestToken save_request;
+  DHEPZ_CHECK(g_config_facet->Save(
+                  saved_preview.token,
+                  [&](const modules::HostOperationCompletion& completion) {
+                    save_completion = completion;
+                    saved = true;
+                  },
+                  &save_request)
+                  .ok());
+  PumpUntil([&] { return saved.load(); }, 2000);
+  DHEPZ_CHECK(saved.load());
+  DHEPZ_CHECK(save_completion.status.ok());
+  DHEPZ_CHECK(save_completion.kind == modules::HostOperationKind::ConfigSave);
+  std::wstring persisted;
+  DHEPZ_CHECK(files::ReadText(path, &persisted).ok());
+  DHEPZ_CHECK_EQ(persisted, candidate_b);
+  modules::ResetRegistryForTests();
+}

--- a/tests/modules/terminal/terminal_state_test.cpp
+++ b/tests/modules/terminal/terminal_state_test.cpp
@@ -42,6 +42,14 @@ class FakeHost final : public modules::ModuleHost {
   }
   void CancelRequest(modules::AsyncRequestToken) override {}
   core::Status PublishStatePatch(const json::Value&) override { return core::Ok(); }
+  core::Status GetSettingsAllFacet(modules::SettingsAllFacet** facet) override {
+    *facet = nullptr;
+    return core::Err(core::ErrorCode::PermissionDenied, L"not granted");
+  }
+  core::Status GetConfigWriteFacet(modules::ConfigWriteFacet** facet) override {
+    *facet = nullptr;
+    return core::Err(core::ErrorCode::PermissionDenied, L"not granted");
+  }
   void ReportStatus(const core::Status&) override {}
   void Log(std::wstring_view, std::wstring_view) override {}
   core::Status RequestRoute(std::wstring_view) override { return core::Ok(); }


### PR DESCRIPTION
Closes #106.

## What changed
- adds dedicated typed `SettingsAllFacet` and `ConfigWriteFacet`
- enforces the `settings` and `ui-editor` claimant policies with source diagnostics
- keeps settings access and config transaction state in parent services
- keeps `AppGate` focused on grants, document ownership, pairing, and routing
- performs config save through the existing async parent dispatcher

## Focused local verification
- `CapabilityFacets`: 2/2 Debug
- `AppGate`: 5/5 Debug
- `ModuleContract`: 3/3 Debug
- static boundary: GateHost has no AppGate/platform/Win32 dependency; AppGate has no direct platform service reach
- `git diff --check`

The GitHub workflow is the sole full regression run for this PR SHA.