### PR TITLE
IC-05: own diagnostics and quarantine fatal modules

### DIFF
--- a/docs/adr/0003-runtime-quarantine-policy.md
+++ b/docs/adr/0003-runtime-quarantine-policy.md
@@ -1,0 +1,46 @@
+# ADR 0003 — Module runtime quarantine and window lifetime
+
+Status: accepted (Integration Checkpoint IC-05). Links: `.docs/plan.md` Part 3;
+issue #109.
+
+## Context
+
+A module boundary can fail because user input is invalid, an OS operation is
+unavailable, or the user cancelled it. Those are expected action outcomes and
+must not make the feature disappear. A failed `Bind`, an exception escaping
+module code, or an internal invariant failure instead means the parent can no
+longer trust that module instance. Keeping its routes/actions live would let a
+faulty child repeatedly destabilize the resident process.
+
+Window lifetime is also shorter than process lifetime. Closing the last app
+window must release activated modules and cancel their host lifetime without
+terminating the tray-resident parent.
+
+## Decision
+
+1. `InvalidArgument`, `NotFound`, `AlreadyExists`, `IoError`, `ParseError`,
+   `PermissionDenied`, `Unsupported`, and `Cancelled` returned from `Handle`
+   are operational statuses. The parent records the latest status and leaves
+   the module mounted.
+2. Any failed `Bind`, any exception crossing `Bind`/`Handle`, and an explicit
+   `Internal` result are fatal for that module lifetime. The parent calls
+   `Release()` once, destroys its `GateHost`, removes its actions and routes,
+   and records a staged runtime diagnostic. Healthy siblings remain mounted.
+3. `Release()` runs once for every started bind lifetime: on last-window close,
+   quarantine, or final shutdown. Repeated close/shutdown calls are idempotent.
+   Destroying `GateHost` invalidates worker delivery and suppresses callbacks
+   belonging to that released module lifetime.
+4. Diagnostics are parent-owned immutable metadata exposed through
+   `ModuleHost::Diagnostics()`. The diagnostics child receives no gate pointer,
+   global singleton, route mutator, or platform service.
+
+## Consequences
+
+- User and OS errors remain visible and retryable instead of disabling a
+  feature.
+- A structurally unhealthy child is removed on first fatal boundary failure,
+  while the resident parent and healthy modules continue.
+- Reopening a window creates a fresh host lifetime and rebinds the descriptor;
+  no completion from the closed lifetime may reach it.
+- The read model is bounded by module count and adds no polling, timer, thread,
+  or idle wakeup.

--- a/src/modules/contract/module_contract.h
+++ b/src/modules/contract/module_contract.h
@@ -49,6 +49,49 @@ struct PeerInfo {
   std::wstring settings_route;  // empty when the peer ships no settings screen
 };
 
+enum class DiagnosticStage {
+  Manifest,
+  Pairing,
+  Capability,
+  Bind,
+  Dispatch,
+  Runtime,
+  Settings,
+  Startup,
+};
+
+struct ModuleDiagnosticEntry {
+  std::wstring module_id;
+  std::wstring reason;
+  std::wstring file;
+  int line = 0;
+  int column = 0;
+  DiagnosticStage stage = DiagnosticStage::Pairing;
+};
+
+struct CapabilityGrantInfo {
+  std::wstring module_id;
+  std::wstring capability;
+  std::wstring file;
+  int line = 0;
+  int column = 0;
+};
+
+struct ModuleStatusEntry {
+  std::wstring module_id;
+  bool ok = true;
+  std::wstring message;
+};
+
+struct DiagnosticsReadModel {
+  std::vector<PeerInfo> accepted;
+  std::vector<ModuleDiagnosticEntry> rejected;
+  std::vector<CapabilityGrantInfo> grants;
+  std::vector<ModuleDiagnosticEntry> runtime_faults;
+  // Latest status per module, bounded by mounted module count.
+  std::vector<ModuleStatusEntry> statuses;
+};
+
 enum class ProcessOperation { Launch, ElevatedLaunch, Capture };
 
 enum class HostOperationKind {
@@ -192,6 +235,9 @@ class ModuleHost {
   // the output to null and returns PermissionDenied.
   virtual core::Status GetSettingsAllFacet(SettingsAllFacet** facet) = 0;
   virtual core::Status GetConfigWriteFacet(ConfigWriteFacet** facet) = 0;
+  // Immutable parent-owned metadata. The default keeps ordinary modules and
+  // test fakes narrow; the diagnostics module receives the real gate model.
+  virtual DiagnosticsReadModel Diagnostics() { return {}; }
   // Report success/error; the parent decides how to show it.
   virtual void ReportStatus(const core::Status& status) = 0;
   virtual void Log(std::wstring_view level, std::wstring_view text) = 0;

--- a/src/modules/diagnostics/diagnostics_module.cpp
+++ b/src/modules/diagnostics/diagnostics_module.cpp
@@ -3,7 +3,6 @@
 // from the gate and surfaces them via Log/ReportStatus; the rendered
 // in-app list lands with viewState bindings, the CI artifact with #85.
 #include "modules/contract/module_contract.h"
-#include "modules/gate/app_gate.h"
 #include "modules/registry/module_registry.h"
 
 #include <memory>
@@ -34,9 +33,17 @@ class DiagnosticsModule final : public modules::ModuleDescriptor {
       return core::Err(core::ErrorCode::NotFound, L"unknown action");
     }
     last_summary_.clear();
-    for (const modules::RejectEntry& reject : modules::CurrentRejects()) {
+    const modules::DiagnosticsReadModel diagnostics = host_->Diagnostics();
+    for (const modules::ModuleDiagnosticEntry& reject : diagnostics.rejected) {
       const std::wstring line = reject.module_id + L": " + reject.reason;
       host_->Log(L"warn", line);
+      if (!last_summary_.empty()) last_summary_ += L"\n";
+      last_summary_ += line;
+    }
+    for (const modules::ModuleStatusEntry& status : diagnostics.statuses) {
+      const std::wstring line = status.module_id + L": " +
+                                (status.ok ? L"Ok" : status.message);
+      host_->Log(status.ok ? L"info" : L"warn", line);
       if (!last_summary_.empty()) last_summary_ += L"\n";
       last_summary_ += line;
     }

--- a/src/modules/gate/app_gate.cpp
+++ b/src/modules/gate/app_gate.cpp
@@ -1,5 +1,7 @@
 #include "modules/gate/app_gate.h"
 
+#include <algorithm>
+#include <exception>
 #include <utility>
 
 #include "modules/gate/config_transaction_service.h"
@@ -9,24 +11,13 @@
 #include "modules/registry/module_registry.h"
 
 namespace modules {
-namespace {
-
-const std::vector<RejectEntry>* g_rejects = nullptr;
-
-}  // namespace
-
-const std::vector<RejectEntry>& CurrentRejects() {
-  static const std::vector<RejectEntry> empty;
-  return g_rejects != nullptr ? *g_rejects : empty;
-}
-
 AppGate::AppGate()
     : settings_service_(
           std::make_unique<SettingsAccessService>([this]() { return Peers(); })),
       config_service_(std::make_unique<ConfigTransactionService>(
           &document_, &document_generation_)) {}
 
-AppGate::~AppGate() = default;
+AppGate::~AppGate() { Shutdown(); }
 
 core::Status AppGate::Start(std::wstring_view override_path) {
   return StartFromResource(L"EMBEDDED_UI", override_path);
@@ -34,6 +25,9 @@ core::Status AppGate::Start(std::wstring_view override_path) {
 
 core::Status AppGate::StartFromResource(std::wstring_view resource_name,
                                         std::wstring_view override_path) {
+  if (shutdown_) {
+    return core::Err(core::ErrorCode::Cancelled, L"AppGate is shut down");
+  }
   if (start_pending_ || document_ != nullptr || !mounted_.empty()) {
     return core::Err(core::ErrorCode::AlreadyExists,
                      L"AppGate was already started");
@@ -64,12 +58,13 @@ core::Status AppGate::StartFromResource(std::wstring_view resource_name,
             const core::Status invalid_override = start_status_;
             start_status_ = PairAndMount(embedded, {});
             rejects_.push_back({L"config-override", invalid_override.Message(),
-                                source, 1, 1});
+                                source, 1, 1, DiagnosticStage::Startup});
           }
         } else {
           start_status_ = PairAndMount(embedded, {});
           rejects_.push_back(
-              {L"config-override", read_status.Message(), source, 1, 1});
+              {L"config-override", read_status.Message(), source, 1, 1,
+               DiagnosticStage::Startup});
         }
         start_pending_ = false;
       });
@@ -77,6 +72,9 @@ core::Status AppGate::StartFromResource(std::wstring_view resource_name,
 
 core::Status AppGate::StartWithEmbedded(std::wstring_view embedded_text,
                                         std::wstring_view override_text) {
+  if (shutdown_) {
+    return core::Err(core::ErrorCode::Cancelled, L"AppGate is shut down");
+  }
   if (start_pending_ || document_ != nullptr || !mounted_.empty()) {
     return core::Err(core::ErrorCode::AlreadyExists,
                      L"AppGate was already started");
@@ -131,29 +129,27 @@ core::Status AppGate::PairAndMount(std::wstring_view embedded_text,
   if (!status.ok()) return status;
 
   document_ = std::move(validation.document);
+  core_catalog_ = std::move(validation.core_catalog);
+  live_sources_ = std::move(validation.accepted_sources);
   rejects_ = std::move(validation.rejects);
   grants_ = std::move(validation.grants);
+  runtime_faults_.clear();
+  module_statuses_.clear();
   action_map_ = std::move(validation.action_map);
   mounted_.clear();
   current_route_ = document_ != nullptr ? document_->initial_route() : L"";
   ++document_generation_;
-  config_service_->ConfigureBase(validation.core_catalog,
+  config_service_->ConfigureBase(core_catalog_,
                                  validation.accepted_base);
 
   for (ValidatedModule& accepted : validation.modules) {
     MountedModule module;
     module.manifest = std::move(accepted.manifest);
     module.descriptor = std::move(accepted.descriptor);
-    module.host = std::make_unique<GateHost>(
-        module.manifest.module_id,
-        [this](std::wstring_view route_id) { return RequestRoute(route_id); },
-        [this]() { return Peers(); }, settings_service_.get(),
-        config_service_.get(), accepted.settings_all_granted,
-        accepted.config_write_granted, operation_window_, operation_message_,
-        state_patch_handler_);
+    module.settings_all_granted = accepted.settings_all_granted;
+    module.config_write_granted = accepted.config_write_granted;
     mounted_.push_back(std::move(module));
   }
-  g_rejects = &rejects_;
   return core::Ok();
 }
 
@@ -166,14 +162,16 @@ AppGate::MountedModule* AppGate::FindByRoute(std::wstring_view route_id) {
 
 AppGate::MountedModule* AppGate::FindByModule(std::wstring_view module_id) {
   for (MountedModule& module : mounted_) {
-    if (module.manifest.module_id == module_id) return &module;
+    if (module.manifest.module_id == module_id && !module.quarantined) {
+      return &module;
+    }
   }
   return nullptr;
 }
 
 bool AppGate::Mounted(std::wstring_view module_id) const {
   for (const MountedModule& module : mounted_) {
-    if (module.manifest.module_id == module_id) return true;
+    if (module.manifest.module_id == module_id && !module.quarantined) return true;
   }
   return false;
 }
@@ -181,16 +179,7 @@ bool AppGate::Mounted(std::wstring_view module_id) const {
 core::Status AppGate::Activate(std::wstring_view route_id) {
   MountedModule* module = FindByRoute(route_id);
   if (module == nullptr) return core::Ok();
-  if (module->activated) return core::Ok();
-  const core::Status bound = module->descriptor->Bind(*module->host);
-  if (!bound.ok()) {
-    rejects_.push_back(
-        {module->manifest.module_id, L"Bind failed: " + bound.Message(),
-         L"runtime", 1, 1});
-    return bound;
-  }
-  module->activated = true;
-  return core::Ok();
+  return BindModule(module);
 }
 
 core::Status AppGate::Dispatch(std::wstring_view action,
@@ -203,11 +192,25 @@ core::Status AppGate::Dispatch(std::wstring_view action,
       return core::Err(core::ErrorCode::NotFound, L"module not mounted");
     }
     if (!module->activated) {
-      const core::Status bound = module->descriptor->Bind(*module->host);
+      const core::Status bound = BindModule(module);
       if (!bound.ok()) return bound;
-      module->activated = true;
     }
-    return module->descriptor->Handle(action, payload, state_patch);
+    core::Status handled;
+    try {
+      handled = module->descriptor->Handle(action, payload, state_patch);
+    } catch (const std::exception&) {
+      handled = core::Err(core::ErrorCode::Internal,
+                          L"module Handle threw an exception");
+    } catch (...) {
+      handled = core::Err(core::ErrorCode::Internal,
+                          L"module Handle threw an unknown exception");
+    }
+    ReportModuleStatus(module_id, handled);
+    if (handled.Code() == core::ErrorCode::Internal) {
+      Quarantine(module, DiagnosticStage::Dispatch,
+                 L"fatal module result: " + handled.Message());
+    }
+    return handled;
   }
   return core::Err(core::ErrorCode::NotFound,
                    L"no module declares this action");
@@ -224,10 +227,137 @@ core::Status AppGate::RequestRoute(std::wstring_view route_id) {
 std::vector<PeerInfo> AppGate::Peers() const {
   std::vector<PeerInfo> peers;
   for (const MountedModule& module : mounted_) {
+    if (module.quarantined) continue;
     peers.push_back({module.manifest.module_id, module.manifest.tab_label,
                      module.manifest.settings_route});
   }
   return peers;
+}
+
+core::Status AppGate::BindModule(MountedModule* module) {
+  if (module == nullptr || module->quarantined) {
+    return core::Err(core::ErrorCode::NotFound, L"module is unavailable");
+  }
+  if (module->activated) return core::Ok();
+  EnsureHost(module);
+  module->bound_lifetime_started = true;
+  core::Status bound;
+  try {
+    bound = module->descriptor->Bind(*module->host);
+  } catch (const std::exception&) {
+    bound = core::Err(core::ErrorCode::Internal,
+                      L"module Bind threw an exception");
+  } catch (...) {
+    bound = core::Err(core::ErrorCode::Internal,
+                      L"module Bind threw an unknown exception");
+  }
+  ReportModuleStatus(module->manifest.module_id, bound);
+  if (!bound.ok()) {
+    Quarantine(module, DiagnosticStage::Bind,
+               L"Bind failed: " + bound.Message());
+    return bound;
+  }
+  module->activated = true;
+  return core::Ok();
+}
+
+void AppGate::EnsureHost(MountedModule* module) {
+  if (module == nullptr || module->host != nullptr) return;
+  module->host = std::make_unique<GateHost>(
+      module->manifest.module_id,
+      [this](std::wstring_view route_id) { return RequestRoute(route_id); },
+      [this]() { return Peers(); }, [this]() { return Diagnostics(); },
+      [this](std::wstring_view module_id, const core::Status& status) {
+        ReportModuleStatus(module_id, status);
+      },
+      settings_service_.get(), config_service_.get(),
+      module->settings_all_granted, module->config_write_granted,
+      operation_window_, operation_message_, state_patch_handler_);
+}
+
+void AppGate::ReleaseBoundModule(MountedModule* module) {
+  if (module == nullptr) return;
+  if (module->bound_lifetime_started) {
+    module->bound_lifetime_started = false;
+    try {
+      module->descriptor->Release();
+    } catch (...) {
+      runtime_faults_.push_back(
+          {module->manifest.module_id, L"module Release threw an exception",
+           L"runtime", 1, 1, DiagnosticStage::Runtime});
+    }
+  }
+  module->activated = false;
+  // Destroying the host invalidates its worker generation and suppresses
+  // settings completions captured by this host lifetime.
+  module->host.reset();
+}
+
+void AppGate::Quarantine(MountedModule* module, DiagnosticStage stage,
+                         std::wstring reason) {
+  if (module == nullptr || module->quarantined) return;
+  const std::wstring module_id = module->manifest.module_id;
+  runtime_faults_.push_back(
+      {module_id, std::move(reason), L"runtime", 1, 1, stage});
+  ReleaseBoundModule(module);
+  module->quarantined = true;
+  std::erase_if(action_map_, [&module_id](const auto& action) {
+    return action.second == module_id;
+  });
+
+  ModuleValidator validator;
+  std::vector<ui::config::ScreenSource> filtered;
+  std::unique_ptr<ui::config::ResolvedUiDocument> filtered_document;
+  if (validator.WithdrawModule(core_catalog_, live_sources_, module_id,
+                               &filtered, &filtered_document)
+          .ok()) {
+    live_sources_ = std::move(filtered);
+    document_ = std::move(filtered_document);
+    ++document_generation_;
+    if (document_ != nullptr &&
+        document_->FindRoute(current_route_) == nullptr) {
+      current_route_ = document_->initial_route();
+    }
+  }
+}
+
+void AppGate::ReportModuleStatus(std::wstring_view module_id,
+                                 const core::Status& status) {
+  for (ModuleStatusEntry& entry : module_statuses_) {
+    if (entry.module_id == module_id) {
+      entry.ok = status.ok();
+      entry.message = status.Message();
+      return;
+    }
+  }
+  module_statuses_.push_back(
+      {std::wstring(module_id), status.ok(), status.Message()});
+}
+
+DiagnosticsReadModel AppGate::Diagnostics() const {
+  DiagnosticsReadModel model;
+  model.accepted = Peers();
+  model.rejected = rejects_;
+  model.grants = grants_;
+  model.runtime_faults = runtime_faults_;
+  model.statuses = module_statuses_;
+  return model;
+}
+
+void AppGate::ReleaseWindowModules() {
+  if (shutdown_) return;
+  for (MountedModule& module : mounted_) {
+    if (!module.quarantined) ReleaseBoundModule(&module);
+  }
+}
+
+void AppGate::Shutdown() {
+  if (shutdown_) return;
+  shutdown_ = true;
+  start_pending_ = false;
+  startup_service_.reset();
+  for (MountedModule& module : mounted_) ReleaseBoundModule(&module);
+  action_map_.clear();
 }
 
 }  // namespace modules

--- a/src/modules/gate/app_gate.h
+++ b/src/modules/gate/app_gate.h
@@ -24,10 +24,6 @@
 
 namespace modules {
 
-// Reject list of the most recent gate Start — the diagnostics module reads
-// this; there is exactly one gate (single choke point).
-const std::vector<RejectEntry>& CurrentRejects();
-
 class ConfigTransactionService;
 class GateStartupService;
 class SettingsAccessService;
@@ -64,6 +60,7 @@ class AppGate final {
   const std::vector<RejectEntry>& Rejects() const { return rejects_; }
   const std::vector<CapabilityGrant>& Grants() const { return grants_; }
   const std::vector<SettingsStoreDiagnostic>& SettingsDiagnostics() const;
+  DiagnosticsReadModel Diagnostics() const;
   bool Mounted(std::wstring_view module_id) const;
 
   // Lazy activation: builds the descriptor and Bind()s it on first visit.
@@ -74,20 +71,37 @@ class AppGate final {
   // From ModuleHost::RequestRoute; the gate may refuse unknown routes.
   core::Status RequestRoute(std::wstring_view route_id);
   const std::wstring& current_route() const { return current_route_; }
+  // Window lifetime and process lifetime are distinct. Closing the last
+  // window releases activated modules; Shutdown is final and idempotent.
+  void ReleaseWindowModules();
+  void Shutdown();
 
  private:
   struct MountedModule {
     ModuleManifest manifest;
     std::unique_ptr<ModuleDescriptor> descriptor;
     std::unique_ptr<GateHost> host;
+    bool settings_all_granted = false;
+    bool config_write_granted = false;
     bool activated = false;
+    bool bound_lifetime_started = false;
+    bool quarantined = false;
   };
 
   core::Status PairAndMount(std::wstring_view embedded_text, std::wstring_view override_text);
   MountedModule* FindByRoute(std::wstring_view route_id);
   MountedModule* FindByModule(std::wstring_view module_id);
+  core::Status BindModule(MountedModule* module);
+  void EnsureHost(MountedModule* module);
+  void ReleaseBoundModule(MountedModule* module);
+  void Quarantine(MountedModule* module, DiagnosticStage stage,
+                  std::wstring reason);
+  void ReportModuleStatus(std::wstring_view module_id,
+                          const core::Status& status);
 
   std::unique_ptr<ui::config::ResolvedUiDocument> document_;
+  json::Value core_catalog_;
+  std::vector<ui::config::ScreenSource> live_sources_;
   std::uint64_t document_generation_ = 0;
   std::unique_ptr<SettingsAccessService> settings_service_;
   std::unique_ptr<ConfigTransactionService> config_service_;
@@ -95,6 +109,8 @@ class AppGate final {
   std::vector<MountedModule> mounted_;
   std::vector<RejectEntry> rejects_;
   std::vector<CapabilityGrant> grants_;
+  std::vector<ModuleDiagnosticEntry> runtime_faults_;
+  std::vector<ModuleStatusEntry> module_statuses_;
   std::vector<std::pair<std::wstring, std::wstring>> action_map_;  // action -> moduleId
   std::wstring current_route_;
   void* operation_window_ = nullptr;
@@ -102,6 +118,7 @@ class AppGate final {
   HostStatePatchHandler state_patch_handler_;
   bool start_pending_ = false;
   core::Status start_status_;
+  bool shutdown_ = false;
 };
 
 }  // namespace modules

--- a/src/modules/gate/gate_host.cpp
+++ b/src/modules/gate/gate_host.cpp
@@ -11,6 +11,8 @@ namespace modules {
 GateHost::GateHost(std::wstring module_id,
                    HostRouteRequestHandler route_request_handler,
                    HostPeersHandler peers_handler,
+                   HostDiagnosticsProvider diagnostics_provider,
+                   HostStatusHandler status_handler,
                    SettingsAccessService* settings_service,
                    ConfigTransactionService* config_service,
                    bool settings_all_granted, bool config_write_granted,
@@ -20,6 +22,8 @@ GateHost::GateHost(std::wstring module_id,
     : module_id_(std::move(module_id)),
       route_request_handler_(std::move(route_request_handler)),
       peers_handler_(std::move(peers_handler)),
+      diagnostics_provider_(std::move(diagnostics_provider)),
+      status_handler_(std::move(status_handler)),
       settings_service_(settings_service),
       config_service_(config_service),
       settings_all_granted_(settings_all_granted),
@@ -35,7 +39,7 @@ GateHost::GateHost(std::wstring module_id,
       operation_window, operation_message, std::move(sink));
 }
 
-GateHost::~GateHost() = default;
+GateHost::~GateHost() { lifetime_alive_->store(false); }
 
 ModuleSurface GateHost::Surface() { return surface_; }
 
@@ -55,7 +59,17 @@ core::Status GateHost::SettingsWrite(std::wstring_view key,
 
 core::Status GateHost::StartSettingsLoad(HostOperationCallback callback,
                                          AsyncRequestToken* token) {
-  return settings_service_->StartLoad(std::move(callback), token);
+  if (!callback) {
+    return core::Err(core::ErrorCode::InvalidArgument,
+                     L"settings-ready callback is required");
+  }
+  const std::shared_ptr<std::atomic<bool>> alive = lifetime_alive_;
+  return settings_service_->StartLoad(
+      [alive, callback = std::move(callback)](
+          const HostOperationCompletion& completion) {
+        if (alive->load()) callback(completion);
+      },
+      token);
 }
 
 core::Status GateHost::StartProcess(const ProcessRequest& request,
@@ -115,6 +129,10 @@ core::Status GateHost::GetConfigWriteFacet(ConfigWriteFacet** facet) {
                          L"config:write is not granted");
 }
 
+DiagnosticsReadModel GateHost::Diagnostics() {
+  return diagnostics_provider_ ? diagnostics_provider_() : DiagnosticsReadModel{};
+}
+
 core::Status GateHost::ReadGlobal(std::wstring_view key, std::wstring* out) {
   return settings_service_->ReadGlobal(key, out);
 }
@@ -172,7 +190,10 @@ core::Status GateHost::Discard(
   return config_service_->Discard(preview, affected_routes);
 }
 
-void GateHost::ReportStatus(const core::Status& status) { last_status_ = status; }
+void GateHost::ReportStatus(const core::Status& status) {
+  last_status_ = status;
+  if (status_handler_) status_handler_(module_id_, status);
+}
 
 void GateHost::Log(std::wstring_view level, std::wstring_view text) {
   std::lock_guard lock(mutex_);

--- a/src/modules/gate/gate_host.h
+++ b/src/modules/gate/gate_host.h
@@ -2,6 +2,7 @@
 // translates that contract into the services owned by the application.
 #pragma once
 
+#include <atomic>
 #include <functional>
 #include <memory>
 #include <mutex>
@@ -23,6 +24,9 @@ using HostStatePatchHandler =
 using HostRouteRequestHandler =
     std::function<core::Status(std::wstring_view route_id)>;
 using HostPeersHandler = std::function<std::vector<PeerInfo>()>;
+using HostDiagnosticsProvider = std::function<DiagnosticsReadModel()>;
+using HostStatusHandler =
+    std::function<void(std::wstring_view module_id, const core::Status& status)>;
 
 class GateHost final : public ModuleHost,
                        public SettingsAllFacet,
@@ -31,6 +35,8 @@ class GateHost final : public ModuleHost,
   GateHost(std::wstring module_id,
            HostRouteRequestHandler route_request_handler,
            HostPeersHandler peers_handler,
+           HostDiagnosticsProvider diagnostics_provider,
+           HostStatusHandler status_handler,
            SettingsAccessService* settings_service,
            ConfigTransactionService* config_service,
            bool settings_all_granted, bool config_write_granted,
@@ -55,6 +61,7 @@ class GateHost final : public ModuleHost,
   core::Status PublishStatePatch(const json::Value& patch) override;
   core::Status GetSettingsAllFacet(SettingsAllFacet** facet) override;
   core::Status GetConfigWriteFacet(ConfigWriteFacet** facet) override;
+  DiagnosticsReadModel Diagnostics() override;
   core::Status ReadGlobal(std::wstring_view key, std::wstring* out) override;
   core::Status WriteGlobal(std::wstring_view key,
                            std::wstring_view value) override;
@@ -81,6 +88,8 @@ class GateHost final : public ModuleHost,
   std::wstring module_id_;
   HostRouteRequestHandler route_request_handler_;
   HostPeersHandler peers_handler_;
+  HostDiagnosticsProvider diagnostics_provider_;
+  HostStatusHandler status_handler_;
   SettingsAccessService* settings_service_;
   ConfigTransactionService* config_service_;
   bool settings_all_granted_ = false;
@@ -90,6 +99,8 @@ class GateHost final : public ModuleHost,
   std::vector<std::wstring> log_;
   core::Status last_status_;
   std::unique_ptr<HostOperationDispatcher> operations_;
+  std::shared_ptr<std::atomic<bool>> lifetime_alive_ =
+      std::make_shared<std::atomic<bool>>(true);
 };
 
 }  // namespace modules

--- a/src/modules/gate/module_validator.cpp
+++ b/src/modules/gate/module_validator.cpp
@@ -166,6 +166,21 @@ ui::config::ScreenSource FilterAcceptedSource(
   return {source.name, json::Serialize(filtered)};
 }
 
+ui::config::ScreenSource FilterWithdrawnSource(
+    const ui::config::ScreenSource& source, std::wstring_view module_id) {
+  json::Value document;
+  if (!json::Parse(source.text, &document).ok()) return source;
+  const json::Value* components = document.Find(L"components");
+  if (components == nullptr || !components->is_array()) return source;
+  json::Value filtered = json::Value::Object();
+  json::Value kept = json::Value::Array();
+  for (const json::Value& component : components->items()) {
+    if (component.StringField(L"module_id") != module_id) kept.Append(component);
+  }
+  filtered.Set(L"components", std::move(kept));
+  return {source.name, json::Serialize(filtered)};
+}
+
 core::Status ParseEnvelope(
     std::wstring_view embedded_text, std::wstring_view override_text,
     json::Value* envelope, json::Value* core_catalog,
@@ -255,7 +270,8 @@ core::Status ModuleValidator::Validate(
             {id,
              diagnostic.message.empty() ? valid.Message() : diagnostic.message,
              source.name, diagnostic.line > 0 ? diagnostic.line : 1,
-             diagnostic.column > 0 ? diagnostic.column : 1});
+             diagnostic.column > 0 ? diagnostic.column : 1,
+             DiagnosticStage::Pairing});
         schema_rejected.insert(id);
         continue;
       }
@@ -293,7 +309,8 @@ core::Status ModuleValidator::Validate(
         const core::Status parsed = json::Parse(manifest_text, &parsed_manifest);
         if (!parsed.ok()) {
           out->rejects.push_back(
-              {L"?", L"manifest invalid: " + parsed.Message(), manifest_file, 1, 1});
+              {L"?", L"manifest invalid: " + parsed.Message(), manifest_file, 1, 1,
+               DiagnosticStage::Manifest});
           continue;
         }
         manifest_value = &parsed_manifest;
@@ -317,18 +334,20 @@ core::Status ModuleValidator::Validate(
                  (diagnostic.message.empty() ? L"unknown error"
                                              : diagnostic.message),
              manifest_file, diagnostic.line > 0 ? diagnostic.line : 1,
-             diagnostic.column > 0 ? diagnostic.column : 1});
+             diagnostic.column > 0 ? diagnostic.column : 1,
+             DiagnosticStage::Manifest});
         continue;
       }
       const int manifest_line = raw_id != nullptr ? raw_id->line() : 1;
       const int manifest_column = raw_id != nullptr ? raw_id->column() : 1;
       auto reject = [&](std::wstring reason, std::wstring file = {}, int line = 0,
-                        int column = 0) {
+                        int column = 0,
+                        DiagnosticStage stage = DiagnosticStage::Pairing) {
         out->rejects.push_back(
             {manifest.module_id, std::move(reason),
              file.empty() ? manifest_file : std::move(file),
              line > 0 ? line : manifest_line,
-             column > 0 ? column : manifest_column});
+             column > 0 ? column : manifest_column, stage});
       };
 
       const RegisteredModule* registration = nullptr;
@@ -475,13 +494,15 @@ core::Status ModuleValidator::Validate(
         if (capability == kCapabilitySettingsAll) {
           if (manifest.module_id != L"settings") {
             reject(L"settings:all is reserved for module 'settings'",
-                   manifest_file, capability_line, capability_column);
+                   manifest_file, capability_line, capability_column,
+                   DiagnosticStage::Capability);
             capability_ok = false;
             break;
           }
           if (settings_all_claimed) {
             reject(L"settings:all already claimed by module 'settings'",
-                   manifest_file, capability_line, capability_column);
+                   manifest_file, capability_line, capability_column,
+                   DiagnosticStage::Capability);
             capability_ok = false;
             break;
           }
@@ -489,20 +510,23 @@ core::Status ModuleValidator::Validate(
         } else if (capability == kCapabilityConfigWrite) {
           if (manifest.module_id != L"ui-editor") {
             reject(L"config:write is reserved for module 'ui-editor'",
-                   manifest_file, capability_line, capability_column);
+                   manifest_file, capability_line, capability_column,
+                   DiagnosticStage::Capability);
             capability_ok = false;
             break;
           }
           if (config_write_claimed) {
             reject(L"config:write already claimed by module 'ui-editor'",
-                   manifest_file, capability_line, capability_column);
+                   manifest_file, capability_line, capability_column,
+                   DiagnosticStage::Capability);
             capability_ok = false;
             break;
           }
           config_write_granted = true;
         } else {
           reject(L"unknown capability '" + capability + L"'", manifest_file,
-                 capability_line, capability_column);
+                 capability_line, capability_column,
+                 DiagnosticStage::Capability);
           capability_ok = false;
           break;
         }
@@ -561,7 +585,8 @@ core::Status ModuleValidator::Validate(
   for (const std::wstring& id : screen_module_ids) {
     if (!manifest_ids.contains(id)) {
       out->rejects.push_back({id, L"screen half has no module.json manifest",
-                              ScreenSourceForModule(resolvable_sources, id), 1, 1});
+                              ScreenSourceForModule(resolvable_sources, id), 1, 1,
+                              DiagnosticStage::Pairing});
     }
   }
   for (const RegisteredModule& registration : registered) {
@@ -569,7 +594,8 @@ core::Status ModuleValidator::Validate(
         !screen_module_ids.contains(registration.module_id)) {
       out->rejects.push_back({registration.module_id,
                               L"logic half has no module.json manifest",
-                              L"registry", 1, 1});
+                              L"registry", 1, 1,
+                              DiagnosticStage::Pairing});
     }
   }
 
@@ -599,7 +625,28 @@ core::Status ModuleValidator::Validate(
   }
   accepted_document.Set(L"components", std::move(accepted_components));
   out->accepted_base = {L"embedded", json::Serialize(accepted_document)};
+  out->accepted_sources = accepted_sources;
   return core::Ok();
+}
+
+core::Status ModuleValidator::WithdrawModule(
+    const json::Value& core_catalog,
+    const std::vector<ui::config::ScreenSource>& current_sources,
+    std::wstring_view module_id,
+    std::vector<ui::config::ScreenSource>* filtered_sources,
+    std::unique_ptr<ui::config::ResolvedUiDocument>* document) const {
+  if (filtered_sources == nullptr || document == nullptr || module_id.empty()) {
+    return DHEPZ_ERR(core::ErrorCode::InvalidArgument,
+                     L"WithdrawModule requires outputs and a module id");
+  }
+  filtered_sources->clear();
+  filtered_sources->reserve(current_sources.size());
+  for (const ui::config::ScreenSource& source : current_sources) {
+    filtered_sources->push_back(FilterWithdrawnSource(source, module_id));
+  }
+  std::vector<ui::config::Diagnostic> diagnostics;
+  return ui::config::ResolveDocument(core_catalog, *filtered_sources,
+                                     &diagnostics, document);
 }
 
 }  // namespace modules

--- a/src/modules/gate/module_validator.h
+++ b/src/modules/gate/module_validator.h
@@ -16,21 +16,8 @@
 
 namespace modules {
 
-struct RejectEntry {
-  std::wstring module_id;
-  std::wstring reason;
-  std::wstring file;
-  int line = 0;
-  int column = 0;
-};
-
-struct CapabilityGrant {
-  std::wstring module_id;
-  std::wstring capability;
-  std::wstring file;
-  int line = 0;
-  int column = 0;
-};
+using RejectEntry = ModuleDiagnosticEntry;
+using CapabilityGrant = CapabilityGrantInfo;
 
 struct ValidatedModule {
   ModuleManifest manifest;
@@ -47,6 +34,7 @@ struct ModuleValidationResult {
   std::vector<RejectEntry> rejects;
   std::vector<CapabilityGrant> grants;
   std::vector<std::pair<std::wstring, std::wstring>> action_map;
+  std::vector<ui::config::ScreenSource> accepted_sources;
 };
 
 class ModuleValidator final {
@@ -55,6 +43,12 @@ class ModuleValidator final {
                         std::wstring_view override_text,
                         const std::vector<RegisteredModule>& registered,
                         ModuleValidationResult* out) const;
+  core::Status WithdrawModule(
+      const json::Value& core_catalog,
+      const std::vector<ui::config::ScreenSource>& current_sources,
+      std::wstring_view module_id,
+      std::vector<ui::config::ScreenSource>* filtered_sources,
+      std::unique_ptr<ui::config::ResolvedUiDocument>* document) const;
 };
 
 }  // namespace modules

--- a/tests/modules/gate/app_gate_test.cpp
+++ b/tests/modules/gate/app_gate_test.cpp
@@ -347,6 +347,8 @@ DHEPZ_TEST(AppGateContract, GeneratedEnvelopePreservesFileLineAndColumn) {
                  std::wstring(L"src/modules/ref-module/screen.json"));
   DHEPZ_CHECK_EQ(gate.Rejects()[0].line, 5);
   DHEPZ_CHECK(gate.Rejects()[0].column > 0);
+  DHEPZ_CHECK(gate.Rejects()[0].stage ==
+              modules::DiagnosticStage::Pairing);
   modules::ResetRegistryForTests();
 }
 

--- a/tests/modules/gate/capability_facets_test.cpp
+++ b/tests/modules/gate/capability_facets_test.cpp
@@ -315,6 +315,10 @@ DHEPZ_TEST(CapabilityFacets, SettingsAllIsTypedSharedAndRestrictedToSettingsModu
   DHEPZ_CHECK(gate.Rejects()[0].reason.find(L"settings:all") != std::wstring::npos);
   DHEPZ_CHECK(!gate.Rejects()[0].file.empty());
   DHEPZ_CHECK(gate.Rejects()[0].line > 0);
+  const modules::DiagnosticsReadModel diagnostics = gate.Diagnostics();
+  DHEPZ_CHECK_EQ(diagnostics.accepted.size(), static_cast<std::size_t>(2));
+  DHEPZ_CHECK_EQ(diagnostics.rejected.size(), static_cast<std::size_t>(1));
+  DHEPZ_CHECK_EQ(diagnostics.grants.size(), static_cast<std::size_t>(1));
 
   DHEPZ_CHECK(gate.Activate(L"settings-home").ok());
   DHEPZ_CHECK(gate.Activate(L"alpha-home").ok());

--- a/tests/modules/gate/runtime_quarantine_test.cpp
+++ b/tests/modules/gate/runtime_quarantine_test.cpp
@@ -1,0 +1,306 @@
+#include "modules/gate/app_gate.h"
+
+#include <windows.h>
+
+#include <atomic>
+#include <chrono>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <thread>
+
+#include "framework/test_case.h"
+#include "modules/registry/module_registry.h"
+#include "platform/worker.h"
+
+namespace {
+
+enum class FaultMode {
+  None,
+  BindStatus,
+  BindThrow,
+  InvalidArgument,
+  IoError,
+  Cancelled,
+  Internal,
+  HandleThrow,
+  StartAsync,
+};
+
+FaultMode g_fault_mode = FaultMode::None;
+int g_bind_count = 0;
+int g_release_count = 0;
+std::atomic<bool> g_async_completion{false};
+
+class FaultModule final : public modules::ModuleDescriptor {
+ public:
+  std::wstring_view ModuleId() const override { return L"faulty"; }
+  std::wstring_view TabLabel() const override { return L"Faulty"; }
+  int Order() const override { return 50; }
+  bool ShowInTabs() const override { return true; }
+  std::wstring_view SettingsRoute() const override { return {}; }
+  std::vector<std::wstring> DeclaredActions() const override {
+    return {L"faulty:run"};
+  }
+  std::vector<std::wstring> DeclaredBindings() const override { return {}; }
+  std::vector<std::wstring> DeclaredCapabilities() const override { return {}; }
+  core::Status Bind(modules::ModuleHost& host) override {
+    ++g_bind_count;
+    if (g_fault_mode == FaultMode::BindThrow) throw std::runtime_error("bind");
+    if (g_fault_mode == FaultMode::BindStatus) {
+      return core::Err(core::ErrorCode::IoError, L"bind failed");
+    }
+    if (g_fault_mode == FaultMode::StartAsync) {
+      modules::ProcessRequest request;
+      request.operation = modules::ProcessOperation::Capture;
+      request.executable = L"cmd.exe";
+      request.arguments = {L"/d", L"/s", L"/c",
+                           L"ping -n 3 127.0.0.1 >nul"};
+      request.timeout_ms = 5000;
+      modules::AsyncRequestToken token;
+      return host.StartProcess(
+          request,
+          [](const modules::HostOperationCompletion&) {
+            g_async_completion = true;
+          },
+          &token);
+    }
+    return core::Ok();
+  }
+  core::Status Handle(std::wstring_view, const json::Value&,
+                      json::Value*) override {
+    if (g_fault_mode == FaultMode::HandleThrow) {
+      throw std::runtime_error("handle");
+    }
+    if (g_fault_mode == FaultMode::InvalidArgument) {
+      return core::Err(core::ErrorCode::InvalidArgument, L"bad input");
+    }
+    if (g_fault_mode == FaultMode::IoError) {
+      return core::Err(core::ErrorCode::IoError, L"expected IO failure");
+    }
+    if (g_fault_mode == FaultMode::Cancelled) {
+      return core::Err(core::ErrorCode::Cancelled, L"cancelled");
+    }
+    if (g_fault_mode == FaultMode::Internal) {
+      return core::Err(core::ErrorCode::Internal, L"invariant broken");
+    }
+    return core::Ok();
+  }
+  void Release() override { ++g_release_count; }
+};
+
+class HealthyModule final : public modules::ModuleDescriptor {
+ public:
+  std::wstring_view ModuleId() const override { return L"healthy"; }
+  std::wstring_view TabLabel() const override { return L"Healthy"; }
+  int Order() const override { return 60; }
+  bool ShowInTabs() const override { return true; }
+  std::wstring_view SettingsRoute() const override { return {}; }
+  std::vector<std::wstring> DeclaredActions() const override {
+    return {L"healthy:run"};
+  }
+  std::vector<std::wstring> DeclaredBindings() const override { return {}; }
+  std::vector<std::wstring> DeclaredCapabilities() const override { return {}; }
+  core::Status Bind(modules::ModuleHost&) override { return core::Ok(); }
+  core::Status Handle(std::wstring_view, const json::Value&,
+                      json::Value*) override {
+    return core::Ok();
+  }
+  void Release() override {}
+};
+
+std::unique_ptr<modules::ModuleDescriptor> MakeFault() {
+  return std::make_unique<FaultModule>();
+}
+std::unique_ptr<modules::ModuleDescriptor> MakeHealthy() {
+  return std::make_unique<HealthyModule>();
+}
+
+std::wstring Embedded() {
+  return LR"({
+    "core": {
+      "schema": "dhepz.ui.core", "version": 1,
+      "tokens": { "dark": { "text": "#ffffff" }, "light": { "text": "#000000" } },
+      "allows_children": ["screen"],
+      "components": { "screen": { "properties": {
+        "route_id": { "kind": "string", "required": true },
+        "module_id": { "kind": "string" },
+        "tab_label": { "kind": "string" },
+        "show_in_tabs": { "kind": "bool" }
+      } } }
+    },
+    "components": [
+      { "type": "screen", "route_id": "faulty", "module_id": "faulty",
+        "tab_label": "Faulty" },
+      { "type": "screen", "route_id": "healthy", "module_id": "healthy",
+        "tab_label": "Healthy" }
+    ],
+    "modules": [
+      { "moduleId": "faulty", "tabLabel": "Faulty", "order": 50,
+        "actions": ["faulty:run"] },
+      { "moduleId": "healthy", "tabLabel": "Healthy", "order": 60,
+        "actions": ["healthy:run"] }
+    ]
+  })";
+}
+
+void Reset(FaultMode mode) {
+  modules::ResetRegistryForTests();
+  modules::RegisterModule(L"faulty", &MakeFault);
+  modules::RegisterModule(L"healthy", &MakeHealthy);
+  g_fault_mode = mode;
+  g_bind_count = 0;
+  g_release_count = 0;
+  g_async_completion = false;
+}
+
+core::Status DispatchFault(modules::AppGate* gate) {
+  json::Value payload;
+  json::Value patch;
+  return gate->Dispatch(L"faulty:run", payload, &patch);
+}
+
+unsigned int g_completion_message = 0;
+LRESULT CALLBACK QuarantineRigProc(HWND window, UINT message, WPARAM wparam,
+                                   LPARAM lparam) {
+  if (message == g_completion_message) {
+    worker::Worker::Settle(lparam);
+    return 0;
+  }
+  return DefWindowProcW(window, message, wparam, lparam);
+}
+
+struct Rig {
+  HWND window = nullptr;
+  Rig() {
+    WNDCLASSW cls{};
+    cls.lpfnWndProc = QuarantineRigProc;
+    cls.hInstance = GetModuleHandleW(nullptr);
+    cls.lpszClassName = L"dhepz.runtime-quarantine.test";
+    RegisterClassW(&cls);
+    g_completion_message =
+        RegisterWindowMessageW(L"dhepz.runtime-quarantine.completion");
+    window = CreateWindowExW(0, cls.lpszClassName, L"", WS_POPUP, 0, 0, 8, 8,
+                             nullptr, nullptr, cls.hInstance, nullptr);
+    DHEPZ_CHECK(window != nullptr);
+  }
+  ~Rig() {
+    if (window != nullptr) DestroyWindow(window);
+  }
+};
+
+void PumpFor(int milliseconds) {
+  const auto deadline = std::chrono::steady_clock::now() +
+                        std::chrono::milliseconds(milliseconds);
+  while (std::chrono::steady_clock::now() < deadline) {
+    MSG message;
+    while (PeekMessageW(&message, nullptr, 0, 0, PM_REMOVE)) {
+      DispatchMessageW(&message);
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }
+}
+
+}  // namespace
+
+DHEPZ_TEST(RuntimeQuarantine, OperationalStatusesDoNotDisableModule) {
+  for (const FaultMode mode : {FaultMode::InvalidArgument, FaultMode::IoError,
+                               FaultMode::Cancelled}) {
+    Reset(mode);
+    modules::AppGate gate;
+    DHEPZ_CHECK(gate.StartWithEmbedded(Embedded()).ok());
+    DHEPZ_CHECK(!DispatchFault(&gate).ok());
+    DHEPZ_CHECK(gate.Mounted(L"faulty"));
+    DHEPZ_CHECK(gate.document()->FindRoute(L"faulty") != nullptr);
+    DHEPZ_CHECK(gate.Diagnostics().runtime_faults.empty());
+    bool saw_operational_status = false;
+    for (const modules::ModuleStatusEntry& status : gate.Diagnostics().statuses) {
+      if (status.module_id == L"faulty" && !status.ok) {
+        saw_operational_status = true;
+      }
+    }
+    DHEPZ_CHECK(saw_operational_status);
+    json::Value payload;
+    json::Value patch;
+    DHEPZ_CHECK(gate.Dispatch(L"healthy:run", payload, &patch).ok());
+  }
+  modules::ResetRegistryForTests();
+}
+
+DHEPZ_TEST(RuntimeQuarantine, BindFailureAndExceptionQuarantineOnce) {
+  for (const FaultMode mode : {FaultMode::BindStatus, FaultMode::BindThrow}) {
+    Reset(mode);
+    modules::AppGate gate;
+    DHEPZ_CHECK(gate.StartWithEmbedded(Embedded()).ok());
+    DHEPZ_CHECK(!gate.Activate(L"faulty").ok());
+    DHEPZ_CHECK(!gate.Mounted(L"faulty"));
+    DHEPZ_CHECK(gate.document()->FindRoute(L"faulty") == nullptr);
+    DHEPZ_CHECK_EQ(g_release_count, 1);
+    const modules::DiagnosticsReadModel diagnostics = gate.Diagnostics();
+    DHEPZ_CHECK_EQ(diagnostics.runtime_faults.size(),
+                   static_cast<std::size_t>(1));
+    DHEPZ_CHECK(diagnostics.runtime_faults[0].stage ==
+                modules::DiagnosticStage::Bind);
+    DHEPZ_CHECK_EQ(diagnostics.runtime_faults[0].file,
+                   std::wstring(L"runtime"));
+    DHEPZ_CHECK(diagnostics.runtime_faults[0].line > 0);
+    DHEPZ_CHECK(!DispatchFault(&gate).ok());
+    DHEPZ_CHECK_EQ(g_release_count, 1);
+  }
+  modules::ResetRegistryForTests();
+}
+
+DHEPZ_TEST(RuntimeQuarantine, HandleExceptionAndInternalStatusQuarantine) {
+  for (const FaultMode mode : {FaultMode::HandleThrow, FaultMode::Internal}) {
+    Reset(mode);
+    modules::AppGate gate;
+    DHEPZ_CHECK(gate.StartWithEmbedded(Embedded()).ok());
+    DHEPZ_CHECK(!DispatchFault(&gate).ok());
+    DHEPZ_CHECK(!gate.Mounted(L"faulty"));
+    DHEPZ_CHECK(gate.document()->FindRoute(L"faulty") == nullptr);
+    DHEPZ_CHECK_EQ(g_release_count, 1);
+    DHEPZ_CHECK_EQ(gate.Diagnostics().runtime_faults.size(),
+                   static_cast<std::size_t>(1));
+    json::Value payload;
+    json::Value patch;
+    DHEPZ_CHECK(gate.Dispatch(L"healthy:run", payload, &patch).ok());
+  }
+  modules::ResetRegistryForTests();
+}
+
+DHEPZ_TEST(ModuleLifecycle, WindowReleaseAndShutdownAreIdempotent) {
+  Reset(FaultMode::None);
+  modules::AppGate gate;
+  DHEPZ_CHECK(gate.StartWithEmbedded(Embedded()).ok());
+  DHEPZ_CHECK(gate.Activate(L"faulty").ok());
+  DHEPZ_CHECK_EQ(g_bind_count, 1);
+  const ui::config::ResolvedUiDocument* document_before_release = gate.document();
+  const std::uint64_t generation_before_release = gate.document_generation();
+  gate.ReleaseWindowModules();
+  gate.ReleaseWindowModules();
+  DHEPZ_CHECK_EQ(g_release_count, 1);
+  DHEPZ_CHECK(gate.document() == document_before_release);
+  DHEPZ_CHECK_EQ(gate.document_generation(), generation_before_release);
+
+  DHEPZ_CHECK(gate.Activate(L"faulty").ok());
+  DHEPZ_CHECK_EQ(g_bind_count, 2);
+  gate.Shutdown();
+  gate.Shutdown();
+  DHEPZ_CHECK_EQ(g_release_count, 2);
+  modules::ResetRegistryForTests();
+}
+
+DHEPZ_TEST(ModuleLifecycle, WindowReleaseCancelsOutstandingCompletion) {
+  Rig rig;
+  Reset(FaultMode::StartAsync);
+  modules::AppGate gate;
+  DHEPZ_CHECK(
+      gate.ConfigureHostOperations(rig.window, g_completion_message, {}).ok());
+  DHEPZ_CHECK(gate.StartWithEmbedded(Embedded()).ok());
+  DHEPZ_CHECK(gate.Activate(L"faulty").ok());
+  gate.ReleaseWindowModules();
+  PumpFor(250);
+  DHEPZ_CHECK(!g_async_completion.load());
+  DHEPZ_CHECK_EQ(g_release_count, 1);
+  modules::ResetRegistryForTests();
+}


### PR DESCRIPTION
## Outcome\n\n- adds immutable parent-owned diagnostics metadata to the child contract\n- removes g_rejects/CurrentRejects() and all gate includes from diagnostics feature code\n- records accepted/rejected modules, grants, latest statuses, and runtime faults\n- keeps operational action errors mounted and retryable\n- quarantines failed bind, boundary exceptions, and explicit internal results\n- withdraws quarantined actions/routes while healthy siblings remain available\n- releases each started bind lifetime exactly once on close, quarantine, or shutdown\n- invalidates outstanding host completions when a window/module lifetime ends\n- documents the status/quarantine policy in ADR 0003\n\nAppGate remains an orchestration/lifecycle object (363 lines) with no platform, file, or process dependency.\n\n## Focused local verification\n\n- RuntimeQuarantine: 3/3\n- ModuleLifecycle: 2/2\n- Diagnostics filter: 4/4\n- AppGate/contract/startup/host filter: 13/13\n- CapabilityFacets: 2/2\n- SettingsPersistence: 1/1\n- linked RCDATA validation passed on each affected build\n- static diagnostics/global/platform boundary scans and git diff --check clean\n\nThe hosted CI run is the sole full Debug/Release regression for this PR SHA.\n\nCloses #109