### PR TITLE
IC-04: validate linked module composition

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -10,6 +10,7 @@
 
 #include "app_version.h"
 #include "core/json.h"
+#include "modules/gate/app_gate.h"
 #include "platform/files.h"
 #include "platform/performance_trace.h"
 #include "platform/tray_process.h"
@@ -86,6 +87,32 @@ int RunValidateUi(const std::wstring& core_path, const std::wstring& screens_dir
   return 0;
 }
 
+int RunValidateEmbedded() {
+  modules::AppGate gate;
+  const core::Status started = gate.Start();
+  if (!started.ok()) {
+    std::wprintf(L"embedded UI startup failed: %ls\n", started.Message().c_str());
+    return 1;
+  }
+  for (const modules::RejectEntry& reject : gate.Rejects()) {
+    std::wprintf(L"%ls(%d,%d): module %ls: %ls\n", reject.file.c_str(),
+                 reject.line, reject.column, reject.module_id.c_str(),
+                 reject.reason.c_str());
+  }
+  if (!gate.Rejects().empty()) {
+    std::wprintf(L"embedded module contract invalid: %zu rejection(s)\n",
+                 gate.Rejects().size());
+    return 1;
+  }
+  if (!gate.Mounted(L"terminal") || !gate.Mounted(L"diagnostics")) {
+    std::wprintf(L"embedded UI omitted terminal or diagnostics\n");
+    return 1;
+  }
+  std::wprintf(L"embedded UI ok: %zu module(s), %zu route(s)\n",
+               gate.Peers().size(), gate.document()->routes().size());
+  return 0;
+}
+
 }  // namespace
 
 int APIENTRY wWinMain(_In_ HINSTANCE instance,
@@ -102,6 +129,13 @@ int APIENTRY wWinMain(_In_ HINSTANCE instance,
   // Tooling path (#57): validate the UI config and exit, no tray, no window.
   int argc = 0;
   LPWSTR* argv = CommandLineToArgvW(GetCommandLineW(), &argc);
+  for (int i = 0; i < argc && argv != nullptr; ++i) {
+    if (lstrcmpW(argv[i], L"--validate-embedded") == 0) {
+      const int code = RunValidateEmbedded();
+      LocalFree(argv);
+      return code;
+    }
+  }
   for (int i = 0; i + 2 < argc + 1 && argv != nullptr; ++i) {
     if (lstrcmpW(argv[i], L"--validate-ui") == 0 && i + 2 <= argc - 1) {
       const int code = RunValidateUi(argv[i + 1], argv[i + 2]);

--- a/src/modules/gate/app_gate.cpp
+++ b/src/modules/gate/app_gate.cpp
@@ -1,18 +1,15 @@
 #include "modules/gate/app_gate.h"
 
-#include <algorithm>
+#include <utility>
 
-#include "core/json.h"
 #include "modules/gate/config_transaction_service.h"
 #include "modules/gate/gate_host.h"
+#include "modules/gate/gate_startup_service.h"
 #include "modules/gate/settings_access_service.h"
 #include "modules/registry/module_registry.h"
-#include "ui/config/config_store.h"
 
 namespace modules {
 namespace {
-
-std::vector<RegisteredModule> RegistrySnapshot() { return CollectModules(); }
 
 const std::vector<RejectEntry>* g_rejects = nullptr;
 
@@ -28,24 +25,69 @@ AppGate::AppGate()
           std::make_unique<SettingsAccessService>([this]() { return Peers(); })),
       config_service_(std::make_unique<ConfigTransactionService>(
           &document_, &document_generation_)) {}
+
 AppGate::~AppGate() = default;
 
 core::Status AppGate::Start(std::wstring_view override_path) {
-  // Embedded RCDATA read lands here once the resource is wired; tests and
-  // the gate fixtures use StartWithEmbedded.
-  (void)override_path;
-  return core::Err(core::ErrorCode::Unsupported, L"embedded resource read lands with #84");
+  return StartFromResource(L"EMBEDDED_UI", override_path);
+}
+
+core::Status AppGate::StartFromResource(std::wstring_view resource_name,
+                                        std::wstring_view override_path) {
+  if (start_pending_ || document_ != nullptr || !mounted_.empty()) {
+    return core::Err(core::ErrorCode::AlreadyExists,
+                     L"AppGate was already started");
+  }
+  std::wstring embedded;
+  DHEPZ_RETURN_IF_ERROR(
+      GateStartupService::ReadEmbeddedResource(resource_name, &embedded));
+  if (override_path.empty()) {
+    start_status_ = PairAndMount(embedded, {});
+    return start_status_;
+  }
+  if (operation_window_ == nullptr || operation_message_ == 0) {
+    return core::Err(core::ErrorCode::Unsupported,
+                     L"Config override requires the parent worker path");
+  }
+
+  start_pending_ = true;
+  startup_service_ = std::make_unique<GateStartupService>(operation_window_,
+                                                          operation_message_);
+  const std::wstring source(override_path);
+  return startup_service_->ReadOverride(
+      source,
+      [this, embedded = std::move(embedded), source](core::Status read_status,
+                                                     std::wstring override_text) {
+        if (read_status.ok()) {
+          start_status_ = PairAndMount(embedded, override_text);
+          if (!start_status_.ok()) {
+            const core::Status invalid_override = start_status_;
+            start_status_ = PairAndMount(embedded, {});
+            rejects_.push_back({L"config-override", invalid_override.Message(),
+                                source, 1, 1});
+          }
+        } else {
+          start_status_ = PairAndMount(embedded, {});
+          rejects_.push_back(
+              {L"config-override", read_status.Message(), source, 1, 1});
+        }
+        start_pending_ = false;
+      });
 }
 
 core::Status AppGate::StartWithEmbedded(std::wstring_view embedded_text,
                                         std::wstring_view override_text) {
+  if (start_pending_ || document_ != nullptr || !mounted_.empty()) {
+    return core::Err(core::ErrorCode::AlreadyExists,
+                     L"AppGate was already started");
+  }
   return PairAndMount(embedded_text, override_text);
 }
 
-core::Status AppGate::ConfigureHostOperations(void* ui_window,
-                                              unsigned int completion_message,
-                                              HostStatePatchHandler state_patch_handler) {
-  if (!mounted_.empty()) {
+core::Status AppGate::ConfigureHostOperations(
+    void* ui_window, unsigned int completion_message,
+    HostStatePatchHandler state_patch_handler) {
+  if (start_pending_ || document_ != nullptr || !mounted_.empty()) {
     return core::Err(core::ErrorCode::AlreadyExists,
                      L"Host operations must be configured before gate start");
   }
@@ -60,7 +102,7 @@ core::Status AppGate::ConfigureHostOperations(void* ui_window,
 }
 
 core::Status AppGate::ConfigureConfigOverridePath(std::wstring path) {
-  if (!mounted_.empty()) {
+  if (start_pending_ || document_ != nullptr || !mounted_.empty()) {
     return core::Err(core::ErrorCode::AlreadyExists,
                      L"Config path must be configured before gate start");
   }
@@ -68,7 +110,7 @@ core::Status AppGate::ConfigureConfigOverridePath(std::wstring path) {
 }
 
 core::Status AppGate::ConfigureSettingsStorePath(std::wstring path) {
-  if (!mounted_.empty()) {
+  if (start_pending_ || document_ != nullptr || !mounted_.empty()) {
     return core::Err(core::ErrorCode::AlreadyExists,
                      L"Settings path must be configured before gate start");
   }
@@ -82,227 +124,44 @@ AppGate::SettingsDiagnostics() const {
 
 core::Status AppGate::PairAndMount(std::wstring_view embedded_text,
                                    std::wstring_view override_text) {
-  document_.reset();
+  ModuleValidationResult validation;
+  ModuleValidator validator;
+  const core::Status status = validator.Validate(
+      embedded_text, override_text, CollectModules(), &validation);
+  if (!status.ok()) return status;
+
+  document_ = std::move(validation.document);
+  rejects_ = std::move(validation.rejects);
+  grants_ = std::move(validation.grants);
+  action_map_ = std::move(validation.action_map);
   mounted_.clear();
-  rejects_.clear();
-  grants_.clear();
-  action_map_.clear();
-  current_route_.clear();
-  json::Value embedded;
-  DHEPZ_RETURN_IF_ERROR(json::Parse(embedded_text, &embedded));
-  const json::Value* core = embedded.Find(L"core");
-  if (core == nullptr || !core->is_object()) {
-    return core::Err(core::ErrorCode::InvalidArgument,
-                     L"embedded document carries no core catalog");
-  }
-
-  json::Value embedded_screens = json::Value::Object();
-  if (const json::Value* components = embedded.Find(L"components")) {
-    embedded_screens.Set(L"components", *components);
-  }
-  std::vector<ui::config::ScreenSource> sources;
-  sources.push_back({L"embedded", json::Serialize(embedded_screens)});
-  if (!override_text.empty()) {
-    sources.push_back({L"override", std::wstring(override_text)});
-  }
-  std::vector<ui::config::Diagnostic> ui_diags;
-  DHEPZ_RETURN_IF_ERROR(ui::config::ResolveDocument(*core, sources, &ui_diags, &document_));
+  current_route_ = document_ != nullptr ? document_->initial_route() : L"";
   ++document_generation_;
-  config_service_->ConfigureBase(*core, sources.front());
+  config_service_->ConfigureBase(validation.core_catalog,
+                                 validation.accepted_base);
 
-  const std::vector<RegisteredModule> registered = RegistrySnapshot();
-  const json::Value* manifests = embedded.Find(L"modules");
-  bool settings_all_claimed = false;
-  bool config_write_claimed = false;
-
-  if (manifests != nullptr && manifests->is_array()) {
-    for (const json::Value& manifest_value : manifests->items()) {
-      ModuleManifest manifest;
-      std::vector<ManifestDiagnostic> manifest_diags;
-      if (!ParseManifest(json::Serialize(manifest_value), &manifest, &manifest_diags).ok()) {
-        const json::Value* raw_id = manifest_value.Find(L"moduleId");
-        const std::wstring id =
-            (raw_id != nullptr && raw_id->is_string()) ? raw_id->AsString() : L"?";
-        rejects_.push_back({id,
-                            L"manifest invalid: " +
-                                (manifest_diags.empty() ? L"?" : manifest_diags[0].message)});
-        continue;
-      }
-
-      const ModuleFactory* factory = nullptr;
-      for (const RegisteredModule& reg : registered) {
-        if (reg.module_id == manifest.module_id) {
-          factory = &reg.factory;
-          break;
-        }
-      }
-      if (factory == nullptr) {
-        rejects_.push_back({manifest.module_id, L"logic half not self-registered"});
-        continue;
-      }
-
-      // Pairing: a screen half with matching module_id must exist.
-      const ui::config::Route* screen = nullptr;
-      for (const ui::config::Route& route : document_->routes()) {
-        if (route.root.GetString(L"module_id") == manifest.module_id) {
-          screen = &route;
-          break;
-        }
-      }
-      if (screen == nullptr) {
-        rejects_.push_back({manifest.module_id, L"no screen half with matching module_id"});
-        continue;
-      }
-
-      std::unique_ptr<ModuleDescriptor> descriptor = (*factory)();
-      const std::vector<std::wstring> declared = descriptor->DeclaredCapabilities();
-      if (declared != manifest.capabilities) {
-        rejects_.push_back({manifest.module_id,
-                            L"DeclaredCapabilities() does not match module.json"});
-        continue;
-      }
-      {
-        const std::vector<std::wstring> code_actions = descriptor->DeclaredActions();
-        std::vector<std::wstring> missing_in_code;
-        for (const std::wstring& action : manifest.actions) {
-          if (std::find(code_actions.begin(), code_actions.end(), action) ==
-              code_actions.end()) {
-            missing_in_code.push_back(action);
-          }
-        }
-        if (!missing_in_code.empty()) {
-          rejects_.push_back({manifest.module_id,
-                              L"action '" + missing_in_code[0] +
-                                  L"' declared in module.json has no handler in C++"});
-          continue;
-        }
-      }
-      bool capability_ok = true;
-      bool settings_all_granted = false;
-      bool config_write_granted = false;
-      const json::Value* capabilities_value = manifest_value.Find(L"capabilities");
-      const int capability_line = capabilities_value != nullptr
-                                      ? capabilities_value->line()
-                                      : 1;
-      const int capability_column = capabilities_value != nullptr
-                                        ? capabilities_value->column()
-                                        : 1;
-      for (const std::wstring& cap : declared) {
-        if (cap == std::wstring(kCapabilitySettingsAll)) {
-          if (manifest.module_id != L"settings") {
-            rejects_.push_back(
-                {manifest.module_id,
-                 L"settings:all is reserved for module 'settings'",
-                 L"embedded", capability_line, capability_column});
-            capability_ok = false;
-            break;
-          }
-          if (settings_all_claimed) {
-            rejects_.push_back(
-                {manifest.module_id,
-                 L"settings:all already claimed by another module",
-                 L"embedded", capability_line, capability_column});
-            capability_ok = false;
-            break;
-          }
-          settings_all_granted = true;
-        } else if (cap == std::wstring(kCapabilityConfigWrite)) {
-          if (manifest.module_id != L"ui-editor") {
-            rejects_.push_back(
-                {manifest.module_id,
-                 L"config:write is reserved for module 'ui-editor'",
-                 L"embedded", capability_line, capability_column});
-            capability_ok = false;
-            break;
-          }
-          if (config_write_claimed) {
-            rejects_.push_back(
-                {manifest.module_id,
-                 L"config:write already claimed by another module",
-                 L"embedded", capability_line, capability_column});
-            capability_ok = false;
-            break;
-          }
-          config_write_granted = true;
-        } else {
-          rejects_.push_back({manifest.module_id,
-                              L"unknown capability '" + cap + L"'",
-                              L"embedded", capability_line,
-                              capability_column});
-          capability_ok = false;
-          break;
-        }
-      }
-      if (!capability_ok) continue;
-      for (const std::wstring& capability : declared) {
-        grants_.push_back({manifest.module_id, capability, L"embedded",
-                           capability_line, capability_column});
-      }
-
-      if (!manifest.settings_route.empty()) {
-        bool ships = false;
-        for (const ui::config::Route& route : document_->routes()) {
-          if (route.id == manifest.settings_route &&
-              route.root.GetString(L"module_id") == manifest.module_id) {
-            ships = true;
-            break;
-          }
-        }
-        if (!ships) {
-          rejects_.push_back({manifest.module_id,
-                              L"settingsRoute not shipped by this module"});
-          continue;
-        }
-      }
-
-      MountedModule module;
-      module.manifest = std::move(manifest);
-      bool actions_ok = true;
-      for (const std::wstring& action : descriptor->DeclaredActions()) {
-        for (const auto& [existing_action, existing_id] : action_map_) {
-          if (existing_action == action) {
-            rejects_.push_back({module.manifest.module_id,
-                                L"action '" + action + L"' already registered by " +
-                                    existing_id});
-            actions_ok = false;
-            break;
-          }
-        }
-        if (!actions_ok) break;
-      }
-      if (!actions_ok) continue;
-      if (settings_all_granted) settings_all_claimed = true;
-      if (config_write_granted) config_write_claimed = true;
-      for (const std::wstring& action : descriptor->DeclaredActions()) {
-        action_map_.emplace_back(action, module.manifest.module_id);
-      }
-      module.descriptor = std::move(descriptor);
-      module.host = std::make_unique<GateHost>(
-          module.manifest.module_id,
-          [this](std::wstring_view route_id) { return RequestRoute(route_id); },
-          [this]() { return Peers(); }, settings_service_.get(),
-          config_service_.get(), settings_all_granted, config_write_granted,
-          operation_window_, operation_message_,
-          state_patch_handler_);
-      mounted_.push_back(std::move(module));
-    }
+  for (ValidatedModule& accepted : validation.modules) {
+    MountedModule module;
+    module.manifest = std::move(accepted.manifest);
+    module.descriptor = std::move(accepted.descriptor);
+    module.host = std::make_unique<GateHost>(
+        module.manifest.module_id,
+        [this](std::wstring_view route_id) { return RequestRoute(route_id); },
+        [this]() { return Peers(); }, settings_service_.get(),
+        config_service_.get(), accepted.settings_all_granted,
+        accepted.config_write_granted, operation_window_, operation_message_,
+        state_patch_handler_);
+    mounted_.push_back(std::move(module));
   }
-
-  current_route_ = document_->initial_route();
   g_rejects = &rejects_;
   return core::Ok();
 }
 
 AppGate::MountedModule* AppGate::FindByRoute(std::wstring_view route_id) {
-  for (MountedModule& module : mounted_) {
-    if (document_ != nullptr) {
-      const ui::config::Route* route = document_->FindRoute(route_id);
-      if (route != nullptr && route->root.GetString(L"module_id") == module.manifest.module_id) {
-        return &module;
-      }
-    }
-  }
-  return nullptr;
+  if (document_ == nullptr) return nullptr;
+  const ui::config::Route* route = document_->FindRoute(route_id);
+  if (route == nullptr) return nullptr;
+  return FindByModule(route->root.GetString(L"module_id"));
 }
 
 AppGate::MountedModule* AppGate::FindByModule(std::wstring_view module_id) {
@@ -321,18 +180,21 @@ bool AppGate::Mounted(std::wstring_view module_id) const {
 
 core::Status AppGate::Activate(std::wstring_view route_id) {
   MountedModule* module = FindByRoute(route_id);
-  if (module == nullptr) return core::Ok();  // built-in screen: nothing to activate
+  if (module == nullptr) return core::Ok();
   if (module->activated) return core::Ok();
   const core::Status bound = module->descriptor->Bind(*module->host);
   if (!bound.ok()) {
-    rejects_.push_back({module->manifest.module_id, L"Bind failed: " + bound.Message()});
+    rejects_.push_back(
+        {module->manifest.module_id, L"Bind failed: " + bound.Message(),
+         L"runtime", 1, 1});
     return bound;
   }
   module->activated = true;
   return core::Ok();
 }
 
-core::Status AppGate::Dispatch(std::wstring_view action, const json::Value& payload,
+core::Status AppGate::Dispatch(std::wstring_view action,
+                               const json::Value& payload,
                                json::Value* state_patch) {
   for (const auto& [registered_action, module_id] : action_map_) {
     if (registered_action != action) continue;
@@ -347,7 +209,8 @@ core::Status AppGate::Dispatch(std::wstring_view action, const json::Value& payl
     }
     return module->descriptor->Handle(action, payload, state_patch);
   }
-  return core::Err(core::ErrorCode::NotFound, L"no module declares this action");
+  return core::Err(core::ErrorCode::NotFound,
+                   L"no module declares this action");
 }
 
 core::Status AppGate::RequestRoute(std::wstring_view route_id) {

--- a/src/modules/gate/app_gate.h
+++ b/src/modules/gate/app_gate.h
@@ -18,32 +18,18 @@
 #include "modules/contract/module_contract.h"
 #include "modules/contract/module_manifest.h"
 #include "modules/gate/gate_host.h"
+#include "modules/gate/module_validator.h"
 #include "modules/gate/settings_store.h"
 #include "ui/config/resolved_ui_document.h"
 
 namespace modules {
-
-struct RejectEntry {
-  std::wstring module_id;
-  std::wstring reason;
-  std::wstring file;
-  int line = 0;
-  int column = 0;
-};
-
-struct CapabilityGrant {
-  std::wstring module_id;
-  std::wstring capability;
-  std::wstring file;
-  int line = 0;
-  int column = 0;
-};
 
 // Reject list of the most recent gate Start — the diagnostics module reads
 // this; there is exactly one gate (single choke point).
 const std::vector<RejectEntry>& CurrentRejects();
 
 class ConfigTransactionService;
+class GateStartupService;
 class SettingsAccessService;
 
 class AppGate final {
@@ -55,6 +41,9 @@ class AppGate final {
 
   // Runtime path: embedded RCDATA resource (+ optional override file).
   core::Status Start(std::wstring_view override_path = {});
+  // Named-resource seam used by the compiled-resource integration test.
+  core::Status StartFromResource(std::wstring_view resource_name,
+                                 std::wstring_view override_path = {});
   // Test path: explicit texts.
   core::Status StartWithEmbedded(std::wstring_view embedded_text,
                                  std::wstring_view override_text = {});
@@ -68,6 +57,8 @@ class AppGate final {
   core::Status ConfigureSettingsStorePath(std::wstring path);
 
   const ui::config::ResolvedUiDocument* document() const { return document_.get(); }
+  bool start_pending() const { return start_pending_; }
+  const core::Status& start_status() const { return start_status_; }
   std::uint64_t document_generation() const { return document_generation_; }
   std::vector<PeerInfo> Peers() const;
   const std::vector<RejectEntry>& Rejects() const { return rejects_; }
@@ -100,6 +91,7 @@ class AppGate final {
   std::uint64_t document_generation_ = 0;
   std::unique_ptr<SettingsAccessService> settings_service_;
   std::unique_ptr<ConfigTransactionService> config_service_;
+  std::unique_ptr<GateStartupService> startup_service_;
   std::vector<MountedModule> mounted_;
   std::vector<RejectEntry> rejects_;
   std::vector<CapabilityGrant> grants_;
@@ -108,6 +100,8 @@ class AppGate final {
   void* operation_window_ = nullptr;
   unsigned int operation_message_ = 0;
   HostStatePatchHandler state_patch_handler_;
+  bool start_pending_ = false;
+  core::Status start_status_;
 };
 
 }  // namespace modules

--- a/src/modules/gate/gate_startup_service.cpp
+++ b/src/modules/gate/gate_startup_service.cpp
@@ -1,0 +1,93 @@
+#include "modules/gate/gate_startup_service.h"
+
+#include <windows.h>
+
+#include <atomic>
+#include <memory>
+#include <string_view>
+#include <utility>
+
+#include "platform/files.h"
+#include "platform/strings.h"
+#include "platform/worker.h"
+
+namespace modules {
+namespace {
+
+struct StartupReadResult {
+  core::Status status;
+  std::wstring text;
+};
+
+}  // namespace
+
+class GateStartupService::Impl final {
+ public:
+  Impl(void* ui_window, unsigned int completion_message)
+      : worker(ui_window, completion_message),
+        generation(worker.CreateGeneration()) {}
+
+  worker::Worker worker;
+  std::uint64_t generation = 0;
+};
+
+GateStartupService::GateStartupService(void* ui_window,
+                                       unsigned int completion_message)
+    : impl_(std::make_unique<Impl>(ui_window, completion_message)) {}
+
+GateStartupService::~GateStartupService() = default;
+
+core::Status GateStartupService::ReadEmbeddedResource(
+    std::wstring_view resource_name, std::wstring* out) {
+  if (out == nullptr) {
+    return DHEPZ_ERR(core::ErrorCode::InvalidArgument,
+                     L"Embedded UI output is required");
+  }
+  out->clear();
+  const HMODULE module = GetModuleHandleW(nullptr);
+  const std::wstring name(resource_name);
+  const HRSRC resource = FindResourceW(module, name.c_str(), RT_RCDATA);
+  if (resource == nullptr) {
+    return DHEPZ_ERR(core::ErrorCode::NotFound,
+                     L"Embedded UI RCDATA is missing");
+  }
+  const HGLOBAL loaded = LoadResource(module, resource);
+  const DWORD size = SizeofResource(module, resource);
+  const void* bytes = loaded != nullptr ? LockResource(loaded) : nullptr;
+  if (bytes == nullptr || size == 0) {
+    return DHEPZ_ERR(core::ErrorCode::IoError,
+                     L"Embedded UI RCDATA could not be loaded");
+  }
+  return str::FromUtf8(
+      std::string_view(static_cast<const char*>(bytes),
+                       static_cast<std::size_t>(size)),
+      out);
+}
+
+core::Status GateStartupService::ReadOverride(std::wstring path,
+                                              StartupReadCallback callback) {
+  if (path.empty() || !callback) {
+    return DHEPZ_ERR(core::ErrorCode::InvalidArgument,
+                     L"Override path and completion are required");
+  }
+  impl_->worker.Submit(
+      [path = std::move(path)](const std::atomic<bool>& cancelled) {
+        auto result = std::make_shared<StartupReadResult>();
+        if (cancelled.load()) {
+          result->status = core::Err(core::ErrorCode::Cancelled,
+                                     L"Config override read was cancelled");
+        } else {
+          result->status = files::ReadText(path, &result->text);
+        }
+        return std::static_pointer_cast<void>(result);
+      },
+      [callback = std::move(callback)](std::shared_ptr<void> cargo) {
+        const auto result =
+            std::static_pointer_cast<StartupReadResult>(std::move(cargo));
+        callback(result->status, std::move(result->text));
+      },
+      impl_->generation);
+  return core::Ok();
+}
+
+}  // namespace modules

--- a/src/modules/gate/gate_startup_service.h
+++ b/src/modules/gate/gate_startup_service.h
@@ -1,0 +1,33 @@
+// Parent startup adapter: reads embedded RCDATA in memory and optional user
+// override text on a run-once worker. AppGate only orchestrates the result.
+#pragma once
+
+#include <functional>
+#include <memory>
+#include <string>
+#include <string_view>
+
+#include "core/status.h"
+
+namespace modules {
+
+using StartupReadCallback =
+    std::function<void(core::Status status, std::wstring text)>;
+
+class GateStartupService final {
+ public:
+  GateStartupService(void* ui_window, unsigned int completion_message);
+  ~GateStartupService();
+  GateStartupService(const GateStartupService&) = delete;
+  GateStartupService& operator=(const GateStartupService&) = delete;
+
+  static core::Status ReadEmbeddedResource(std::wstring_view resource_name,
+                                           std::wstring* out);
+  core::Status ReadOverride(std::wstring path, StartupReadCallback callback);
+
+ private:
+  class Impl;
+  std::unique_ptr<Impl> impl_;
+};
+
+}  // namespace modules

--- a/src/modules/gate/module_validator.cpp
+++ b/src/modules/gate/module_validator.cpp
@@ -1,0 +1,605 @@
+#include "modules/gate/module_validator.h"
+
+#include <algorithm>
+#include <set>
+#include <utility>
+
+namespace modules {
+namespace {
+
+bool SameUniqueStrings(const std::vector<std::wstring>& left,
+                       const std::vector<std::wstring>& right) {
+  const std::set<std::wstring> left_set(left.begin(), left.end());
+  const std::set<std::wstring> right_set(right.begin(), right.end());
+  return left_set.size() == left.size() && right_set.size() == right.size() &&
+         left_set == right_set;
+}
+
+const json::Value* NodeProperty(const ui::config::ComponentNode& node,
+                                std::wstring_view name) {
+  for (const auto& [key, value] : node.properties_) {
+    if (key == name) return &value;
+  }
+  return nullptr;
+}
+
+void CollectBindings(const json::Value& value,
+                     std::set<std::wstring>* bindings) {
+  if (value.is_object()) {
+    if (const json::Value* binding = value.Find(L"$bind");
+        binding != nullptr && binding->is_string() &&
+        value.members().size() == 1) {
+      bindings->insert(binding->AsString());
+      return;
+    }
+    for (const auto& [key, member] : value.members()) {
+      (void)key;
+      CollectBindings(member, bindings);
+    }
+  } else if (value.is_array()) {
+    for (const json::Value& item : value.items()) {
+      CollectBindings(item, bindings);
+    }
+  }
+}
+
+const json::Value* FindBinding(const json::Value& value,
+                               std::wstring_view reference) {
+  if (value.is_object()) {
+    if (const json::Value* binding = value.Find(L"$bind");
+        binding != nullptr && binding->is_string() &&
+        value.members().size() == 1 && binding->AsString() == reference) {
+      return binding;
+    }
+    for (const auto& [key, member] : value.members()) {
+      (void)key;
+      if (const json::Value* found = FindBinding(member, reference)) return found;
+    }
+  } else if (value.is_array()) {
+    for (const json::Value& item : value.items()) {
+      if (const json::Value* found = FindBinding(item, reference)) return found;
+    }
+  }
+  return nullptr;
+}
+
+void CollectReferences(const ui::config::ComponentNode& node,
+                       std::set<std::wstring>* actions,
+                       std::set<std::wstring>* bindings,
+                       std::set<std::wstring>* styles) {
+  for (const auto& [key, value] : node.properties_) {
+    CollectBindings(value, bindings);
+    if (key == L"action" && value.is_string()) {
+      actions->insert(value.AsString());
+    } else if (key.find(L"binding") != std::wstring::npos &&
+               value.is_string()) {
+      std::wstring binding = value.AsString();
+      if (!binding.empty() && binding.front() == L'$') binding.erase(binding.begin());
+      bindings->insert(std::move(binding));
+    } else if (key == L"style" && value.is_string()) {
+      styles->insert(value.AsString());
+    }
+  }
+  for (const ui::config::ComponentNode& child : node.children_) {
+    CollectReferences(child, actions, bindings, styles);
+  }
+}
+
+const json::Value* FindReferenceValue(const ui::config::ComponentNode& node,
+                                      std::wstring_view kind,
+                                      std::wstring_view reference) {
+  for (const auto& [key, value] : node.properties_) {
+    if (kind == L"binding") {
+      if (const json::Value* found = FindBinding(value, reference)) return found;
+    }
+    if (!value.is_string()) continue;
+    bool kind_matches = key == kind;
+    if (kind == L"binding") {
+      kind_matches = key.find(L"binding") != std::wstring::npos;
+    }
+    if (!kind_matches) continue;
+    std::wstring candidate = value.AsString();
+    if (kind == L"binding" && !candidate.empty() &&
+        candidate.front() == L'$') {
+      candidate.erase(candidate.begin());
+    }
+    if (candidate == reference) return &value;
+  }
+  for (const ui::config::ComponentNode& child : node.children_) {
+    if (const json::Value* found = FindReferenceValue(child, kind, reference)) {
+      return found;
+    }
+  }
+  return nullptr;
+}
+
+std::wstring ScreenSourceForModule(
+    const std::vector<ui::config::ScreenSource>& sources,
+    std::wstring_view module_id) {
+  for (const ui::config::ScreenSource& source : sources) {
+    json::Value document;
+    if (!json::Parse(source.text, &document).ok()) continue;
+    const json::Value* components = document.Find(L"components");
+    if (components == nullptr || !components->is_array()) continue;
+    for (const json::Value& component : components->items()) {
+      if (component.StringField(L"module_id") == module_id) return source.name;
+    }
+  }
+  return L"embedded";
+}
+
+std::set<std::wstring> SourceModuleIds(
+    const ui::config::ScreenSource& source) {
+  std::set<std::wstring> ids;
+  json::Value document;
+  if (!json::Parse(source.text, &document).ok()) return ids;
+  const json::Value* components = document.Find(L"components");
+  if (components == nullptr || !components->is_array()) return ids;
+  for (const json::Value& component : components->items()) {
+    const std::wstring id = component.StringField(L"module_id");
+    if (!id.empty()) ids.insert(id);
+  }
+  return ids;
+}
+
+bool StyleExists(const json::Value& core, std::wstring_view style) {
+  const json::Value* styles = core.ObjectField(L"styles");
+  return styles != nullptr && styles->Find(style) != nullptr;
+}
+
+ui::config::ScreenSource FilterAcceptedSource(
+    const ui::config::ScreenSource& source,
+    const std::set<std::wstring>& accepted_modules) {
+  json::Value document;
+  if (!json::Parse(source.text, &document).ok()) return source;
+  const json::Value* components = document.Find(L"components");
+  if (components == nullptr || !components->is_array()) return source;
+  json::Value filtered = json::Value::Object();
+  json::Value kept = json::Value::Array();
+  for (const json::Value& component : components->items()) {
+    const std::wstring module_id = component.StringField(L"module_id");
+    if (module_id.empty() || accepted_modules.contains(module_id)) {
+      kept.Append(component);
+    }
+  }
+  filtered.Set(L"components", std::move(kept));
+  return {source.name, json::Serialize(filtered)};
+}
+
+core::Status ParseEnvelope(
+    std::wstring_view embedded_text, std::wstring_view override_text,
+    json::Value* envelope, json::Value* core_catalog,
+    std::vector<ui::config::ScreenSource>* sources,
+    std::size_t* shipped_source_count) {
+  DHEPZ_RETURN_IF_ERROR(json::Parse(embedded_text, envelope));
+  const json::Value* core = envelope->Find(L"core");
+  json::Value parsed_core;
+  if (const json::Value* core_text = envelope->Find(L"coreText");
+      core_text != nullptr && core_text->is_string()) {
+    DHEPZ_RETURN_IF_ERROR(json::Parse(core_text->AsString(), &parsed_core));
+    core = &parsed_core;
+  }
+  if (core == nullptr || !core->is_object()) {
+    return DHEPZ_ERR(core::ErrorCode::InvalidArgument,
+                     L"Embedded document carries no core catalog");
+  }
+  *core_catalog = *core;
+
+  if (const json::Value* entries = envelope->Find(L"sources");
+      entries != nullptr && entries->is_array()) {
+    for (const json::Value& entry : entries->items()) {
+      const json::Value* file = entry.Find(L"file");
+      const json::Value* text = entry.Find(L"text");
+      if (file == nullptr || !file->is_string() || text == nullptr ||
+          !text->is_string()) {
+        return DHEPZ_ERR(core::ErrorCode::InvalidArgument,
+                         L"Embedded screen source requires file and text");
+      }
+      sources->push_back({file->AsString(), text->AsString()});
+    }
+  } else {
+    json::Value screens = json::Value::Object();
+    if (const json::Value* components = envelope->Find(L"components")) {
+      screens.Set(L"components", *components);
+    }
+    sources->push_back({L"embedded", json::Serialize(screens)});
+  }
+  if (sources->empty()) {
+    return DHEPZ_ERR(core::ErrorCode::InvalidArgument,
+                     L"Embedded document carries no screen sources");
+  }
+  *shipped_source_count = sources->size();
+  if (!override_text.empty()) {
+    sources->push_back({L"override", std::wstring(override_text)});
+  }
+  return core::Ok();
+}
+
+}  // namespace
+
+core::Status ModuleValidator::Validate(
+    std::wstring_view embedded_text, std::wstring_view override_text,
+    const std::vector<RegisteredModule>& registered,
+    ModuleValidationResult* out) const {
+  if (out == nullptr) {
+    return DHEPZ_ERR(core::ErrorCode::InvalidArgument,
+                     L"Module validation output is required");
+  }
+  *out = {};
+  json::Value envelope;
+  std::vector<ui::config::ScreenSource> sources;
+  std::size_t shipped_source_count = 0;
+  DHEPZ_RETURN_IF_ERROR(ParseEnvelope(embedded_text, override_text, &envelope,
+                                      &out->core_catalog, &sources,
+                                      &shipped_source_count));
+
+  // A schema-broken module source is quarantined before the combined resolve,
+  // so one bad child cannot remove the parent shell or healthy siblings.
+  std::set<std::wstring> schema_rejected;
+  std::vector<ui::config::ScreenSource> resolvable_sources;
+  std::size_t resolvable_shipped_count = 0;
+  for (std::size_t source_index = 0; source_index < sources.size();
+       ++source_index) {
+    const ui::config::ScreenSource& source = sources[source_index];
+    const std::set<std::wstring> ids = SourceModuleIds(source);
+    if (source_index < shipped_source_count && ids.size() == 1) {
+      std::vector<ui::config::Diagnostic> diagnostics;
+      std::unique_ptr<ui::config::ResolvedUiDocument> isolated;
+      const core::Status valid = ui::config::ResolveDocument(
+          out->core_catalog, {source}, &diagnostics, &isolated);
+      if (!valid.ok()) {
+        const ui::config::Diagnostic diagnostic =
+            diagnostics.empty() ? ui::config::Diagnostic{} : diagnostics.front();
+        const std::wstring id = *ids.begin();
+        out->rejects.push_back(
+            {id,
+             diagnostic.message.empty() ? valid.Message() : diagnostic.message,
+             source.name, diagnostic.line > 0 ? diagnostic.line : 1,
+             diagnostic.column > 0 ? diagnostic.column : 1});
+        schema_rejected.insert(id);
+        continue;
+      }
+    }
+    resolvable_sources.push_back(source);
+    if (source_index < shipped_source_count) ++resolvable_shipped_count;
+  }
+
+  std::vector<ui::config::Diagnostic> ui_diagnostics;
+  std::unique_ptr<ui::config::ResolvedUiDocument> candidate_document;
+  const core::Status resolved = ui::config::ResolveDocument(
+      out->core_catalog, resolvable_sources, &ui_diagnostics,
+      &candidate_document);
+  if (!resolved.ok()) return resolved;
+
+  const json::Value* manifests = envelope.Find(L"modules");
+  std::set<std::wstring> manifest_ids;
+  std::set<std::wstring> accepted_ids;
+  bool settings_all_claimed = false;
+  bool config_write_claimed = false;
+
+  if (manifests != nullptr && manifests->is_array()) {
+    for (const json::Value& manifest_entry : manifests->items()) {
+      json::Value parsed_manifest;
+      const json::Value* manifest_value = &manifest_entry;
+      std::wstring manifest_file = L"embedded";
+      std::wstring manifest_text = json::Serialize(manifest_entry);
+      if (const json::Value* raw_text = manifest_entry.Find(L"text");
+          raw_text != nullptr && raw_text->is_string()) {
+        if (const json::Value* file = manifest_entry.Find(L"file");
+            file != nullptr && file->is_string()) {
+          manifest_file = file->AsString();
+        }
+        manifest_text = raw_text->AsString();
+        const core::Status parsed = json::Parse(manifest_text, &parsed_manifest);
+        if (!parsed.ok()) {
+          out->rejects.push_back(
+              {L"?", L"manifest invalid: " + parsed.Message(), manifest_file, 1, 1});
+          continue;
+        }
+        manifest_value = &parsed_manifest;
+      }
+
+      const json::Value* raw_id = manifest_value->Find(L"moduleId");
+      const std::wstring hinted_id =
+          raw_id != nullptr && raw_id->is_string() ? raw_id->AsString() : L"?";
+      manifest_ids.insert(hinted_id);
+      if (schema_rejected.contains(hinted_id)) continue;
+
+      ModuleManifest manifest;
+      std::vector<ManifestDiagnostic> manifest_diagnostics;
+      if (!ParseManifest(manifest_text, &manifest, &manifest_diagnostics).ok()) {
+        const ManifestDiagnostic diagnostic = manifest_diagnostics.empty()
+                                                  ? ManifestDiagnostic{}
+                                                  : manifest_diagnostics.front();
+        out->rejects.push_back(
+            {hinted_id,
+             L"manifest invalid: " +
+                 (diagnostic.message.empty() ? L"unknown error"
+                                             : diagnostic.message),
+             manifest_file, diagnostic.line > 0 ? diagnostic.line : 1,
+             diagnostic.column > 0 ? diagnostic.column : 1});
+        continue;
+      }
+      const int manifest_line = raw_id != nullptr ? raw_id->line() : 1;
+      const int manifest_column = raw_id != nullptr ? raw_id->column() : 1;
+      auto reject = [&](std::wstring reason, std::wstring file = {}, int line = 0,
+                        int column = 0) {
+        out->rejects.push_back(
+            {manifest.module_id, std::move(reason),
+             file.empty() ? manifest_file : std::move(file),
+             line > 0 ? line : manifest_line,
+             column > 0 ? column : manifest_column});
+      };
+
+      const RegisteredModule* registration = nullptr;
+      for (const RegisteredModule& item : registered) {
+        if (item.module_id == manifest.module_id) {
+          registration = &item;
+          break;
+        }
+      }
+      if (registration == nullptr) {
+        reject(L"logic half not self-registered");
+        continue;
+      }
+
+      std::vector<const ui::config::Route*> module_routes;
+      for (const ui::config::Route& route : candidate_document->routes()) {
+        if (route.root.GetString(L"module_id") == manifest.module_id) {
+          module_routes.push_back(&route);
+        }
+      }
+      if (module_routes.empty()) {
+        reject(L"no screen half with matching module_id");
+        continue;
+      }
+
+      std::unique_ptr<ModuleDescriptor> descriptor = registration->factory();
+      const std::wstring screen_file =
+          ScreenSourceForModule(resolvable_sources, manifest.module_id);
+      if (descriptor->ModuleId() != manifest.module_id ||
+          descriptor->TabLabel() != manifest.tab_label ||
+          descriptor->Order() != manifest.order ||
+          descriptor->ShowInTabs() != manifest.show_in_tabs ||
+          descriptor->SettingsRoute() != manifest.settings_route) {
+        reject(L"descriptor metadata does not match module.json");
+        continue;
+      }
+      const std::vector<std::wstring> code_actions =
+          descriptor->DeclaredActions();
+      if (!SameUniqueStrings(code_actions, manifest.actions)) {
+        std::wstring reason = L"DeclaredActions() contains duplicates";
+        for (const std::wstring& action : manifest.actions) {
+          if (std::find(code_actions.begin(), code_actions.end(), action) ==
+              code_actions.end()) {
+            reason = L"action '" + action +
+                     L"' declared in module.json has no C++ handler";
+            break;
+          }
+        }
+        if (reason.find(L"duplicates") != std::wstring::npos) {
+          for (const std::wstring& action : code_actions) {
+            if (std::find(manifest.actions.begin(), manifest.actions.end(), action) ==
+                manifest.actions.end()) {
+              reason = L"C++ action '" + action +
+                       L"' is not declared in module.json";
+              break;
+            }
+          }
+        }
+        reject(std::move(reason));
+        continue;
+      }
+      if (!SameUniqueStrings(descriptor->DeclaredBindings(), manifest.bindings)) {
+        reject(L"DeclaredBindings() does not match module.json");
+        continue;
+      }
+      if (!SameUniqueStrings(descriptor->DeclaredCapabilities(),
+                             manifest.capabilities)) {
+        reject(L"DeclaredCapabilities() does not match module.json");
+        continue;
+      }
+
+      const ui::config::Route* primary = module_routes.front();
+      if ((primary->root.Has(L"tab_label") &&
+           primary->tab_label != manifest.tab_label) ||
+          primary->show_in_tabs != manifest.show_in_tabs) {
+        const json::Value* at = primary->root.Has(L"tab_label")
+                                    ? NodeProperty(primary->root, L"tab_label")
+                                    : NodeProperty(primary->root, L"show_in_tabs");
+        reject(L"screen metadata does not match module.json", screen_file,
+               at != nullptr ? at->line() : 1,
+               at != nullptr ? at->column() : 1);
+        continue;
+      }
+
+      std::set<std::wstring> referenced_actions;
+      std::set<std::wstring> referenced_bindings;
+      std::set<std::wstring> referenced_styles;
+      for (const ui::config::Route* route : module_routes) {
+        CollectReferences(route->root, &referenced_actions, &referenced_bindings,
+                          &referenced_styles);
+      }
+      const std::set<std::wstring> action_set(manifest.actions.begin(),
+                                              manifest.actions.end());
+      const std::set<std::wstring> binding_set(manifest.bindings.begin(),
+                                               manifest.bindings.end());
+      bool references_ok = true;
+      for (const std::wstring& action : referenced_actions) {
+        if (!action_set.contains(action)) {
+          const json::Value* at =
+              FindReferenceValue(primary->root, L"action", action);
+          reject(L"screen references undeclared action '" + action + L"'",
+                 screen_file, at != nullptr ? at->line() : 1,
+                 at != nullptr ? at->column() : 1);
+          references_ok = false;
+          break;
+        }
+      }
+      if (references_ok) {
+        for (const std::wstring& binding : referenced_bindings) {
+          if (!binding.empty() && !binding_set.contains(binding)) {
+            const json::Value* at =
+                FindReferenceValue(primary->root, L"binding", binding);
+            reject(L"screen references undeclared binding '" + binding + L"'",
+                   screen_file, at != nullptr ? at->line() : 1,
+                   at != nullptr ? at->column() : 1);
+            references_ok = false;
+            break;
+          }
+        }
+      }
+      if (references_ok) {
+        for (const std::wstring& style : referenced_styles) {
+          if (!style.empty() && !StyleExists(out->core_catalog, style)) {
+            const json::Value* at =
+                FindReferenceValue(primary->root, L"style", style);
+            reject(L"screen references unknown style '" + style + L"'",
+                   screen_file, at != nullptr ? at->line() : 1,
+                   at != nullptr ? at->column() : 1);
+            references_ok = false;
+            break;
+          }
+        }
+      }
+      if (!references_ok) continue;
+
+      bool settings_all_granted = false;
+      bool config_write_granted = false;
+      const json::Value* capabilities = manifest_value->Find(L"capabilities");
+      const int capability_line = capabilities != nullptr ? capabilities->line() : 1;
+      const int capability_column =
+          capabilities != nullptr ? capabilities->column() : 1;
+      bool capability_ok = true;
+      for (const std::wstring& capability : manifest.capabilities) {
+        if (capability == kCapabilitySettingsAll) {
+          if (manifest.module_id != L"settings") {
+            reject(L"settings:all is reserved for module 'settings'",
+                   manifest_file, capability_line, capability_column);
+            capability_ok = false;
+            break;
+          }
+          if (settings_all_claimed) {
+            reject(L"settings:all already claimed by module 'settings'",
+                   manifest_file, capability_line, capability_column);
+            capability_ok = false;
+            break;
+          }
+          settings_all_granted = true;
+        } else if (capability == kCapabilityConfigWrite) {
+          if (manifest.module_id != L"ui-editor") {
+            reject(L"config:write is reserved for module 'ui-editor'",
+                   manifest_file, capability_line, capability_column);
+            capability_ok = false;
+            break;
+          }
+          if (config_write_claimed) {
+            reject(L"config:write already claimed by module 'ui-editor'",
+                   manifest_file, capability_line, capability_column);
+            capability_ok = false;
+            break;
+          }
+          config_write_granted = true;
+        } else {
+          reject(L"unknown capability '" + capability + L"'", manifest_file,
+                 capability_line, capability_column);
+          capability_ok = false;
+          break;
+        }
+      }
+      if (!capability_ok) continue;
+
+      if (!manifest.settings_route.empty()) {
+        const ui::config::Route* settings_route =
+            candidate_document->FindRoute(manifest.settings_route);
+        if (settings_route == nullptr ||
+            settings_route->root.GetString(L"module_id") != manifest.module_id) {
+          reject(L"settingsRoute not shipped by this module");
+          continue;
+        }
+      }
+
+      bool actions_unique = true;
+      for (const std::wstring& action : manifest.actions) {
+        for (const auto& [existing, owner] : out->action_map) {
+          if (existing == action) {
+            reject(L"action '" + action + L"' already registered by " + owner);
+            actions_unique = false;
+            break;
+          }
+        }
+        if (!actions_unique) break;
+      }
+      if (!actions_unique) continue;
+
+      if (settings_all_granted) settings_all_claimed = true;
+      if (config_write_granted) config_write_claimed = true;
+      for (const std::wstring& action : manifest.actions) {
+        out->action_map.emplace_back(action, manifest.module_id);
+      }
+      if (settings_all_granted) {
+        out->grants.push_back({manifest.module_id,
+                              std::wstring(kCapabilitySettingsAll), manifest_file,
+                              capability_line, capability_column});
+      }
+      if (config_write_granted) {
+        out->grants.push_back({manifest.module_id,
+                              std::wstring(kCapabilityConfigWrite), manifest_file,
+                              capability_line, capability_column});
+      }
+      accepted_ids.insert(manifest.module_id);
+      out->modules.push_back({std::move(manifest), std::move(descriptor),
+                              settings_all_granted, config_write_granted});
+    }
+  }
+
+  std::set<std::wstring> screen_module_ids;
+  for (const ui::config::Route& route : candidate_document->routes()) {
+    const std::wstring id = route.root.GetString(L"module_id");
+    if (!id.empty()) screen_module_ids.insert(id);
+  }
+  for (const std::wstring& id : screen_module_ids) {
+    if (!manifest_ids.contains(id)) {
+      out->rejects.push_back({id, L"screen half has no module.json manifest",
+                              ScreenSourceForModule(resolvable_sources, id), 1, 1});
+    }
+  }
+  for (const RegisteredModule& registration : registered) {
+    if (!manifest_ids.contains(registration.module_id) &&
+        !screen_module_ids.contains(registration.module_id)) {
+      out->rejects.push_back({registration.module_id,
+                              L"logic half has no module.json manifest",
+                              L"registry", 1, 1});
+    }
+  }
+
+  std::vector<ui::config::ScreenSource> accepted_sources;
+  accepted_sources.reserve(resolvable_sources.size());
+  for (const ui::config::ScreenSource& source : resolvable_sources) {
+    accepted_sources.push_back(FilterAcceptedSource(source, accepted_ids));
+  }
+  std::vector<ui::config::Diagnostic> accepted_diagnostics;
+  DHEPZ_RETURN_IF_ERROR(ui::config::ResolveDocument(
+      out->core_catalog, accepted_sources, &accepted_diagnostics, &out->document));
+
+  json::Value accepted_document = json::Value::Object();
+  json::Value accepted_components = json::Value::Array();
+  for (std::size_t index = 0;
+       index < accepted_sources.size() && index < resolvable_shipped_count;
+       ++index) {
+    json::Value source_document;
+    DHEPZ_RETURN_IF_ERROR(
+        json::Parse(accepted_sources[index].text, &source_document));
+    if (const json::Value* components = source_document.Find(L"components");
+        components != nullptr && components->is_array()) {
+      for (const json::Value& component : components->items()) {
+        accepted_components.Append(component);
+      }
+    }
+  }
+  accepted_document.Set(L"components", std::move(accepted_components));
+  out->accepted_base = {L"embedded", json::Serialize(accepted_document)};
+  return core::Ok();
+}
+
+}  // namespace modules

--- a/src/modules/gate/module_validator.h
+++ b/src/modules/gate/module_validator.h
@@ -1,0 +1,60 @@
+// Symmetric module contract validator. It compares all three module halves
+// (descriptor, manifest, screens) and returns only accepted routes/modules.
+#pragma once
+
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "core/json.h"
+#include "core/status.h"
+#include "modules/contract/module_contract.h"
+#include "modules/contract/module_manifest.h"
+#include "modules/registry/module_registry.h"
+#include "ui/config/resolved_ui_document.h"
+
+namespace modules {
+
+struct RejectEntry {
+  std::wstring module_id;
+  std::wstring reason;
+  std::wstring file;
+  int line = 0;
+  int column = 0;
+};
+
+struct CapabilityGrant {
+  std::wstring module_id;
+  std::wstring capability;
+  std::wstring file;
+  int line = 0;
+  int column = 0;
+};
+
+struct ValidatedModule {
+  ModuleManifest manifest;
+  std::unique_ptr<ModuleDescriptor> descriptor;
+  bool settings_all_granted = false;
+  bool config_write_granted = false;
+};
+
+struct ModuleValidationResult {
+  json::Value core_catalog;
+  ui::config::ScreenSource accepted_base;
+  std::unique_ptr<ui::config::ResolvedUiDocument> document;
+  std::vector<ValidatedModule> modules;
+  std::vector<RejectEntry> rejects;
+  std::vector<CapabilityGrant> grants;
+  std::vector<std::pair<std::wstring, std::wstring>> action_map;
+};
+
+class ModuleValidator final {
+ public:
+  core::Status Validate(std::wstring_view embedded_text,
+                        std::wstring_view override_text,
+                        const std::vector<RegisteredModule>& registered,
+                        ModuleValidationResult* out) const;
+};
+
+}  // namespace modules

--- a/tests/app_icon.rc
+++ b/tests/app_icon.rc
@@ -5,3 +5,6 @@
 // The test binary embeds the same icon so the resource-level assertions in
 // app_icon_test.cpp run against a real compiled icon, not a file read.
 IDI_APP_ICON ICON "..\\assets\\app.ico"
+
+// Compiled-resource seam for AppGate startup/override integration tests.
+APP_GATE_TEST_UI RCDATA "fixtures\\app_gate_embedded.json"

--- a/tests/fixtures/app_gate_embedded.json
+++ b/tests/fixtures/app_gate_embedded.json
@@ -1,0 +1,37 @@
+{
+  "core": {
+    "schema": "dhepz.ui.core",
+    "version": 1,
+    "tokens": {
+      "dark": { "text": "#ffffff" },
+      "light": { "text": "#000000" }
+    },
+    "allows_children": ["screen"],
+    "components": {
+      "screen": {
+        "properties": {
+          "route_id": { "kind": "string", "required": true },
+          "module_id": { "kind": "string" },
+          "tab_label": { "kind": "string" }
+        }
+      }
+    }
+  },
+  "components": [
+    {
+      "type": "screen",
+      "route_id": "resource-alpha",
+      "module_id": "resource-alpha",
+      "tab_label": "resource-alpha"
+    }
+  ],
+  "modules": [
+    {
+      "moduleId": "resource-alpha",
+      "tabLabel": "resource-alpha",
+      "actions": [],
+      "bindings": [],
+      "capabilities": []
+    }
+  ]
+}

--- a/tests/modules/diagnostics/diagnostics_test.cpp
+++ b/tests/modules/diagnostics/diagnostics_test.cpp
@@ -81,6 +81,13 @@ std::wstring ScreenFor(const wchar_t* id) {
          L"\", \"children\": [ { \"type\": \"text\", \"text\": \"x\" } ] }";
 }
 
+std::wstring DiagnosticsScreen() {
+  return L"{ \"type\": \"screen\", \"route_id\": \"diagnostics\", "
+         L"\"module_id\": \"diagnostics\", \"tab_label\": \"Diagnostics\", "
+         L"\"show_in_tabs\": false, \"children\": [ "
+         L"{ \"type\": \"text\", \"text\": \"x\" } ] }";
+}
+
 }  // namespace
 
 DHEPZ_TEST(Diagnostics, ThreeFoldersHealthyActiveBrokenReported) {
@@ -89,8 +96,9 @@ DHEPZ_TEST(Diagnostics, ThreeFoldersHealthyActiveBrokenReported) {
   modules::RegisterModule(L"typo", &MakeTypo);
   modules::RegisterModule(L"diagnostics", &modules::MakeDiagnosticsForTests);
 
-  const std::wstring screens = ScreenFor(L"alpha") + L", " + ScreenFor(L"typo") + L", " +
-                               ScreenFor(L"diagnostics");
+  const std::wstring screens = ScreenFor(L"alpha") + L", " +
+                               ScreenFor(L"typo") + L", " +
+                               DiagnosticsScreen();
   // alpha healthy; typo declares the correct action name in module.json but
   // the code registered the misspelling; malformed manifest does not parse.
   // "broken" fails schema validation (missing tabLabel) — the runtime form
@@ -101,7 +109,8 @@ DHEPZ_TEST(Diagnostics, ThreeFoldersHealthyActiveBrokenReported) {
       L"{ \"moduleId\": \"broken\" }";
   const std::wstring diagnostics_manifest =
       L"{ \"moduleId\": \"diagnostics\", \"tabLabel\": \"Diagnostics\", "
-        L"\"showInTabs\": false, \"actions\": [\"diagnostics:refresh\"] }";
+        L"\"order\": 900, \"showInTabs\": false, "
+        L"\"actions\": [\"diagnostics:refresh\"] }";
   const std::wstring embedded = L"{ \"core\": " + W(kCore) + L", \"components\": [ " +
                                 screens + L" ], \"modules\": [ " + manifests + L", " +
                                 diagnostics_manifest + L" ] }";

--- a/tests/modules/gate/app_gate_startup_test.cpp
+++ b/tests/modules/gate/app_gate_startup_test.cpp
@@ -1,0 +1,114 @@
+#include "modules/gate/app_gate.h"
+
+#include <windows.h>
+
+#include <chrono>
+#include <memory>
+#include <string>
+#include <thread>
+
+#include "framework/test_case.h"
+#include "modules/registry/module_registry.h"
+#include "platform/worker.h"
+
+namespace {
+
+class ResourceAlpha final : public modules::ModuleDescriptor {
+ public:
+  std::wstring_view ModuleId() const override { return L"resource-alpha"; }
+  std::wstring_view TabLabel() const override { return L"resource-alpha"; }
+  int Order() const override { return 100; }
+  bool ShowInTabs() const override { return true; }
+  std::wstring_view SettingsRoute() const override { return {}; }
+  std::vector<std::wstring> DeclaredActions() const override { return {}; }
+  std::vector<std::wstring> DeclaredBindings() const override { return {}; }
+  std::vector<std::wstring> DeclaredCapabilities() const override { return {}; }
+  core::Status Bind(modules::ModuleHost&) override { return core::Ok(); }
+  core::Status Handle(std::wstring_view, const json::Value&,
+                      json::Value*) override {
+    return core::Ok();
+  }
+  void Release() override {}
+};
+
+std::unique_ptr<modules::ModuleDescriptor> MakeResourceAlpha() {
+  return std::make_unique<ResourceAlpha>();
+}
+
+struct StartupRigState {
+  unsigned int completion_message = 0;
+};
+StartupRigState* g_startup_rig = nullptr;
+
+LRESULT CALLBACK StartupRigProc(HWND window, UINT message, WPARAM wparam,
+                                LPARAM lparam) {
+  if (g_startup_rig != nullptr &&
+      message == g_startup_rig->completion_message) {
+    worker::Worker::Settle(lparam);
+    return 0;
+  }
+  return DefWindowProcW(window, message, wparam, lparam);
+}
+
+struct StartupRig {
+  HWND window = nullptr;
+  StartupRigState state;
+  StartupRig() {
+    g_startup_rig = &state;
+    WNDCLASSW cls{};
+    cls.lpfnWndProc = StartupRigProc;
+    cls.hInstance = GetModuleHandleW(nullptr);
+    cls.lpszClassName = L"dhepz.app-gate-startup.test";
+    RegisterClassW(&cls);
+    state.completion_message =
+        RegisterWindowMessageW(L"dhepz.app-gate-startup.completion");
+    window = CreateWindowExW(0, cls.lpszClassName, L"", WS_POPUP, 0, 0, 16,
+                             16, nullptr, nullptr, cls.hInstance, nullptr);
+    DHEPZ_CHECK(window != nullptr);
+  }
+  ~StartupRig() {
+    if (window != nullptr) DestroyWindow(window);
+    g_startup_rig = nullptr;
+  }
+};
+
+template <typename Predicate>
+void PumpUntil(Predicate predicate, int timeout_ms = 2000) {
+  const auto deadline = std::chrono::steady_clock::now() +
+                        std::chrono::milliseconds(timeout_ms);
+  while (std::chrono::steady_clock::now() < deadline) {
+    MSG message;
+    while (PeekMessageW(&message, nullptr, 0, 0, PM_REMOVE)) {
+      TranslateMessage(&message);
+      DispatchMessageW(&message);
+    }
+    if (predicate()) return;
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }
+}
+
+}  // namespace
+
+DHEPZ_TEST(AppGateStartup, ResourceStartQueuesOverrideIoAndFallsBackHidden) {
+  StartupRig rig;
+  modules::ResetRegistryForTests();
+  modules::RegisterModule(L"resource-alpha", &MakeResourceAlpha);
+  modules::AppGate gate;
+  DHEPZ_CHECK(gate.ConfigureHostOperations(
+                      rig.window, rig.state.completion_message, {})
+                  .ok());
+  const std::wstring missing =
+      L"Z:\\dhepz-app-gate-test\\missing-override.json";
+  DHEPZ_CHECK(gate.StartFromResource(L"APP_GATE_TEST_UI", missing).ok());
+  DHEPZ_CHECK(gate.start_pending());
+  DHEPZ_CHECK(gate.document() == nullptr);
+
+  PumpUntil([&] { return !gate.start_pending(); });
+  DHEPZ_CHECK(!gate.start_pending());
+  DHEPZ_CHECK(gate.start_status().ok());
+  DHEPZ_CHECK(gate.Mounted(L"resource-alpha"));
+  DHEPZ_CHECK(gate.document()->FindRoute(L"resource-alpha") != nullptr);
+  DHEPZ_CHECK_EQ(gate.Rejects().size(), static_cast<std::size_t>(1));
+  DHEPZ_CHECK_EQ(gate.Rejects()[0].file, missing);
+  modules::ResetRegistryForTests();
+}

--- a/tests/modules/gate/app_gate_test.cpp
+++ b/tests/modules/gate/app_gate_test.cpp
@@ -25,7 +25,7 @@ class SimpleModule final : public modules::ModuleDescriptor {
   bool ShowInTabs() const override { return true; }
   std::wstring_view SettingsRoute() const override { return {}; }
   std::vector<std::wstring> DeclaredActions() const override { return Base::Actions(); }
-  std::vector<std::wstring> DeclaredBindings() const override { return {}; }
+  std::vector<std::wstring> DeclaredBindings() const override { return Base::Bindings(); }
   std::vector<std::wstring> DeclaredCapabilities() const override { return Base::Caps(); }
   core::Status Bind(modules::ModuleHost& host) override {
     bound_ = true;
@@ -45,21 +45,55 @@ struct Alpha {
   static std::wstring_view Id() { return L"alpha"; }
   static std::vector<std::wstring> Actions() { return {L"alpha-launch"}; }
   static std::vector<std::wstring> Caps() { return {}; }
+  static std::vector<std::wstring> Bindings() { return {}; }
 };
 struct BadCap {
   static std::wstring_view Id() { return L"badcap"; }
   static std::vector<std::wstring> Actions() { return {}; }
   static std::vector<std::wstring> Caps() { return {L"kernel:admin"}; }
+  static std::vector<std::wstring> Bindings() { return {}; }
 };
 struct Mismatch {
   static std::wstring_view Id() { return L"mismatch"; }
   static std::vector<std::wstring> Actions() { return {}; }
   static std::vector<std::wstring> Caps() { return {L"config:write"}; }
+  static std::vector<std::wstring> Bindings() { return {}; }
 };
 struct ClaimA {
   static std::wstring_view Id() { return L"settings"; }
   static std::vector<std::wstring> Actions() { return {}; }
   static std::vector<std::wstring> Caps() { return {L"settings:all"}; }
+  static std::vector<std::wstring> Bindings() { return {}; }
+};
+struct RefModule {
+  static std::wstring_view Id() { return L"ref-module"; }
+  static std::vector<std::wstring> Actions() { return {}; }
+  static std::vector<std::wstring> Caps() { return {}; }
+  static std::vector<std::wstring> Bindings() { return {}; }
+};
+struct DuplicateAction {
+  static std::wstring_view Id() { return L"duplicate"; }
+  static std::vector<std::wstring> Actions() { return {L"alpha-launch"}; }
+  static std::vector<std::wstring> Caps() { return {}; }
+  static std::vector<std::wstring> Bindings() { return {}; }
+};
+
+class RouteOwnerModule final : public modules::ModuleDescriptor {
+ public:
+  std::wstring_view ModuleId() const override { return L"route-owner"; }
+  std::wstring_view TabLabel() const override { return L"route-owner"; }
+  int Order() const override { return 100; }
+  bool ShowInTabs() const override { return true; }
+  std::wstring_view SettingsRoute() const override { return L"owner-settings"; }
+  std::vector<std::wstring> DeclaredActions() const override { return {}; }
+  std::vector<std::wstring> DeclaredBindings() const override { return {}; }
+  std::vector<std::wstring> DeclaredCapabilities() const override { return {}; }
+  core::Status Bind(modules::ModuleHost&) override { return core::Ok(); }
+  core::Status Handle(std::wstring_view, const json::Value&,
+                      json::Value*) override {
+    return core::Ok();
+  }
+  void Release() override {}
 };
 
 std::unique_ptr<modules::ModuleDescriptor> MakeAlpha() {
@@ -74,6 +108,15 @@ std::unique_ptr<modules::ModuleDescriptor> MakeMismatch() {
 std::unique_ptr<modules::ModuleDescriptor> MakeClaimA() {
   return std::make_unique<SimpleModule<ClaimA>>();
 }
+std::unique_ptr<modules::ModuleDescriptor> MakeRefModule() {
+  return std::make_unique<SimpleModule<RefModule>>();
+}
+std::unique_ptr<modules::ModuleDescriptor> MakeDuplicateAction() {
+  return std::make_unique<SimpleModule<DuplicateAction>>();
+}
+std::unique_ptr<modules::ModuleDescriptor> MakeRouteOwner() {
+  return std::make_unique<RouteOwnerModule>();
+}
 const char* kCore = R"({
   "schema": "dhepz.ui.core",
   "version": 1,
@@ -81,28 +124,36 @@ const char* kCore = R"({
     "dark": { "text": "#E9EDF4", "window": "#14161B" },
     "light": { "text": "#181C24", "window": "#F5F6F9" }
   },
+  "common": { "properties": { "style": { "kind": "string" } } },
   "allows_children": ["screen"],
   "components": {
     "screen": { "properties": {
       "route_id": { "kind": "string", "required": true },
       "module_id": { "kind": "string" },
       "tab_label": { "kind": "string" } } },
-    "text": { "properties": { "text": { "kind": "text", "required": true } } }
+    "text": { "properties": { "text": { "kind": "text", "required": true } } },
+    "button": { "properties": {
+      "label": { "kind": "text", "required": true },
+      "action": { "kind": "string" },
+      "action_payload": { "kind": "object" } } },
+    "input": { "properties": { "value_binding": { "kind": "binding" } } }
   }
 })";
 
 const char* kScreenAlpha =
     R"({ "type": "screen", "route_id": "alpha-home", "module_id": "alpha",
-         "tab_label": "Alpha", "children": [ { "type": "text", "text": "a" } ] })";
+         "tab_label": "alpha", "children": [ { "type": "text", "text": "a" } ] })";
 
 std::wstring EmbeddedWith(const std::wstring& screens, const std::wstring& manifests) {
   return L"{ \"core\": " + W(kCore) + L", \"components\": [ " + screens +
          L" ], \"modules\": [ " + manifests + L" ] }";
 }
 
-std::wstring ManifestFor(const wchar_t* id, const wchar_t* caps = L"") {
+std::wstring ManifestFor(const wchar_t* id, const wchar_t* caps = L"",
+                         const wchar_t* actions = L"") {
   return std::wstring(L"{ \"moduleId\": \"") + id + L"\", \"tabLabel\": \"" + id +
-         L"\", \"capabilities\": [" + caps + L"] }";
+         L"\", \"actions\": [" + actions + L"], \"capabilities\": [" + caps +
+         L"] }";
 }
 
 }  // namespace
@@ -112,7 +163,9 @@ DHEPZ_TEST(AppGate, HealthyModuleMountsActivatesAndDispatches) {
   modules::RegisterModule(L"alpha", &MakeAlpha);
   modules::AppGate gate;
   DHEPZ_CHECK(
-      gate.StartWithEmbedded(EmbeddedWith(W(kScreenAlpha), ManifestFor(L"alpha"))).ok());
+      gate.StartWithEmbedded(EmbeddedWith(
+          W(kScreenAlpha), ManifestFor(L"alpha", L"", L"\"alpha-launch\"")))
+          .ok());
   DHEPZ_CHECK(gate.Rejects().empty());
   DHEPZ_CHECK(gate.Mounted(L"alpha"));
   DHEPZ_CHECK_EQ(gate.Peers().size(), static_cast<std::size_t>(1));
@@ -141,7 +194,8 @@ DHEPZ_TEST(AppGate, BrokenModulesRejectedAppContinues) {
       L", { \"type\": \"screen\", \"route_id\": \"badcap-home\", \"module_id\": \"badcap\","
         L" \"children\": [ { \"type\": \"text\", \"text\": \"b\" } ] }";
   const std::wstring manifests =
-      ManifestFor(L"alpha") + L", " + ManifestFor(L"badcap", L"\"kernel:admin\"") + L", " +
+      ManifestFor(L"alpha", L"", L"\"alpha-launch\"") + L", " +
+      ManifestFor(L"badcap", L"\"kernel:admin\"") + L", " +
       ManifestFor(L"ghost");
   DHEPZ_CHECK(gate.StartWithEmbedded(EmbeddedWith(screens, manifests)).ok());
 
@@ -170,8 +224,192 @@ DHEPZ_TEST(AppGate, CapabilityMismatchBetweenCodeAndManifestRejected) {
   // Manifest declares no capabilities; the code declares config:write.
   DHEPZ_CHECK(gate.StartWithEmbedded(EmbeddedWith(screens, ManifestFor(L"mismatch"))).ok());
   DHEPZ_CHECK(!gate.Mounted(L"mismatch"));
+  DHEPZ_CHECK(gate.document()->FindRoute(L"mismatch-home") == nullptr);
   DHEPZ_CHECK_EQ(gate.Rejects().size(), static_cast<std::size_t>(1));
   DHEPZ_CHECK(gate.Rejects()[0].reason.find(L"does not match") != std::wstring::npos);
+  modules::ResetRegistryForTests();
+}
+
+DHEPZ_TEST(AppGateContract, ExtraCppActionLeavesNoRouteOrDispatch) {
+  modules::ResetRegistryForTests();
+  modules::RegisterModule(L"alpha", &MakeAlpha);
+  modules::AppGate gate;
+  DHEPZ_CHECK(gate.StartWithEmbedded(
+                      EmbeddedWith(W(kScreenAlpha), ManifestFor(L"alpha")))
+                  .ok());
+  DHEPZ_CHECK(!gate.Mounted(L"alpha"));
+  DHEPZ_CHECK(gate.document()->FindRoute(L"alpha-home") == nullptr);
+  json::Value payload;
+  json::Value patch;
+  DHEPZ_CHECK(!gate.Dispatch(L"alpha-launch", payload, &patch).ok());
+  DHEPZ_CHECK(gate.Rejects()[0].reason.find(L"alpha-launch") !=
+              std::wstring::npos);
+  modules::ResetRegistryForTests();
+}
+
+DHEPZ_TEST(AppGateContract, MetadataDriftNamesScreenLocation) {
+  modules::ResetRegistryForTests();
+  modules::RegisterModule(L"alpha", &MakeAlpha);
+  const std::wstring screen =
+      L"{ \"type\": \"screen\", \"route_id\": \"alpha-home\", "
+      L"\"module_id\": \"alpha\",\n  \"tab_label\": \"Wrong\" }";
+  modules::AppGate gate;
+  DHEPZ_CHECK(gate.StartWithEmbedded(EmbeddedWith(
+                      screen, ManifestFor(L"alpha", L"", L"\"alpha-launch\"")))
+                  .ok());
+  DHEPZ_CHECK(!gate.Mounted(L"alpha"));
+  DHEPZ_CHECK(gate.Rejects()[0].reason.find(L"screen metadata") !=
+              std::wstring::npos);
+  DHEPZ_CHECK(!gate.Rejects()[0].file.empty());
+  DHEPZ_CHECK(gate.Rejects()[0].line > 0);
+  modules::ResetRegistryForTests();
+}
+
+DHEPZ_TEST(AppGateContract, UndeclaredScreenReferencesAreRejected) {
+  const std::wstring screens[] = {
+      L"{ \"type\": \"screen\", \"route_id\": \"ref-home\", "
+      L"\"module_id\": \"ref-module\", \"children\": ["
+      L"{ \"type\": \"button\", \"label\": \"x\", \"action\": \"missing\" } ] }",
+      L"{ \"type\": \"screen\", \"route_id\": \"ref-home\", "
+      L"\"module_id\": \"ref-module\", \"children\": ["
+      L"{ \"type\": \"input\", \"value_binding\": \"missing\" } ] }",
+      L"{ \"type\": \"screen\", \"route_id\": \"ref-home\", "
+      L"\"module_id\": \"ref-module\", \"style\": \"missing\" }"};
+  const wchar_t* reasons[] = {L"undeclared action", L"undeclared binding",
+                              L"unknown style"};
+  for (int index = 0; index < 3; ++index) {
+    modules::ResetRegistryForTests();
+    modules::RegisterModule(L"ref-module", &MakeRefModule);
+    modules::AppGate gate;
+    DHEPZ_CHECK(gate.StartWithEmbedded(
+                        EmbeddedWith(screens[index], ManifestFor(L"ref-module")))
+                    .ok());
+    DHEPZ_CHECK(!gate.Mounted(L"ref-module"));
+    DHEPZ_CHECK(gate.Rejects()[0].reason.find(reasons[index]) !=
+                std::wstring::npos);
+    DHEPZ_CHECK(gate.Rejects()[0].line > 0);
+  }
+  modules::ResetRegistryForTests();
+}
+
+DHEPZ_TEST(AppGateContract, DuplicateActionRejectsSecondOwnerAndItsRoute) {
+  modules::ResetRegistryForTests();
+  modules::RegisterModule(L"alpha", &MakeAlpha);
+  modules::RegisterModule(L"duplicate", &MakeDuplicateAction);
+  const std::wstring duplicate_screen =
+      L"{ \"type\": \"screen\", \"route_id\": \"duplicate-home\", "
+      L"\"module_id\": \"duplicate\", \"tab_label\": \"duplicate\" }";
+  modules::AppGate gate;
+  DHEPZ_CHECK(gate.StartWithEmbedded(EmbeddedWith(
+                      W(kScreenAlpha) + L", " + duplicate_screen,
+                      ManifestFor(L"alpha", L"", L"\"alpha-launch\"") + L", " +
+                          ManifestFor(L"duplicate", L"", L"\"alpha-launch\"")))
+                  .ok());
+  DHEPZ_CHECK(gate.Mounted(L"alpha"));
+  DHEPZ_CHECK(!gate.Mounted(L"duplicate"));
+  DHEPZ_CHECK(gate.document()->FindRoute(L"duplicate-home") == nullptr);
+  modules::ResetRegistryForTests();
+}
+
+DHEPZ_TEST(AppGateContract, GeneratedEnvelopePreservesFileLineAndColumn) {
+  modules::ResetRegistryForTests();
+  modules::RegisterModule(L"ref-module", &MakeRefModule);
+  const std::wstring screen =
+      L"{\n  \"components\": [\n    { \"type\": \"screen\", "
+      L"\"route_id\": \"ref-home\",\n      \"module_id\": \"ref-module\", "
+      L"\"children\": [\n        { \"type\": \"button\", \"label\": \"x\", "
+      L"\"action\": \"missing\" }\n      ] }\n  ]\n}";
+  const std::wstring manifest =
+      L"{\n  \"moduleId\": \"ref-module\",\n  \"tabLabel\": \"ref-module\",\n"
+      L"  \"actions\": []\n}";
+  json::Value source_entry = json::Value::Object();
+  source_entry.Set(L"file", json::Value::String(
+                                L"src/modules/ref-module/screen.json"));
+  source_entry.Set(L"text", json::Value::String(screen));
+  json::Value sources = json::Value::Array();
+  sources.Append(std::move(source_entry));
+  json::Value manifest_entry = json::Value::Object();
+  manifest_entry.Set(L"file", json::Value::String(
+                                  L"src/modules/ref-module/module.json"));
+  manifest_entry.Set(L"text", json::Value::String(manifest));
+  json::Value manifests = json::Value::Array();
+  manifests.Append(std::move(manifest_entry));
+  json::Value core;
+  DHEPZ_CHECK(json::Parse(W(kCore), &core).ok());
+  json::Value envelope = json::Value::Object();
+  envelope.Set(L"core", std::move(core));
+  envelope.Set(L"sources", std::move(sources));
+  envelope.Set(L"modules", std::move(manifests));
+
+  modules::AppGate gate;
+  DHEPZ_CHECK(gate.StartWithEmbedded(json::Serialize(envelope)).ok());
+  DHEPZ_CHECK_EQ(gate.Rejects()[0].file,
+                 std::wstring(L"src/modules/ref-module/screen.json"));
+  DHEPZ_CHECK_EQ(gate.Rejects()[0].line, 5);
+  DHEPZ_CHECK(gate.Rejects()[0].column > 0);
+  modules::ResetRegistryForTests();
+}
+
+DHEPZ_TEST(AppGateContract, UnknownComponentQuarantinesOnlyItsModuleSource) {
+  modules::ResetRegistryForTests();
+  modules::RegisterModule(L"ref-module", &MakeRefModule);
+  const std::wstring screen =
+      L"{ \"components\": [ { \"type\": \"screen\", "
+      L"\"route_id\": \"ref-home\", \"module_id\": \"ref-module\", "
+      L"\"children\": [ { \"type\": \"unknown-widget\" } ] } ] }";
+  const std::wstring manifest =
+      L"{ \"moduleId\": \"ref-module\", \"tabLabel\": \"ref-module\" }";
+  json::Value source_entry = json::Value::Object();
+  source_entry.Set(L"file", json::Value::String(L"ref/screen.json"));
+  source_entry.Set(L"text", json::Value::String(screen));
+  json::Value sources = json::Value::Array();
+  sources.Append(std::move(source_entry));
+  json::Value manifest_entry = json::Value::Object();
+  manifest_entry.Set(L"file", json::Value::String(L"ref/module.json"));
+  manifest_entry.Set(L"text", json::Value::String(manifest));
+  json::Value manifests = json::Value::Array();
+  manifests.Append(std::move(manifest_entry));
+  json::Value core;
+  DHEPZ_CHECK(json::Parse(W(kCore), &core).ok());
+  json::Value envelope = json::Value::Object();
+  envelope.Set(L"core", std::move(core));
+  envelope.Set(L"sources", std::move(sources));
+  envelope.Set(L"modules", std::move(manifests));
+
+  modules::AppGate gate;
+  DHEPZ_CHECK(gate.StartWithEmbedded(json::Serialize(envelope)).ok());
+  DHEPZ_CHECK(!gate.Mounted(L"ref-module"));
+  DHEPZ_CHECK(gate.document()->FindRoute(L"ref-home") == nullptr);
+  DHEPZ_CHECK_EQ(gate.Rejects()[0].file,
+                 std::wstring(L"ref/screen.json"));
+  DHEPZ_CHECK(gate.Rejects()[0].reason.find(L"unknown") !=
+              std::wstring::npos);
+  modules::ResetRegistryForTests();
+}
+
+DHEPZ_TEST(AppGateContract, SettingsRouteMustBelongToDeclaringModule) {
+  modules::ResetRegistryForTests();
+  modules::RegisterModule(L"route-owner", &MakeRouteOwner);
+  const std::wstring screens =
+      L"{ \"type\": \"screen\", \"route_id\": \"owner-home\", "
+      L"\"module_id\": \"route-owner\", \"tab_label\": \"route-owner\" }, "
+      L"{ \"type\": \"screen\", \"route_id\": \"owner-settings\", "
+      L"\"module_id\": \"other\" }";
+  const std::wstring manifest =
+      L"{ \"moduleId\": \"route-owner\", \"tabLabel\": \"route-owner\", "
+      L"\"settingsRoute\": \"owner-settings\" }";
+  modules::AppGate gate;
+  DHEPZ_CHECK(
+      gate.StartWithEmbedded(EmbeddedWith(screens, manifest)).ok());
+  DHEPZ_CHECK(!gate.Mounted(L"route-owner"));
+  bool saw_owner_reject = false;
+  for (const modules::RejectEntry& reject : gate.Rejects()) {
+    if (reject.module_id == L"route-owner" &&
+        reject.reason.find(L"settingsRoute") != std::wstring::npos) {
+      saw_owner_reject = true;
+    }
+  }
+  DHEPZ_CHECK(saw_owner_reject);
   modules::ResetRegistryForTests();
 }
 

--- a/tests/modules/gate/capability_facets_test.cpp
+++ b/tests/modules/gate/capability_facets_test.cpp
@@ -141,8 +141,13 @@ std::wstring Manifest(std::wstring_view id, std::wstring_view label,
   const std::wstring caps = capability.empty()
                                 ? L"[]"
                                 : L"[ \"" + std::wstring(capability) + L"\" ]";
+  const int order = id == L"settings"   ? 10
+                    : id == L"ui-editor" ? 20
+                    : id == L"alpha"     ? 30
+                                           : 40;
   return L"{ \"moduleId\": \"" + std::wstring(id) + L"\", \"tabLabel\": \"" +
-         std::wstring(label) + L"\", \"capabilities\": " + caps + L" }";
+         std::wstring(label) + L"\", \"order\": " + std::to_wstring(order) +
+         L", \"capabilities\": " + caps + L" }";
 }
 
 std::wstring Embedded(const std::vector<std::wstring>& screens,

--- a/tests/modules/gate/fixtures_test.cpp
+++ b/tests/modules/gate/fixtures_test.cpp
@@ -50,10 +50,14 @@ std::wstring RepoRoot() {
 
 struct Healthy {
   static std::wstring_view Id() { return L"fixture-healthy"; }
+  static std::wstring_view Label() { return L"Fixture Healthy"; }
+  static int Order() { return 500; }
   static std::vector<std::wstring> Actions() { return {L"fixture-launch"}; }
 };
 struct Typo {
   static std::wstring_view Id() { return L"fixture-typo"; }
+  static std::wstring_view Label() { return L"Fixture Typo"; }
+  static int Order() { return 501; }
   // The misspelling: module.json declares fixture-launch, the handler
   // registers under this name, so the gate must reject the module.
   static std::vector<std::wstring> Actions() { return {L"fixture-launhc"}; }
@@ -63,8 +67,8 @@ template <typename Base>
 class FixtureModule final : public modules::ModuleDescriptor {
  public:
   std::wstring_view ModuleId() const override { return Base::Id(); }
-  std::wstring_view TabLabel() const override { return Base::Id(); }
-  int Order() const override { return 500; }
+  std::wstring_view TabLabel() const override { return Base::Label(); }
+  int Order() const override { return Base::Order(); }
   bool ShowInTabs() const override { return false; }
   std::wstring_view SettingsRoute() const override { return {}; }
   std::vector<std::wstring> DeclaredActions() const override { return Base::Actions(); }

--- a/tools/Build.ps1
+++ b/tools/Build.ps1
@@ -102,6 +102,14 @@ $exitCode = $LASTEXITCODE
 if ($exitCode -eq 0) {
     $exe = Join-Path $repositoryRoot "build\$Platform\$Configuration\dhepz.exe"
     if (Test-Path -LiteralPath $exe -PathType Leaf) {
+        # Full module validation must run after link because only the linked
+        # image contains the real RCDATA and self-registered descriptors.
+        $validation = Start-Process -FilePath $exe -ArgumentList '--validate-embedded' `
+            -Wait -PassThru -NoNewWindow
+        if ($validation.ExitCode -ne 0) {
+            Write-Error "Embedded UI validation failed for '$exe'."
+            exit $validation.ExitCode
+        }
         $size = [math]::Round((Get-Item -LiteralPath $exe).Length / 1KB, 1)
         Write-Host "Built $exe ($size KB)" -ForegroundColor Green
     }

--- a/tools/Merge-UiConfig.ps1
+++ b/tools/Merge-UiConfig.ps1
@@ -34,13 +34,18 @@ if ($GenerateEmbedded) {
     # no filesystem walk at startup. PowerShell-only so a clean build can run
     # it before the exe exists; full schema validation runs at test time and
     # at the gate.
-    $components = New-Object System.Collections.ArrayList
+    $componentCount = 0
+    $sources = New-Object System.Collections.ArrayList
     $manifests = New-Object System.Collections.ArrayList
     $screensRoot = Join-Path $RepositoryRoot 'assets\ui\screens'
     if (Test-Path -LiteralPath $screensRoot -PathType Container) {
         foreach ($file in @(Get-ChildItem -LiteralPath $screensRoot -Filter *.json | Sort-Object Name)) {
-            $doc = Get-Content -LiteralPath $file.FullName -Raw | ConvertFrom-Json
-            foreach ($component in $doc.components) { $null = $components.Add($component) }
+            $text = Get-Content -LiteralPath $file.FullName -Raw
+            try { $doc = $text | ConvertFrom-Json -ErrorAction Stop }
+            catch { throw "$($file.FullName): malformed JSON: $($_.Exception.Message)" }
+            foreach ($component in @($doc.components)) { $componentCount++ }
+            $relative = [IO.Path]::GetRelativePath($RepositoryRoot, $file.FullName).Replace('\', '/')
+            $null = $sources.Add([ordered]@{ file = $relative; text = $text })
         }
     }
     $modulesRoot = Join-Path $RepositoryRoot 'src\modules'
@@ -58,19 +63,36 @@ if ($GenerateEmbedded) {
             if (-not $hasScreen) {
                 throw "Module '$($dir.Name)' has no screen.json."
             }
-            $doc = Get-Content -LiteralPath $screenPath -Raw | ConvertFrom-Json
-            foreach ($component in $doc.components) { $null = $components.Add($component) }
-            $manifest = Get-Content -LiteralPath $manifestPath -Raw | ConvertFrom-Json
-            $null = $manifests.Add($manifest)
+            $screenText = Get-Content -LiteralPath $screenPath -Raw
+            try { $screenDoc = $screenText | ConvertFrom-Json -ErrorAction Stop }
+            catch { throw "${screenPath}: malformed JSON: $($_.Exception.Message)" }
+            foreach ($component in @($screenDoc.components)) { $componentCount++ }
+            $screenRelative = [IO.Path]::GetRelativePath($RepositoryRoot, $screenPath).Replace('\', '/')
+            $null = $sources.Add([ordered]@{ file = $screenRelative; text = $screenText })
+
+            $manifestText = Get-Content -LiteralPath $manifestPath -Raw
+            try { $null = $manifestText | ConvertFrom-Json -ErrorAction Stop }
+            catch { throw "${manifestPath}: malformed JSON: $($_.Exception.Message)" }
+            $manifestRelative = [IO.Path]::GetRelativePath($RepositoryRoot, $manifestPath).Replace('\', '/')
+            $null = $manifests.Add([ordered]@{ file = $manifestRelative; text = $manifestText })
         }
     }
-    $core = Get-Content -LiteralPath (Join-Path $RepositoryRoot 'assets\ui\core.json') -Raw | ConvertFrom-Json
-    $merged = [ordered]@{ core = $core; components = $components; modules = $manifests }
+    $corePath = Join-Path $RepositoryRoot 'assets\ui\core.json'
+    $coreText = Get-Content -LiteralPath $corePath -Raw
+    try { $core = $coreText | ConvertFrom-Json -ErrorAction Stop }
+    catch { throw "${corePath}: malformed JSON: $($_.Exception.Message)" }
+    $merged = [ordered]@{
+        core = $core
+        coreText = $coreText
+        coreFile = 'assets/ui/core.json'
+        sources = $sources
+        modules = $manifests
+    }
     $outDir = Join-Path $RepositoryRoot 'build\generated'
     $null = New-Item -ItemType Directory -Force -Path $outDir
     $json = ($merged | ConvertTo-Json -Depth 32) + "`n"
     [System.IO.File]::WriteAllText((Join-Path $outDir 'embedded_ui.json'), $json, (New-Object System.Text.UTF8Encoding($false)))
-    Write-Host "Embedded UI document written ($($components.Count) components)."
+    Write-Host "Embedded UI document written ($componentCount components)."
     exit 0
 }
 


### PR DESCRIPTION
## Outcome\n\n- makes AppGate::Start() read the linked EMBEDDED_UI RCDATA\n- reads optional overrides asynchronously and falls back before any document mounts\n- extracts resource/worker work into GateStartupService\n- extracts the symmetric descriptor/manifest/screen checks into ModuleValidator\n- filters every rejected module route/action before mount\n- preserves generated source file, line, and column\n- adds --validate-embedded and runs it post-link from Build.ps1\n- keeps pre-link PowerShell generation syntax-only and source-aware\n\nAppGate is 233 lines after this change; it contains no Win32, file, path, or worker dependency.\n\n## Focused local verification\n\n- Debug AppGate/contract/startup/host operations: 13/13\n- Debug CapabilityFacets: 2/2\n- Debug ContractFixtures: 1/1\n- Debug diagnostics-related filter: 4/4\n- Debug SettingsPersistence: 1/1\n- every focused build ran the linked executable's real RCDATA validator: 2 modules, 5 routes\n- git diff --check and architecture scans clean\n\nThe hosted CI run is the sole full Debug/Release regression for this PR SHA.\n\nCloses #108