### PR TITLE
IC-03: persist parent-owned settings asynchronously

### DIFF
--- a/docs/adr/0002-parent-owned-settings-store.md
+++ b/docs/adr/0002-parent-owned-settings-store.md
@@ -1,0 +1,50 @@
+# ADR 0002 — Parent-owned asynchronous settings persistence
+
+Status: accepted (Integration Checkpoint IC-03). Links: `.docs/plan.md` Part 3,
+decision 13; `docs/audit.md` H-12.
+
+## Context
+
+Phase 4 initially kept settings in a map owned by each `GateHost`. That made a
+unit test look persistent while every process restart lost terminal recent
+folders. Moving the file into the future settings module would also violate the
+parent-owned lifecycle rule and delay real persistence until Phase 5. Disk I/O
+cannot run on the UI thread, and silent tray construction must remain inert.
+
+## Decision
+
+1. Parent `SettingsAccessService` owns one `SettingsStore`; `AppGate` only
+   composes and configures that service. Production resolves exactly one path:
+   `paths::Join(paths::StateDir(), L"settings.json")`; creation goes through
+   `paths::EnsureStateDir()` immediately before the first write. Tests may
+   inject a path before gate start and never use the user's state directory.
+2. Construction performs no I/O, creates no directory, and starts no thread.
+   `StartSettingsLoad` is the first-read trigger. It uses a run-once worker and
+   posts a typed completion to the UI thread. A missing or corrupt file produces
+   defaults plus a `Status` diagnostic rather than failing gate startup.
+3. The physical document is an ordered JSON object with `global` and
+   `modules.<moduleId>` sections. Reads and writes change only the addressed
+   value. Unknown root members, module sections, keys, and JSON value types are
+   retained. A normal `GateHost` can address only its module section and read
+   globals; only `SettingsAllFacet` can address all sections or write globals.
+4. Each accepted write updates the UI-owned snapshot first and receives a
+   revision. One run-once writer drains to the newest accepted serialized
+   snapshot in revision order using `files::WriteTextAtomic`. An older write can
+   never finish after a newer write. Save failures return a completion `Status`
+   and are retained in store diagnostics.
+5. Graceful shutdown stops accepting UI work and joins at most the active
+   run-once writer, which drains the newest already-accepted snapshot before it
+   exits. Completion delivery may be suppressed during teardown, but the file
+   cannot be torn or rolled backward. No worker or timer remains at idle.
+6. Modules never receive the path and never call file APIs. The Phase 5
+   `settings` module is an editor through `settings:all`, not the store owner.
+
+## Consequences
+
+- Settings survive a complete gate/process-owner teardown and preserve data
+  written by future modules.
+- First paint and tray-only construction do not wait for or touch settings I/O.
+- Callers must request readiness and handle defaults explicitly. Persistence is
+  asynchronous, so a successful immediate write status means accepted and
+  queued; final I/O status arrives through the parent diagnostics/completion
+  path.

--- a/src/modules/contract/module_contract.h
+++ b/src/modules/contract/module_contract.h
@@ -51,7 +51,15 @@ struct PeerInfo {
 
 enum class ProcessOperation { Launch, ElevatedLaunch, Capture };
 
-enum class HostOperationKind { Launch, ElevatedLaunch, Capture, FolderProbe, ConfigSave };
+enum class HostOperationKind {
+  Launch,
+  ElevatedLaunch,
+  Capture,
+  FolderProbe,
+  ConfigSave,
+  SettingsLoad,
+  SettingsSave,
+};
 
 struct AsyncRequestToken {
   std::uint64_t value = 0;
@@ -160,9 +168,11 @@ class ModuleHost {
   virtual core::Status SettingsRead(std::wstring_view key, std::wstring* out) = 0;
   virtual core::Status SettingsReadGlobal(std::wstring_view key, std::wstring* out) = 0;
   virtual core::Status SettingsWrite(std::wstring_view key, std::wstring_view value) = 0;
-  // Bulk/blob data scoped to this moduleId only.
-  virtual core::Status StorageWrite(std::wstring_view name, std::wstring_view data) = 0;
-  virtual core::Status StorageRead(std::wstring_view name, std::wstring* out) = 0;
+  // Explicit readiness boundary for the parent-owned settings snapshot.
+  // Until this completion arrives, reads return their empty/default value and
+  // NotFound. No module infers readiness from a synchronous read result.
+  virtual core::Status StartSettingsLoad(HostOperationCallback callback,
+                                         AsyncRequestToken* token) = 0;
   // Starts immediately and returns a parent-issued token. The callback is
   // delivered on the UI thread with this host lifetime's generation. Modules
   // pass argv, never a prequoted command line; the parent owns quoting.

--- a/src/modules/gate/app_gate.cpp
+++ b/src/modules/gate/app_gate.cpp
@@ -56,7 +56,7 @@ core::Status AppGate::ConfigureHostOperations(void* ui_window,
   operation_window_ = ui_window;
   operation_message_ = completion_message;
   state_patch_handler_ = std::move(state_patch_handler);
-  return core::Ok();
+  return settings_service_->ConfigureHost(ui_window, completion_message);
 }
 
 core::Status AppGate::ConfigureConfigOverridePath(std::wstring path) {
@@ -65,6 +65,19 @@ core::Status AppGate::ConfigureConfigOverridePath(std::wstring path) {
                      L"Config path must be configured before gate start");
   }
   return config_service_->ConfigureOverridePath(std::move(path));
+}
+
+core::Status AppGate::ConfigureSettingsStorePath(std::wstring path) {
+  if (!mounted_.empty()) {
+    return core::Err(core::ErrorCode::AlreadyExists,
+                     L"Settings path must be configured before gate start");
+  }
+  return settings_service_->ConfigureStorePath(std::move(path));
+}
+
+const std::vector<SettingsStoreDiagnostic>&
+AppGate::SettingsDiagnostics() const {
+  return settings_service_->Diagnostics();
 }
 
 core::Status AppGate::PairAndMount(std::wstring_view embedded_text,

--- a/src/modules/gate/app_gate.h
+++ b/src/modules/gate/app_gate.h
@@ -18,6 +18,7 @@
 #include "modules/contract/module_contract.h"
 #include "modules/contract/module_manifest.h"
 #include "modules/gate/gate_host.h"
+#include "modules/gate/settings_store.h"
 #include "ui/config/resolved_ui_document.h"
 
 namespace modules {
@@ -63,12 +64,15 @@ class AppGate final {
   core::Status ConfigureHostOperations(void* ui_window, unsigned int completion_message,
                                        HostStatePatchHandler state_patch_handler);
   core::Status ConfigureConfigOverridePath(std::wstring path);
+  // Test seam; production leaves this empty and uses StateDir/settings.json.
+  core::Status ConfigureSettingsStorePath(std::wstring path);
 
   const ui::config::ResolvedUiDocument* document() const { return document_.get(); }
   std::uint64_t document_generation() const { return document_generation_; }
   std::vector<PeerInfo> Peers() const;
   const std::vector<RejectEntry>& Rejects() const { return rejects_; }
   const std::vector<CapabilityGrant>& Grants() const { return grants_; }
+  const std::vector<SettingsStoreDiagnostic>& SettingsDiagnostics() const;
   bool Mounted(std::wstring_view module_id) const;
 
   // Lazy activation: builds the descriptor and Bind()s it on first visit.

--- a/src/modules/gate/gate_host.cpp
+++ b/src/modules/gate/gate_host.cpp
@@ -53,21 +53,9 @@ core::Status GateHost::SettingsWrite(std::wstring_view key,
   return settings_service_->WriteModule(module_id_, key, value);
 }
 
-core::Status GateHost::StorageWrite(std::wstring_view name,
-                                    std::wstring_view data) {
-  std::lock_guard lock(mutex_);
-  storage_[std::wstring(name)] = std::wstring(data);
-  return core::Ok();
-}
-
-core::Status GateHost::StorageRead(std::wstring_view name, std::wstring* out) {
-  std::lock_guard lock(mutex_);
-  const auto it = storage_.find(std::wstring(name));
-  if (it == storage_.end()) {
-    return core::Err(core::ErrorCode::NotFound, L"no such blob");
-  }
-  *out = it->second;
-  return core::Ok();
+core::Status GateHost::StartSettingsLoad(HostOperationCallback callback,
+                                         AsyncRequestToken* token) {
+  return settings_service_->StartLoad(std::move(callback), token);
 }
 
 core::Status GateHost::StartProcess(const ProcessRequest& request,
@@ -92,6 +80,7 @@ core::Status GateHost::StartFolderProbe(const FolderProbeRequest& request,
 
 void GateHost::CancelRequest(AsyncRequestToken token) {
   if (operations_) operations_->CancelRequest(token);
+  settings_service_->CancelRequest(token);
 }
 
 core::Status GateHost::PublishStatePatch(const json::Value& patch) {

--- a/src/modules/gate/gate_host.h
+++ b/src/modules/gate/gate_host.h
@@ -3,7 +3,6 @@
 #pragma once
 
 #include <functional>
-#include <map>
 #include <memory>
 #include <mutex>
 #include <string>
@@ -44,8 +43,8 @@ class GateHost final : public ModuleHost,
   core::Status SettingsRead(std::wstring_view key, std::wstring* out) override;
   core::Status SettingsReadGlobal(std::wstring_view key, std::wstring* out) override;
   core::Status SettingsWrite(std::wstring_view key, std::wstring_view value) override;
-  core::Status StorageWrite(std::wstring_view name, std::wstring_view data) override;
-  core::Status StorageRead(std::wstring_view name, std::wstring* out) override;
+  core::Status StartSettingsLoad(HostOperationCallback callback,
+                                 AsyncRequestToken* token) override;
   core::Status StartProcess(const ProcessRequest& request,
                             HostOperationCallback callback,
                             AsyncRequestToken* token) override;
@@ -88,7 +87,6 @@ class GateHost final : public ModuleHost,
   bool config_write_granted_ = false;
   ModuleSurface surface_;
   std::mutex mutex_;
-  std::map<std::wstring, std::wstring> storage_;
   std::vector<std::wstring> log_;
   core::Status last_status_;
   std::unique_ptr<HostOperationDispatcher> operations_;

--- a/src/modules/gate/settings_access_service.cpp
+++ b/src/modules/gate/settings_access_service.cpp
@@ -1,9 +1,73 @@
 #include "modules/gate/settings_access_service.h"
 
+#include <utility>
+
 namespace modules {
 
 SettingsAccessService::SettingsAccessService(PeersProvider peers_provider)
     : peers_provider_(std::move(peers_provider)) {}
+
+SettingsAccessService::~SettingsAccessService() = default;
+
+core::Status SettingsAccessService::ConfigureHost(
+    void* ui_window, unsigned int completion_message) {
+  if (store_) {
+    return core::Err(core::ErrorCode::AlreadyExists,
+                     L"settings store is already active");
+  }
+  if (ui_window == nullptr || completion_message == 0) {
+    return core::Err(core::ErrorCode::InvalidArgument,
+                     L"settings host requires a UI completion target");
+  }
+  ui_window_ = ui_window;
+  completion_message_ = completion_message;
+  return core::Ok();
+}
+
+core::Status SettingsAccessService::ConfigureStorePath(std::wstring path) {
+  if (store_) {
+    return core::Err(core::ErrorCode::AlreadyExists,
+                     L"settings store is already active");
+  }
+  store_path_ = std::move(path);
+  return core::Ok();
+}
+
+SettingsStore* SettingsAccessService::EnsureStore() {
+  if (!store_) {
+    store_ = std::make_unique<SettingsStore>(
+        ui_window_, completion_message_, store_path_);
+  }
+  return store_.get();
+}
+
+core::Status SettingsAccessService::StartLoad(
+    HostOperationCallback callback, AsyncRequestToken* token) {
+  if (!callback) {
+    return core::Err(core::ErrorCode::InvalidArgument,
+                     L"settings-ready callback is required");
+  }
+  if (ui_window_ == nullptr || completion_message_ == 0) {
+    return core::Err(core::ErrorCode::Unsupported,
+                     L"async settings host is not configured");
+  }
+  return EnsureStore()->StartLoad(
+      [callback = std::move(callback)](
+          const SettingsStoreCompletion& completion) {
+        HostOperationCompletion host_completion;
+        host_completion.token = completion.token;
+        host_completion.kind = completion.operation == SettingsStoreOperation::Load
+                                   ? HostOperationKind::SettingsLoad
+                                   : HostOperationKind::SettingsSave;
+        host_completion.status = completion.status;
+        callback(host_completion);
+      },
+      token);
+}
+
+void SettingsAccessService::CancelRequest(AsyncRequestToken token) {
+  if (store_) store_->CancelRequest(token);
+}
 
 core::Status SettingsAccessService::ReadGlobal(std::wstring_view key,
                                                std::wstring* out) {
@@ -11,20 +75,23 @@ core::Status SettingsAccessService::ReadGlobal(std::wstring_view key,
     return core::Err(core::ErrorCode::InvalidArgument,
                      L"settings output is required");
   }
-  std::lock_guard lock(mutex_);
-  const auto it = global_.find(std::wstring(key));
-  if (it == global_.end()) {
-    return core::Err(core::ErrorCode::NotFound, L"no such key");
+  if (!store_) {
+    out->clear();
+    return core::Err(core::ErrorCode::NotFound,
+                     L"settings are not loaded");
   }
-  *out = it->second;
-  return core::Ok();
+  return store_->ReadGlobal(key, out);
 }
 
 core::Status SettingsAccessService::WriteGlobal(std::wstring_view key,
                                                 std::wstring_view value) {
-  std::lock_guard lock(mutex_);
-  global_[std::wstring(key)] = std::wstring(value);
-  return core::Ok();
+  if (ui_window_ == nullptr || completion_message_ == 0) {
+    return core::Err(core::ErrorCode::Unsupported,
+                     L"async settings host is not configured");
+  }
+  AsyncRequestToken token;
+  return EnsureStore()->StartWriteGlobal(
+      key, value, [](const SettingsStoreCompletion&) {}, &token);
 }
 
 core::Status SettingsAccessService::ReadModule(std::wstring_view module_id,
@@ -34,29 +101,40 @@ core::Status SettingsAccessService::ReadModule(std::wstring_view module_id,
     return core::Err(core::ErrorCode::InvalidArgument,
                      L"settings output is required");
   }
-  std::lock_guard lock(mutex_);
-  const auto section = modules_.find(std::wstring(module_id));
-  if (section == modules_.end()) {
-    return core::Err(core::ErrorCode::NotFound, L"no such module settings");
+  if (!store_) {
+    out->clear();
+    return core::Err(core::ErrorCode::NotFound,
+                     L"settings are not loaded");
   }
-  const auto value = section->second.find(std::wstring(key));
-  if (value == section->second.end()) {
-    return core::Err(core::ErrorCode::NotFound, L"no such key");
-  }
-  *out = value->second;
-  return core::Ok();
+  return store_->ReadModule(module_id, key, out);
 }
 
 core::Status SettingsAccessService::WriteModule(std::wstring_view module_id,
                                                 std::wstring_view key,
                                                 std::wstring_view value) {
-  std::lock_guard lock(mutex_);
-  modules_[std::wstring(module_id)][std::wstring(key)] = std::wstring(value);
-  return core::Ok();
+  if (ui_window_ == nullptr || completion_message_ == 0) {
+    return core::Err(core::ErrorCode::Unsupported,
+                     L"async settings host is not configured");
+  }
+  AsyncRequestToken token;
+  return EnsureStore()->StartWriteModule(
+      module_id, key, value, [](const SettingsStoreCompletion&) {}, &token);
 }
 
 std::vector<PeerInfo> SettingsAccessService::Peers() const {
   return peers_provider_ ? peers_provider_() : std::vector<PeerInfo>{};
+}
+
+const std::vector<SettingsStoreDiagnostic>&
+SettingsAccessService::Diagnostics() const {
+  static const std::vector<SettingsStoreDiagnostic> empty;
+  return store_ ? store_->diagnostics() : empty;
+}
+
+std::size_t SettingsAccessService::ThreadCount() {
+  if (!store_) return 0;
+  store_->ReapFinished();
+  return store_->ThreadCount();
 }
 
 }  // namespace modules

--- a/src/modules/gate/settings_access_service.h
+++ b/src/modules/gate/settings_access_service.h
@@ -1,15 +1,16 @@
-// Parent-owned settings view used by ModuleHost capability facets. Physical
-// persistence replaces this in IC-03 without widening the child contract.
+// Parent-owned settings view used by ModuleHost capability facets. It owns the
+// lazy physical store without exposing paths or file APIs to child modules.
 #pragma once
 
+#include <cstddef>
 #include <functional>
-#include <map>
-#include <mutex>
+#include <memory>
 #include <string>
 #include <string_view>
 #include <vector>
 
 #include "modules/contract/module_contract.h"
+#include "modules/gate/settings_store.h"
 
 namespace modules {
 
@@ -18,6 +19,14 @@ class SettingsAccessService final {
   using PeersProvider = std::function<std::vector<PeerInfo>()>;
 
   explicit SettingsAccessService(PeersProvider peers_provider);
+  ~SettingsAccessService();
+
+  core::Status ConfigureHost(void* ui_window,
+                             unsigned int completion_message);
+  core::Status ConfigureStorePath(std::wstring path);
+  core::Status StartLoad(HostOperationCallback callback,
+                         AsyncRequestToken* token);
+  void CancelRequest(AsyncRequestToken token);
 
   core::Status ReadGlobal(std::wstring_view key, std::wstring* out);
   core::Status WriteGlobal(std::wstring_view key, std::wstring_view value);
@@ -26,12 +35,17 @@ class SettingsAccessService final {
   core::Status WriteModule(std::wstring_view module_id, std::wstring_view key,
                            std::wstring_view value);
   std::vector<PeerInfo> Peers() const;
+  const std::vector<SettingsStoreDiagnostic>& Diagnostics() const;
+  std::size_t ThreadCount();
 
  private:
+  SettingsStore* EnsureStore();
+
   PeersProvider peers_provider_;
-  mutable std::mutex mutex_;
-  std::map<std::wstring, std::map<std::wstring, std::wstring>> modules_;
-  std::map<std::wstring, std::wstring> global_;
+  void* ui_window_ = nullptr;
+  unsigned int completion_message_ = 0;
+  std::wstring store_path_;
+  std::unique_ptr<SettingsStore> store_;
 };
 
 }  // namespace modules

--- a/src/modules/gate/settings_store.cpp
+++ b/src/modules/gate/settings_store.cpp
@@ -1,0 +1,403 @@
+#include "modules/gate/settings_store.h"
+
+#include <algorithm>
+#include <mutex>
+#include <utility>
+
+#include "core/json.h"
+#include "platform/files.h"
+#include "platform/paths.h"
+#include "platform/worker.h"
+
+namespace modules {
+namespace {
+
+json::Value DefaultSnapshot() {
+  json::Value root = json::Value::Object();
+  root.Set(L"global", json::Value::Object());
+  root.Set(L"modules", json::Value::Object());
+  return root;
+}
+
+core::Status ValidateSnapshot(const json::Value& root) {
+  if (!root.is_object()) {
+    return DHEPZ_ERR(core::ErrorCode::ParseError,
+                     L"settings root must be an object");
+  }
+  const json::Value* global = root.Find(L"global");
+  if (global != nullptr && !global->is_object()) {
+    return DHEPZ_ERR(core::ErrorCode::ParseError,
+                     L"settings global section must be an object");
+  }
+  const json::Value* modules_value = root.Find(L"modules");
+  if (modules_value != nullptr && !modules_value->is_object()) {
+    return DHEPZ_ERR(core::ErrorCode::ParseError,
+                     L"settings modules section must be an object");
+  }
+  if (modules_value != nullptr) {
+    for (const auto& [module_id, section] : modules_value->members()) {
+      (void)module_id;
+      if (!section.is_object()) {
+        return DHEPZ_ERR(core::ErrorCode::ParseError,
+                         L"every module settings section must be an object");
+      }
+    }
+  }
+  return core::Ok();
+}
+
+void EnsureShape(json::Value* root) {
+  if (root->Find(L"global") == nullptr) root->Set(L"global", json::Value::Object());
+  if (root->Find(L"modules") == nullptr) root->Set(L"modules", json::Value::Object());
+}
+
+json::Value SettingValue(std::wstring_view text) {
+  json::Value parsed;
+  if (json::Parse(text, &parsed).ok()) return parsed;
+  return json::Value::String(std::wstring(text));
+}
+
+core::Status ReadSetting(const json::Value* section, std::wstring_view key,
+                         std::wstring* out) {
+  if (out == nullptr) {
+    return DHEPZ_ERR(core::ErrorCode::InvalidArgument,
+                     L"A settings output is required");
+  }
+  out->clear();
+  if (section == nullptr || !section->is_object()) {
+    return DHEPZ_ERR(core::ErrorCode::NotFound, L"Settings section is unavailable");
+  }
+  const json::Value* value = section->Find(key);
+  if (value == nullptr) {
+    return DHEPZ_ERR(core::ErrorCode::NotFound, L"Setting is absent");
+  }
+  *out = value->is_string() ? value->AsString() : json::Serialize(*value, false);
+  return core::Ok();
+}
+
+core::Status ValidateAsync(const SettingsStoreCallback& callback,
+                           AsyncRequestToken* token) {
+  if (token == nullptr) {
+    return DHEPZ_ERR(core::ErrorCode::InvalidArgument,
+                     L"A request-token output is required");
+  }
+  *token = {};
+  if (!callback) {
+    return DHEPZ_ERR(core::ErrorCode::InvalidArgument,
+                     L"A settings completion callback is required");
+  }
+  return core::Ok();
+}
+
+struct LoadCargo {
+  json::Value snapshot = DefaultSnapshot();
+  core::Status status;
+  bool used_defaults = false;
+};
+
+struct SaveCargo {
+  std::uint64_t revision = 0;
+  core::Status status;
+};
+
+struct PendingSave {
+  AsyncRequestToken token;
+  std::uint64_t revision = 0;
+  SettingsStoreCallback callback;
+};
+
+struct PendingLoad {
+  AsyncRequestToken token;
+  SettingsStoreCallback callback;
+};
+
+struct LatestWrite {
+  std::mutex mutex;
+  std::wstring text;
+  std::uint64_t revision = 0;
+};
+
+}  // namespace
+
+struct SettingsStore::Impl {
+  Impl(void* window, unsigned int message, std::wstring configured_path)
+      : ui_window(window), completion_message(message) {
+    default_path = configured_path.empty();
+    path = default_path ? paths::Join(paths::StateDir(), L"settings.json")
+                        : std::move(configured_path);
+  }
+
+  void EnsureWorker() {
+    if (worker) return;
+    worker = std::make_unique<worker::Worker>(ui_window, completion_message);
+    generation = worker->CreateGeneration();
+  }
+
+  void StartLatestWrite() {
+    if (write_active || !ready || completed_revision >= revision) return;
+    EnsureWorker();
+    write_active = true;
+    const std::wstring target = path;
+    const bool ensure_default = default_path;
+    const std::shared_ptr<LatestWrite> latest = latest_write;
+    worker->Submit(
+        [latest, target, ensure_default](const std::atomic<bool>& cancelled) {
+          auto result = std::make_shared<SaveCargo>();
+          // Drain to the newest snapshot on this one run-once thread. Shutdown
+          // may suppress delivery, but it does not abandon the newest complete
+          // snapshot already accepted on the UI thread.
+          for (;;) {
+            std::wstring text;
+            std::uint64_t revision = 0;
+            {
+              std::lock_guard lock(latest->mutex);
+              text = latest->text;
+              revision = latest->revision;
+            }
+            (void)cancelled;
+            result->revision = revision;
+            result->status = core::Ok();
+            if (target.empty()) {
+              result->status = core::Err(core::ErrorCode::IoError,
+                                         L"Settings path is unavailable");
+            } else {
+              if (ensure_default) result->status = paths::EnsureStateDir();
+              if (result->status.ok()) {
+                result->status = files::WriteTextAtomic(target, text);
+              }
+            }
+            std::lock_guard lock(latest->mutex);
+            if (latest->revision == revision) break;
+          }
+          return std::static_pointer_cast<void>(result);
+        },
+        [this](std::shared_ptr<void> cargo) {
+          const auto result = std::static_pointer_cast<SaveCargo>(std::move(cargo));
+          write_active = false;
+          completed_revision = result->revision;
+          if (!result->status.ok()) {
+            diagnostics.push_back(
+                {SettingsStoreOperation::Save, result->revision, result->status});
+          }
+
+          std::vector<PendingSave> remaining;
+          for (PendingSave& pending : pending_saves) {
+            if (pending.revision <= result->revision) {
+              pending.callback({pending.token, SettingsStoreOperation::Save,
+                                result->revision, false, result->status});
+            } else {
+              remaining.push_back(std::move(pending));
+            }
+          }
+          pending_saves = std::move(remaining);
+          // A newer in-memory snapshot may have arrived while this write ran.
+          // It starts only after the older write completed, so completion
+          // order can never roll the file backward.
+          StartLatestWrite();
+        },
+        generation);
+  }
+
+  core::Status StartWrite(std::wstring_view module_id, std::wstring_view key,
+                          std::wstring_view value, SettingsStoreCallback callback,
+                          AsyncRequestToken* token) {
+    DHEPZ_RETURN_IF_ERROR(ValidateAsync(callback, token));
+    if (!ready) {
+      return DHEPZ_ERR(core::ErrorCode::NotFound,
+                       L"Settings are not ready; call StartSettingsLoad first");
+    }
+    if (key.empty()) {
+      return DHEPZ_ERR(core::ErrorCode::InvalidArgument,
+                       L"A setting key is required");
+    }
+    EnsureShape(&snapshot);
+    if (module_id.empty()) {
+      snapshot.Find(L"global")->Set(key, SettingValue(value));
+    } else {
+      json::Value* modules_value = snapshot.Find(L"modules");
+      json::Value* section = modules_value->Find(module_id);
+      if (section == nullptr) {
+        modules_value->Set(module_id, json::Value::Object());
+        section = modules_value->Find(module_id);
+      }
+      section->Set(key, SettingValue(value));
+    }
+    ++revision;
+    {
+      std::lock_guard lock(latest_write->mutex);
+      latest_write->text = json::Serialize(snapshot, true);
+      latest_write->revision = revision;
+    }
+    AsyncRequestToken issued{next_token++};
+    pending_saves.push_back({issued, revision, std::move(callback)});
+    *token = issued;
+    StartLatestWrite();
+    return core::Ok();
+  }
+
+  void* ui_window = nullptr;
+  unsigned int completion_message = 0;
+  std::wstring path;
+  bool default_path = false;
+  std::unique_ptr<worker::Worker> worker;
+  std::uint64_t generation = 0;
+  // Keep store tokens disjoint from per-module host-operation tokens so a
+  // single CancelRequest call can safely be routed to both owners.
+  std::uint64_t next_token = std::uint64_t{1} << 63;
+  worker::JobHandle load_handle;
+  std::vector<PendingLoad> load_waiters;
+  core::Status load_status;
+  bool load_used_defaults = false;
+  json::Value snapshot = DefaultSnapshot();
+  bool loading = false;
+  bool ready = false;
+  bool write_active = false;
+  std::uint64_t revision = 0;
+  std::uint64_t completed_revision = 0;
+  std::shared_ptr<LatestWrite> latest_write = std::make_shared<LatestWrite>();
+  std::vector<PendingSave> pending_saves;
+  std::vector<SettingsStoreDiagnostic> diagnostics;
+};
+
+SettingsStore::SettingsStore(void* ui_window, unsigned int completion_message,
+                             std::wstring path)
+    : impl_(std::make_unique<Impl>(ui_window, completion_message, std::move(path))) {}
+
+SettingsStore::~SettingsStore() = default;
+
+core::Status SettingsStore::StartLoad(SettingsStoreCallback callback,
+                                      AsyncRequestToken* token) {
+  DHEPZ_RETURN_IF_ERROR(ValidateAsync(callback, token));
+  const AsyncRequestToken issued{impl_->next_token++};
+  *token = issued;
+  if (impl_->ready) {
+    callback({issued, SettingsStoreOperation::Load, 0,
+              impl_->load_used_defaults, impl_->load_status});
+    return core::Ok();
+  }
+  impl_->load_waiters.push_back({issued, std::move(callback)});
+  if (impl_->loading) return core::Ok();
+  impl_->EnsureWorker();
+  impl_->loading = true;
+  const std::wstring path = impl_->path;
+  impl_->load_handle = impl_->worker->Submit(
+      [path](const std::atomic<bool>& cancelled) {
+        auto result = std::make_shared<LoadCargo>();
+        if (cancelled.load()) {
+          result->status =
+              core::Err(core::ErrorCode::Cancelled, L"Settings load was cancelled");
+          result->used_defaults = true;
+          return std::static_pointer_cast<void>(result);
+        }
+        std::wstring text;
+        result->status = path.empty()
+                             ? core::Err(core::ErrorCode::IoError,
+                                         L"Settings path is unavailable")
+                             : files::ReadText(path, &text);
+        if (result->status.ok()) {
+          result->status = json::Parse(text, &result->snapshot);
+        }
+        if (result->status.ok()) result->status = ValidateSnapshot(result->snapshot);
+        if (!result->status.ok()) {
+          result->snapshot = DefaultSnapshot();
+          result->used_defaults = true;
+        } else {
+          EnsureShape(&result->snapshot);
+        }
+        return std::static_pointer_cast<void>(result);
+      },
+      [this](std::shared_ptr<void> cargo) {
+        const auto result = std::static_pointer_cast<LoadCargo>(std::move(cargo));
+        impl_->loading = false;
+        impl_->ready = true;
+        impl_->snapshot = std::move(result->snapshot);
+        impl_->load_status = result->status;
+        impl_->load_used_defaults = result->used_defaults;
+        if (!result->status.ok()) {
+          impl_->diagnostics.push_back(
+              {SettingsStoreOperation::Load, 0, result->status});
+        }
+        impl_->load_handle = {};
+        std::vector<PendingLoad> waiters = std::move(impl_->load_waiters);
+        impl_->load_waiters.clear();
+        for (PendingLoad& waiter : waiters) {
+          waiter.callback({waiter.token, SettingsStoreOperation::Load, 0,
+                           result->used_defaults, result->status});
+        }
+      },
+      impl_->generation);
+  return core::Ok();
+}
+
+core::Status SettingsStore::ReadGlobal(std::wstring_view key, std::wstring* out) const {
+  if (out != nullptr) out->clear();
+  if (!impl_->ready) {
+    return DHEPZ_ERR(core::ErrorCode::NotFound, L"Settings are not ready");
+  }
+  return ReadSetting(impl_->snapshot.Find(L"global"), key, out);
+}
+
+core::Status SettingsStore::ReadModule(std::wstring_view module_id,
+                                       std::wstring_view key,
+                                       std::wstring* out) const {
+  if (out != nullptr) out->clear();
+  if (!impl_->ready) {
+    return DHEPZ_ERR(core::ErrorCode::NotFound, L"Settings are not ready");
+  }
+  const json::Value* modules_value = impl_->snapshot.Find(L"modules");
+  const json::Value* section =
+      modules_value != nullptr ? modules_value->Find(module_id) : nullptr;
+  return ReadSetting(section, key, out);
+}
+
+core::Status SettingsStore::StartWriteGlobal(std::wstring_view key,
+                                             std::wstring_view value,
+                                             SettingsStoreCallback callback,
+                                             AsyncRequestToken* token) {
+  return impl_->StartWrite({}, key, value, std::move(callback), token);
+}
+
+core::Status SettingsStore::StartWriteModule(std::wstring_view module_id,
+                                             std::wstring_view key,
+                                             std::wstring_view value,
+                                             SettingsStoreCallback callback,
+                                             AsyncRequestToken* token) {
+  if (module_id.empty()) {
+    return DHEPZ_ERR(core::ErrorCode::InvalidArgument,
+                     L"A module id is required for module settings");
+  }
+  return impl_->StartWrite(module_id, key, value, std::move(callback), token);
+}
+
+void SettingsStore::CancelRequest(AsyncRequestToken token) {
+  if (!token) return;
+  const std::size_t before = impl_->load_waiters.size();
+  std::erase_if(impl_->load_waiters,
+                [token](const PendingLoad& pending) { return pending.token == token; });
+  if (impl_->load_waiters.size() != before) {
+    if (impl_->loading && impl_->load_waiters.empty()) {
+      impl_->worker->Cancel(impl_->load_handle);
+      impl_->loading = false;
+      impl_->load_handle = {};
+    }
+    return;
+  }
+  std::erase_if(impl_->pending_saves,
+                [token](const PendingSave& pending) { return pending.token == token; });
+}
+
+bool SettingsStore::ready() const { return impl_->ready; }
+
+const std::vector<SettingsStoreDiagnostic>& SettingsStore::diagnostics() const {
+  return impl_->diagnostics;
+}
+
+void SettingsStore::ReapFinished() {
+  if (impl_->worker) impl_->worker->JoinFinished();
+}
+
+std::size_t SettingsStore::ThreadCount() const {
+  return impl_->worker ? impl_->worker->ThreadCount() : 0;
+}
+
+}  // namespace modules

--- a/src/modules/gate/settings_store.h
+++ b/src/modules/gate/settings_store.h
@@ -1,0 +1,78 @@
+// Parent-owned, demand-loaded settings persistence.
+//
+// The object itself is inert: it creates neither a directory nor a worker
+// until StartLoad or a write is requested. All file work runs on run-once
+// worker threads and every completion settles on the configured UI thread.
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "core/status.h"
+#include "modules/contract/module_contract.h"
+
+namespace modules {
+
+enum class SettingsStoreOperation { Load, Save };
+
+struct SettingsStoreCompletion {
+  AsyncRequestToken token;
+  SettingsStoreOperation operation = SettingsStoreOperation::Load;
+  std::uint64_t revision = 0;
+  bool used_defaults = false;
+  core::Status status;
+};
+
+using SettingsStoreCallback =
+    std::function<void(const SettingsStoreCompletion& completion)>;
+
+struct SettingsStoreDiagnostic {
+  SettingsStoreOperation operation = SettingsStoreOperation::Load;
+  std::uint64_t revision = 0;
+  core::Status status;
+};
+
+class SettingsStore final {
+ public:
+  // Empty path selects paths::StateDir()/settings.json. A non-empty path is
+  // a test seam and is never derived or changed by a module.
+  SettingsStore(void* ui_window, unsigned int completion_message,
+                std::wstring path = {});
+  ~SettingsStore();
+  SettingsStore(const SettingsStore&) = delete;
+  SettingsStore& operator=(const SettingsStore&) = delete;
+
+  core::Status StartLoad(SettingsStoreCallback callback, AsyncRequestToken* token);
+
+  // Before load completion these return NotFound and clear the output, which
+  // is the default snapshot. StartLoad completion is the explicit readiness
+  // boundary; callers never infer readiness from a missing key.
+  core::Status ReadGlobal(std::wstring_view key, std::wstring* out) const;
+  core::Status ReadModule(std::wstring_view module_id, std::wstring_view key,
+                          std::wstring* out) const;
+
+  core::Status StartWriteGlobal(std::wstring_view key, std::wstring_view value,
+                                SettingsStoreCallback callback,
+                                AsyncRequestToken* token);
+  core::Status StartWriteModule(std::wstring_view module_id,
+                                std::wstring_view key, std::wstring_view value,
+                                SettingsStoreCallback callback,
+                                AsyncRequestToken* token);
+  void CancelRequest(AsyncRequestToken token);
+
+  bool ready() const;
+  const std::vector<SettingsStoreDiagnostic>& diagnostics() const;
+  void ReapFinished();
+  std::size_t ThreadCount() const;
+
+ private:
+  struct Impl;
+  std::unique_ptr<Impl> impl_;
+};
+
+}  // namespace modules

--- a/tests/modules/contract/module_contract_test.cpp
+++ b/tests/modules/contract/module_contract_test.cpp
@@ -42,8 +42,15 @@ struct TestHost final : modules::ModuleHost {
     last_write = std::wstring(key);
     return core::Ok();
   }
-  core::Status StorageWrite(std::wstring_view, std::wstring_view) override { return core::Ok(); }
-  core::Status StorageRead(std::wstring_view, std::wstring*) override { return core::Ok(); }
+  core::Status StartSettingsLoad(modules::HostOperationCallback callback,
+                                 modules::AsyncRequestToken* token) override {
+    token->value = 40;
+    modules::HostOperationCompletion completion;
+    completion.token = *token;
+    completion.kind = modules::HostOperationKind::SettingsLoad;
+    callback(completion);
+    return core::Ok();
+  }
   core::Status StartProcess(const modules::ProcessRequest& request,
                             modules::HostOperationCallback callback,
                             modules::AsyncRequestToken* token) override {
@@ -122,6 +129,21 @@ class TestModule final : public modules::ModuleDescriptor {
 };
 
 }  // namespace
+
+DHEPZ_TEST(ModuleContract, SettingsReadinessIsAnExplicitAsyncCompletion) {
+  TestHost host;
+  modules::HostOperationCompletion completion;
+  modules::AsyncRequestToken token;
+  DHEPZ_CHECK(host.StartSettingsLoad(
+                        [&](const modules::HostOperationCompletion& value) {
+                          completion = value;
+                        },
+                        &token)
+                  .ok());
+  DHEPZ_CHECK(token);
+  DHEPZ_CHECK(completion.token == token);
+  DHEPZ_CHECK(completion.kind == modules::HostOperationKind::SettingsLoad);
+}
 
 DHEPZ_TEST(ModuleManifest, ValidManifestParses) {
   modules::ModuleManifest manifest;

--- a/tests/modules/gate/app_gate_test.cpp
+++ b/tests/modules/gate/app_gate_test.cpp
@@ -29,7 +29,8 @@ class SimpleModule final : public modules::ModuleDescriptor {
   std::vector<std::wstring> DeclaredCapabilities() const override { return Base::Caps(); }
   core::Status Bind(modules::ModuleHost& host) override {
     bound_ = true;
-    return host.SettingsWrite(L"k", L"v");
+    (void)host;
+    return core::Ok();
   }
   core::Status Handle(std::wstring_view action, const json::Value&, json::Value*) override {
     handled_ = std::wstring(action);

--- a/tests/modules/gate/capability_facets_test.cpp
+++ b/tests/modules/gate/capability_facets_test.cpp
@@ -104,6 +104,7 @@ class IntruderModule final : public modules::ModuleDescriptor {
 std::unique_ptr<modules::ModuleDescriptor> MakeSettings() {
   return std::make_unique<SettingsModule>();
 }
+
 std::unique_ptr<modules::ModuleDescriptor> MakeEditor() {
   return std::make_unique<EditorModule>();
 }
@@ -224,13 +225,73 @@ void ResetGlobals() {
 
 }  // namespace
 
+DHEPZ_TEST(SettingsPersistence, NarrowHostSurvivesNewGateOnSameFile) {
+  Rig rig;
+  const std::wstring path = TempFile();
+  modules::ResetRegistryForTests();
+  modules::RegisterModule(L"alpha", &MakeAlpha);
+  const std::wstring embedded =
+      Embedded({Screen(L"alpha", L"Alpha")}, {Manifest(L"alpha", L"Alpha")});
+
+  {
+    ResetGlobals();
+    modules::AppGate first;
+    DHEPZ_CHECK(
+        first.ConfigureHostOperations(rig.window, rig.state.completion_message, {}).ok());
+    DHEPZ_CHECK(first.ConfigureSettingsStorePath(path).ok());
+    DHEPZ_CHECK(first.StartWithEmbedded(embedded).ok());
+    DHEPZ_CHECK(first.Activate(L"alpha-home").ok());
+    std::atomic<bool> ready{false};
+    modules::AsyncRequestToken load;
+    DHEPZ_CHECK(g_alpha_host
+                    ->StartSettingsLoad(
+                        [&](const modules::HostOperationCompletion&) { ready = true; },
+                        &load)
+                    .ok());
+    PumpUntil([&] { return ready.load(); }, 2000);
+    DHEPZ_CHECK(ready.load());
+    DHEPZ_CHECK(g_alpha_host->SettingsWrite(L"persisted", L"across-process").ok());
+  }
+
+  {
+    ResetGlobals();
+    modules::AppGate second;
+    DHEPZ_CHECK(
+        second.ConfigureHostOperations(rig.window, rig.state.completion_message, {}).ok());
+    DHEPZ_CHECK(second.ConfigureSettingsStorePath(path).ok());
+    DHEPZ_CHECK(second.StartWithEmbedded(embedded).ok());
+    DHEPZ_CHECK(second.Activate(L"alpha-home").ok());
+    std::atomic<bool> ready{false};
+    modules::HostOperationCompletion load_completion;
+    modules::AsyncRequestToken load;
+    DHEPZ_CHECK(g_alpha_host
+                    ->StartSettingsLoad(
+                        [&](const modules::HostOperationCompletion& completion) {
+                          load_completion = completion;
+                          ready = true;
+                        },
+                        &load)
+                    .ok());
+    PumpUntil([&] { return ready.load(); }, 2000);
+    DHEPZ_CHECK(ready.load());
+    DHEPZ_CHECK(load_completion.status.ok());
+    std::wstring value;
+    DHEPZ_CHECK(g_alpha_host->SettingsRead(L"persisted", &value).ok());
+    DHEPZ_CHECK_EQ(value, std::wstring(L"across-process"));
+  }
+  modules::ResetRegistryForTests();
+}
+
 DHEPZ_TEST(CapabilityFacets, SettingsAllIsTypedSharedAndRestrictedToSettingsModule) {
+  Rig rig;
   modules::ResetRegistryForTests();
   ResetGlobals();
   modules::RegisterModule(L"settings", &MakeSettings);
   modules::RegisterModule(L"alpha", &MakeAlpha);
   modules::RegisterModule(L"intruder", &MakeIntruder);
   modules::AppGate gate;
+  DHEPZ_CHECK(gate.ConfigureHostOperations(rig.window, rig.state.completion_message, {}).ok());
+  DHEPZ_CHECK(gate.ConfigureSettingsStorePath(TempFile()).ok());
   const std::wstring embedded = Embedded(
       {Screen(L"settings", L"Settings"), Screen(L"alpha", L"Alpha"),
        Screen(L"intruder", L"Intruder")},
@@ -254,6 +315,19 @@ DHEPZ_TEST(CapabilityFacets, SettingsAllIsTypedSharedAndRestrictedToSettingsModu
   DHEPZ_CHECK(gate.Activate(L"alpha-home").ok());
   DHEPZ_CHECK(g_settings_facet != nullptr);
   DHEPZ_CHECK(g_alpha_host != nullptr);
+  std::atomic<bool> settings_ready{false};
+  modules::AsyncRequestToken settings_load;
+  DHEPZ_CHECK(g_alpha_host
+                  ->StartSettingsLoad(
+                      [&](const modules::HostOperationCompletion& completion) {
+                        DHEPZ_CHECK(completion.kind ==
+                                    modules::HostOperationKind::SettingsLoad);
+                        settings_ready = true;
+                      },
+                      &settings_load)
+                  .ok());
+  PumpUntil([&] { return settings_ready.load(); }, 2000);
+  DHEPZ_CHECK(settings_ready.load());
   modules::SettingsAllFacet* denied_settings = g_settings_facet;
   modules::ConfigWriteFacet* denied_config =
       reinterpret_cast<modules::ConfigWriteFacet*>(g_settings_facet);

--- a/tests/modules/gate/settings_store_test.cpp
+++ b/tests/modules/gate/settings_store_test.cpp
@@ -1,0 +1,285 @@
+#include "modules/gate/settings_store.h"
+
+#include <windows.h>
+
+#include <atomic>
+#include <chrono>
+#include <string>
+#include <thread>
+
+#include "core/json.h"
+#include "framework/test_case.h"
+#include "platform/files.h"
+#include "platform/paths.h"
+#include "platform/worker.h"
+
+namespace {
+
+struct RigState {
+  unsigned int completion_message = 0;
+};
+RigState* g_settings_rig = nullptr;
+
+LRESULT CALLBACK SettingsRigProc(HWND window, UINT message, WPARAM wparam, LPARAM lparam) {
+  if (g_settings_rig != nullptr && message == g_settings_rig->completion_message) {
+    worker::Worker::Settle(lparam);
+    return 0;
+  }
+  return DefWindowProcW(window, message, wparam, lparam);
+}
+
+struct Rig {
+  HWND window = nullptr;
+  RigState state;
+  Rig() {
+    g_settings_rig = &state;
+    WNDCLASSW cls{};
+    cls.lpfnWndProc = SettingsRigProc;
+    cls.hInstance = GetModuleHandleW(nullptr);
+    cls.lpszClassName = L"dhepz.settings-store.test";
+    RegisterClassW(&cls);
+    state.completion_message = RegisterWindowMessageW(L"dhepz.settings-store.completion");
+    window = CreateWindowExW(0, cls.lpszClassName, L"", WS_POPUP, 0, 0, 16, 16,
+                             nullptr, nullptr, cls.hInstance, nullptr);
+    DHEPZ_CHECK(window != nullptr);
+  }
+  ~Rig() {
+    if (window != nullptr) DestroyWindow(window);
+    g_settings_rig = nullptr;
+  }
+};
+
+template <typename Predicate>
+void PumpUntil(Predicate predicate, int timeout_ms = 3000) {
+  const auto deadline = std::chrono::steady_clock::now() +
+                        std::chrono::milliseconds(timeout_ms);
+  while (std::chrono::steady_clock::now() < deadline) {
+    MSG message;
+    while (PeekMessageW(&message, nullptr, 0, 0, PM_REMOVE)) {
+      TranslateMessage(&message);
+      DispatchMessageW(&message);
+    }
+    if (predicate()) return;
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }
+}
+
+std::wstring UniquePath(std::wstring_view leaf) {
+  wchar_t base[MAX_PATH]{};
+  GetTempPathW(MAX_PATH, base);
+  const std::wstring dir = std::wstring(base) + L"dhepz-settings-store-" +
+                           std::to_wstring(GetTickCount64()) + L"-" +
+                           std::to_wstring(reinterpret_cast<std::uintptr_t>(&base));
+  return paths::Join(dir, leaf);
+}
+
+void Load(modules::SettingsStore& store, modules::SettingsStoreCompletion* completion) {
+  std::atomic<bool> done{false};
+  modules::AsyncRequestToken token;
+  DHEPZ_CHECK(store.StartLoad(
+                        [&](const modules::SettingsStoreCompletion& value) {
+                          *completion = value;
+                          done = true;
+                        },
+                        &token)
+                  .ok());
+  DHEPZ_CHECK(token);
+  PumpUntil([&] { return done.load(); });
+  DHEPZ_CHECK(done.load());
+}
+
+}  // namespace
+
+DHEPZ_TEST(SettingsStore, OnePhysicalLoadCompletesEveryModuleWaiter) {
+  Rig rig;
+  const std::wstring path = UniquePath(L"waiters\\settings.json");
+  modules::SettingsStore store(rig.window, rig.state.completion_message, path);
+  std::atomic<int> ready_count{0};
+  modules::AsyncRequestToken first;
+  modules::AsyncRequestToken second;
+  DHEPZ_CHECK(store.StartLoad(
+                        [&](const modules::SettingsStoreCompletion&) { ++ready_count; },
+                        &first)
+                  .ok());
+  DHEPZ_CHECK(store.StartLoad(
+                        [&](const modules::SettingsStoreCompletion&) { ++ready_count; },
+                        &second)
+                  .ok());
+  DHEPZ_CHECK(first != second);
+  PumpUntil([&] { return ready_count.load() == 2; });
+  DHEPZ_CHECK_EQ(ready_count.load(), 2);
+
+  modules::AsyncRequestToken late;
+  DHEPZ_CHECK(store.StartLoad(
+                        [&](const modules::SettingsStoreCompletion&) { ++ready_count; },
+                        &late)
+                  .ok());
+  DHEPZ_CHECK(late != first && late != second);
+  DHEPZ_CHECK_EQ(ready_count.load(), 3);
+}
+
+DHEPZ_TEST(SettingsStore, PersistenceFailureCompletesWithStatusAndDiagnostic) {
+  Rig rig;
+  const std::wstring blocker = UniquePath(L"blocker");
+  DHEPZ_CHECK(files::WriteTextAtomic(blocker, L"not a directory").ok());
+  modules::SettingsStore store(rig.window, rig.state.completion_message,
+                               paths::Join(blocker, L"settings.json"));
+  modules::SettingsStoreCompletion loaded;
+  Load(store, &loaded);
+  std::atomic<bool> done{false};
+  modules::SettingsStoreCompletion saved;
+  modules::AsyncRequestToken token;
+  DHEPZ_CHECK(store.StartWriteGlobal(
+                        L"theme", L"dark",
+                        [&](const modules::SettingsStoreCompletion& completion) {
+                          saved = completion;
+                          done = true;
+                        },
+                        &token)
+                  .ok());
+  PumpUntil([&] { return done.load(); });
+  DHEPZ_CHECK(done.load());
+  DHEPZ_CHECK(!saved.status.ok());
+  DHEPZ_CHECK(saved.operation == modules::SettingsStoreOperation::Save);
+  DHEPZ_CHECK(!store.diagnostics().empty());
+  DHEPZ_CHECK(store.diagnostics().back().status.Code() == saved.status.Code());
+  PumpUntil([] { return false; }, 100);
+  store.ReapFinished();
+  DHEPZ_CHECK_EQ(store.diagnostics().size(), static_cast<std::size_t>(2));
+  DHEPZ_CHECK_EQ(store.ThreadCount(), static_cast<std::size_t>(0));
+}
+
+DHEPZ_TEST(SettingsStore, ShutdownFlushesOnlyTheNewestAcceptedSnapshot) {
+  Rig rig;
+  const std::wstring path = UniquePath(L"shutdown\\settings.json");
+  {
+    modules::SettingsStore store(rig.window, rig.state.completion_message, path);
+    modules::SettingsStoreCompletion loaded;
+    Load(store, &loaded);
+    modules::AsyncRequestToken first;
+    modules::AsyncRequestToken second;
+    DHEPZ_CHECK(store.StartWriteModule(L"terminal", L"value", L"old",
+                                      [](const auto&) {}, &first)
+                    .ok());
+    DHEPZ_CHECK(store.StartWriteModule(L"terminal", L"value", L"new",
+                                      [](const auto&) {}, &second)
+                    .ok());
+    // No message pumping: destruction is the graceful-shutdown path.
+  }
+  modules::SettingsStore reloaded(rig.window, rig.state.completion_message, path);
+  modules::SettingsStoreCompletion loaded;
+  Load(reloaded, &loaded);
+  std::wstring value;
+  DHEPZ_CHECK(reloaded.ReadModule(L"terminal", L"value", &value).ok());
+  DHEPZ_CHECK_EQ(value, std::wstring(L"new"));
+}
+
+DHEPZ_TEST(SettingsStore, ConstructionIsInertAndMissingLoadUsesDefaults) {
+  Rig rig;
+  const std::wstring path = UniquePath(L"missing\\settings.json");
+  const std::wstring parent = paths::Parent(path);
+  modules::SettingsStore store(rig.window, rig.state.completion_message, path);
+  DHEPZ_CHECK(!paths::DirectoryExists(parent));
+  DHEPZ_CHECK_EQ(store.ThreadCount(), static_cast<std::size_t>(0));
+
+  std::wstring value = L"not-cleared";
+  DHEPZ_CHECK(!store.ReadGlobal(L"theme", &value).ok());
+  DHEPZ_CHECK(value.empty());
+
+  modules::SettingsStoreCompletion completion;
+  Load(store, &completion);
+  DHEPZ_CHECK(completion.used_defaults);
+  DHEPZ_CHECK(!completion.status.ok());
+  DHEPZ_CHECK(store.ready());
+  DHEPZ_CHECK(!store.diagnostics().empty());
+  DHEPZ_CHECK(!paths::DirectoryExists(parent));
+}
+
+DHEPZ_TEST(SettingsStore, PersistsAcrossOwnersAndPreservesUnknownSections) {
+  Rig rig;
+  const std::wstring path = UniquePath(L"persist\\settings.json");
+  DHEPZ_CHECK(files::WriteTextAtomic(
+                  path,
+                  LR"({"global":{"theme":"light"},"modules":{"future":{"opaque":{"x":1}}}})")
+                  .ok());
+  {
+    modules::SettingsStore first(rig.window, rig.state.completion_message, path);
+    modules::SettingsStoreCompletion loaded;
+    Load(first, &loaded);
+    DHEPZ_CHECK(loaded.status.ok());
+    std::atomic<bool> saved{false};
+    modules::AsyncRequestToken token;
+    DHEPZ_CHECK(first.StartWriteModule(
+                          L"terminal", L"recent_folders", LR"(["C:\\work"])",
+                          [&](const modules::SettingsStoreCompletion& completion) {
+                            DHEPZ_CHECK(completion.status.ok());
+                            saved = true;
+                          },
+                          &token)
+                    .ok());
+    PumpUntil([&] { return saved.load(); });
+    DHEPZ_CHECK(saved.load());
+  }
+  {
+    modules::SettingsStore second(rig.window, rig.state.completion_message, path);
+    modules::SettingsStoreCompletion loaded;
+    Load(second, &loaded);
+    std::wstring recent;
+    DHEPZ_CHECK(second.ReadModule(L"terminal", L"recent_folders", &recent).ok());
+    DHEPZ_CHECK_EQ(recent, std::wstring(LR"(["C:\\work"])") );
+    std::wstring text;
+    DHEPZ_CHECK(files::ReadText(path, &text).ok());
+    json::Value root;
+    DHEPZ_CHECK(json::Parse(text, &root).ok());
+    const json::Value* modules_value = root.Find(L"modules");
+    DHEPZ_CHECK(modules_value != nullptr);
+    const json::Value* future = modules_value->Find(L"future");
+    DHEPZ_CHECK(future != nullptr && future->Find(L"opaque") != nullptr);
+  }
+}
+
+DHEPZ_TEST(SettingsStore, RapidWritesPersistNewestCompleteSnapshot) {
+  Rig rig;
+  const std::wstring path = UniquePath(L"rapid\\settings.json");
+  modules::SettingsStore store(rig.window, rig.state.completion_message, path);
+  modules::SettingsStoreCompletion loaded;
+  Load(store, &loaded);
+
+  std::atomic<int> completions{0};
+  modules::AsyncRequestToken first_token;
+  modules::AsyncRequestToken second_token;
+  const std::wstring large(1024 * 1024, L'a');
+  DHEPZ_CHECK(store.StartWriteModule(
+                        L"terminal", L"value", large,
+                        [&](const modules::SettingsStoreCompletion&) { ++completions; },
+                        &first_token)
+                  .ok());
+  DHEPZ_CHECK(store.StartWriteModule(
+                        L"terminal", L"value", L"newest",
+                        [&](const modules::SettingsStoreCompletion&) { ++completions; },
+                        &second_token)
+                  .ok());
+  DHEPZ_CHECK(first_token != second_token);
+  PumpUntil([&] { return completions.load() == 2; }, 6000);
+  DHEPZ_CHECK_EQ(completions.load(), 2);
+
+  modules::SettingsStore reloaded(rig.window, rig.state.completion_message, path);
+  Load(reloaded, &loaded);
+  std::wstring value;
+  DHEPZ_CHECK(reloaded.ReadModule(L"terminal", L"value", &value).ok());
+  DHEPZ_CHECK_EQ(value, std::wstring(L"newest"));
+}
+
+DHEPZ_TEST(SettingsStore, CorruptFileReportsDiagnosticAndKeepsDefaults) {
+  Rig rig;
+  const std::wstring path = UniquePath(L"corrupt\\settings.json");
+  DHEPZ_CHECK(files::WriteTextAtomic(path, L"{ broken").ok());
+  modules::SettingsStore store(rig.window, rig.state.completion_message, path);
+  modules::SettingsStoreCompletion loaded;
+  Load(store, &loaded);
+  DHEPZ_CHECK(store.ready());
+  DHEPZ_CHECK(loaded.used_defaults);
+  DHEPZ_CHECK(!loaded.status.ok());
+  DHEPZ_CHECK(loaded.status.Code() == core::ErrorCode::ParseError);
+  DHEPZ_CHECK_EQ(store.diagnostics().size(), static_cast<std::size_t>(1));
+}

--- a/tests/modules/terminal/terminal_state_test.cpp
+++ b/tests/modules/terminal/terminal_state_test.cpp
@@ -27,9 +27,14 @@ class FakeHost final : public modules::ModuleHost {
     settings[std::wstring(key)] = std::wstring(value);
     return core::Ok();
   }
-  core::Status StorageWrite(std::wstring_view, std::wstring_view) override { return core::Ok(); }
-  core::Status StorageRead(std::wstring_view, std::wstring*) override {
-    return core::Err(core::ErrorCode::NotFound, L"no blob");
+  core::Status StartSettingsLoad(modules::HostOperationCallback callback,
+                                 modules::AsyncRequestToken* token) override {
+    token->value = 1;
+    modules::HostOperationCompletion completion;
+    completion.token = *token;
+    completion.kind = modules::HostOperationKind::SettingsLoad;
+    callback(completion);
+    return core::Ok();
   }
   core::Status StartProcess(const modules::ProcessRequest&, modules::HostOperationCallback,
                             modules::AsyncRequestToken*) override {


### PR DESCRIPTION
## Outcome\n\n- adds lazy parent-owned settings persistence at %LOCALAPPDATA%\\dhepz\\state\\settings.json\n- exposes explicit async settings readiness through ModuleHost\n- scopes normal hosts to their own module section while preserving the typed settings:all facet\n- serializes atomic latest-snapshot writes and preserves unknown JSON data\n- removes the fake in-memory StorageRead/StorageWrite contract\n- records the ownership decision in ADR 0002\n\n## Focused local verification\n\n- Debug build + SettingsStore: 7/7\n- SettingsPersistence: 1/1\n- CapabilityFacets: 2/2\n- ModuleContract: 4/4\n- git diff --check\n- boundary scans: no platform/file/path I/O in AppGate or GateHost; no legacy storage APIs remain\n\nThe hosted CI run is the sole full Debug/Release regression for this PR SHA.\n\nCloses #107