### PR TITLE
IC-06: compose the production JSON UI path

### DIFF
--- a/src/application/production_application.cpp
+++ b/src/application/production_application.cpp
@@ -1,0 +1,244 @@
+#include "application/production_application.h"
+
+#include <windows.h>
+#include <dwmapi.h>
+
+#include "core/json.h"
+#include "modules/gate/app_gate.h"
+#include "platform/performance_trace.h"
+#include "platform/tray_process.h"
+#include "platform/worker.h"
+#include "render/gdi_resource_cache.h"
+#include "ui/presenter/screen_presenter.h"
+#include "ui/shell/app_window.h"
+
+namespace application {
+namespace {
+
+core::Status TrayStartStatus(tray::StartResult result) {
+  switch (result) {
+    case tray::StartResult::Ok:
+      return core::Ok();
+    case tray::StartResult::WindowClassFailed:
+      return DHEPZ_ERR(core::ErrorCode::Internal,
+                       L"Infrastructure window class registration failed");
+    case tray::StartResult::WindowCreateFailed:
+      return DHEPZ_ERR(core::ErrorCode::Internal,
+                       L"Infrastructure window creation failed");
+    case tray::StartResult::TaskbarMessageFailed:
+      return DHEPZ_ERR(core::ErrorCode::Internal,
+                       L"TaskbarCreated message registration failed");
+  }
+  return DHEPZ_ERR(core::ErrorCode::Internal, L"Unknown tray startup result");
+}
+
+void ShowActivationFailure(const core::Status& status) {
+  const std::wstring message = L"The launcher window could not be shown.\n\n" +
+                               status.Message();
+  MessageBoxW(nullptr, message.c_str(), L"dhepz", MB_OK | MB_ICONERROR);
+}
+
+}  // namespace
+
+ProductionApplication::ProductionApplication()
+    : tray_(std::make_unique<tray::TrayProcess>()) {}
+
+ProductionApplication::~ProductionApplication() { Shutdown(); }
+
+core::Status ProductionApplication::Start(void* instance, bool tray_only) {
+  if (started_) {
+    return DHEPZ_ERR(core::ErrorCode::AlreadyExists,
+                     L"Production application was already started");
+  }
+  if (instance == nullptr) {
+    return DHEPZ_ERR(core::ErrorCode::InvalidArgument,
+                     L"Production application requires a module instance");
+  }
+
+  instance_ = instance;
+  DHEPZ_RETURN_IF_ERROR(TrayStartStatus(tray_->Start(instance_)));
+  started_ = true;
+  tray_->set_activate_handler([this] {
+    const core::Status shown = ShowMainWindow();
+    if (!shown.ok()) ShowActivationFailure(shown);
+  });
+  (void)tray_->InstallTray();  // Explorer may be absent; the process may still run.
+
+  if (tray_only) return core::Ok();
+  const core::Status shown = ShowMainWindow();
+  if (!shown.ok()) Shutdown();
+  return shown;
+}
+
+core::Status ProductionApplication::ComposeWindow() {
+  cache_ = std::make_unique<render::GdiResourceCache>();
+  window_ = std::make_unique<shell::AppWindow>(cache_.get());
+  if (!window_->Create(instance_)) {
+    DestroyWindowState();
+    return DHEPZ_ERR(core::ErrorCode::Internal,
+                     L"Launcher window creation failed");
+  }
+
+  worker_completion_message_ =
+      RegisterWindowMessageW(L"dhepz.production.worker.completion");
+  if (worker_completion_message_ == 0) {
+    DestroyWindowState();
+    return DHEPZ_ERR(core::ErrorCode::Internal,
+                     L"Worker completion message registration failed");
+  }
+  window_->set_message_handler(
+      [message_id = worker_completion_message_](unsigned int message,
+                                                unsigned long long,
+                                                long long lparam) {
+        if (message != message_id) return false;
+        worker::Worker::Settle(lparam);
+        return true;
+      });
+
+  gate_ = std::make_unique<modules::AppGate>();
+  const core::Status host_configured = gate_->ConfigureHostOperations(
+      window_->hwnd(), worker_completion_message_,
+      [](std::wstring_view, const json::Value&) {
+        return DHEPZ_ERR(core::ErrorCode::Unsupported,
+                         L"Route state bridge is introduced by IC-07");
+      });
+  if (!host_configured.ok()) {
+    DestroyWindowState();
+    return host_configured;
+  }
+  const core::Status started = gate_->Start();
+  if (!started.ok()) {
+    DestroyWindowState();
+    return started;
+  }
+  if (gate_->start_pending() || gate_->document() == nullptr) {
+    DestroyWindowState();
+    return DHEPZ_ERR(core::ErrorCode::Internal,
+                     L"Embedded UI startup did not produce a document");
+  }
+
+  trace::TraceConfigResolved();
+  startup_stage_ = StartupStage::ConfigResolved;
+
+  // Binding the initial module may quarantine it. That is degraded mode, not
+  // a fatal shell failure; use the gate's resulting live document.
+  (void)gate_->Activate(gate_->document()->initial_route());
+  presenter_ = std::make_unique<ui::presenter::ScreenPresenter>(window_->backend());
+  presenter_->SetDocument(gate_->document());
+  presenter_->set_caption_height(40.0f);
+
+  window_->set_content_layout(
+      [this](const render::Rect& content) { OnLayout(content); });
+  window_->set_content_painter(
+      [this](render::GdiBackend&, const render::Rect& content) {
+        presenter_->Paint(content);
+      });
+  window_->set_content_key_handler(
+      [this](int key) { return presenter_->HandleKey(key); });
+  window_->set_content_click_handler(
+      [this](float x, float y) { return presenter_->HandleClick(x, y); });
+  window_->set_content_move_handler(
+      [this](float x, float y) { return presenter_->HandleMove(x, y); });
+  window_->set_content_down_handler(
+      [this](float x, float y) { return presenter_->HandleDown(x, y); });
+  window_->set_content_hittest_handler(
+      [this](float x, float y) { return presenter_->HitTestContent(x, y); });
+  window_->set_frame_presented_handler([this] { OnFramePresented(); });
+  window_->set_visibility_handler([this](bool visible) {
+    if (!visible && gate_) gate_->ReleaseWindowModules();
+  });
+  return core::Ok();
+}
+
+void ProductionApplication::OnLayout(const render::Rect& content) {
+  if (startup_stage_ == StartupStage::ConfigResolved) {
+    trace::TraceRenderBufferReady();
+    startup_stage_ = StartupStage::RenderBufferReady;
+  }
+  presenter_->Prepare(content);
+  if (startup_stage_ == StartupStage::RenderBufferReady) {
+    trace::TraceFirstLayoutComplete();
+    startup_stage_ = StartupStage::FirstLayoutComplete;
+  }
+}
+
+void ProductionApplication::OnFramePresented() {
+  if (startup_stage_ == StartupStage::FirstLayoutComplete) {
+    trace::TraceFirstPresentComplete();
+    startup_stage_ = StartupStage::FirstPresentComplete;
+  }
+}
+
+core::Status ProductionApplication::ShowMainWindow() {
+  if (!started_) {
+    return DHEPZ_ERR(core::ErrorCode::InvalidArgument,
+                     L"Production application has not started");
+  }
+  if (!window_) DHEPZ_RETURN_IF_ERROR(ComposeWindow());
+
+  // Rebind the current route after close/minimise invalidated window lifetime.
+  (void)gate_->Activate(presenter_->current_route());
+  HWND hwnd = static_cast<HWND>(window_->hwnd());
+  if (window_->visible()) {
+    if (IsIconic(hwnd)) ShowWindow(hwnd, SW_RESTORE);
+    SetForegroundWindow(hwnd);
+    return core::Ok();
+  }
+
+  window_->Show();
+  if (!window_->visible()) {
+    return DHEPZ_ERR(core::ErrorCode::Internal,
+                     L"Launcher window remained hidden after ShowWindow");
+  }
+  if (startup_stage_ == StartupStage::FirstPresentComplete &&
+      SUCCEEDED(DwmFlush())) {
+    trace::TraceFirstFrameVisible();
+    startup_stage_ = StartupStage::FirstFrameVisible;
+  }
+  SetForegroundWindow(hwnd);
+  return core::Ok();
+}
+
+int ProductionApplication::Run() { return started_ ? tray_->Run() : 1; }
+
+void ProductionApplication::DestroyWindowState() {
+  if (gate_) gate_->Shutdown();
+  if (window_) {
+    window_->set_visibility_handler({});
+    window_->set_frame_presented_handler({});
+    window_->set_message_handler({});
+    window_->set_content_layout({});
+    window_->set_content_painter({});
+    window_->set_content_key_handler({});
+    window_->set_content_click_handler({});
+    window_->set_content_move_handler({});
+    window_->set_content_down_handler({});
+    window_->set_content_hittest_handler({});
+  }
+  presenter_.reset();
+  if (window_) window_->Destroy();
+  gate_.reset();
+  window_.reset();
+  cache_.reset();
+  worker_completion_message_ = 0;
+  startup_stage_ = StartupStage::None;
+}
+
+void ProductionApplication::Shutdown() {
+  if (!tray_) return;
+  tray_->set_activate_handler({});
+  DestroyWindowState();
+  tray_->Shutdown();
+  started_ = false;
+  instance_ = nullptr;
+}
+
+void* ProductionApplication::tray_window() const {
+  return tray_ ? tray_->window() : nullptr;
+}
+
+bool ProductionApplication::startup_trace_complete() const {
+  return startup_stage_ == StartupStage::FirstFrameVisible;
+}
+
+}  // namespace application

--- a/src/application/production_application.h
+++ b/src/application/production_application.h
@@ -1,0 +1,63 @@
+// Production composition root: owns the parent-level object graph and only
+// coordinates lifecycle. Feature logic remains behind AppGate/ModuleHost.
+#pragma once
+
+#include <cstdint>
+#include <memory>
+
+#include "core/status.h"
+
+namespace modules { class AppGate; }
+namespace render { class GdiResourceCache; struct Rect; }
+namespace shell { class AppWindow; }
+namespace tray { class TrayProcess; }
+namespace ui::presenter { class ScreenPresenter; }
+
+namespace application {
+
+class ProductionApplication final {
+ public:
+  ProductionApplication();
+  ~ProductionApplication();
+
+  ProductionApplication(const ProductionApplication&) = delete;
+  ProductionApplication& operator=(const ProductionApplication&) = delete;
+
+  core::Status Start(void* instance, bool tray_only);
+  core::Status ShowMainWindow();
+  int Run();
+  void Shutdown();
+
+  void* tray_window() const;
+  shell::AppWindow* window() const { return window_.get(); }
+  modules::AppGate* gate() const { return gate_.get(); }
+  ui::presenter::ScreenPresenter* presenter() const { return presenter_.get(); }
+  bool startup_trace_complete() const;
+
+ private:
+  enum class StartupStage {
+    None,
+    ConfigResolved,
+    RenderBufferReady,
+    FirstLayoutComplete,
+    FirstPresentComplete,
+    FirstFrameVisible,
+  };
+
+  core::Status ComposeWindow();
+  void DestroyWindowState();
+  void OnLayout(const render::Rect& content);
+  void OnFramePresented();
+
+  void* instance_ = nullptr;
+  std::unique_ptr<tray::TrayProcess> tray_;
+  std::unique_ptr<render::GdiResourceCache> cache_;
+  std::unique_ptr<shell::AppWindow> window_;
+  std::unique_ptr<modules::AppGate> gate_;
+  std::unique_ptr<ui::presenter::ScreenPresenter> presenter_;
+  StartupStage startup_stage_ = StartupStage::None;
+  unsigned int worker_completion_message_ = 0;
+  bool started_ = false;
+};
+
+}  // namespace application

--- a/src/dhepz.vcxproj
+++ b/src/dhepz.vcxproj
@@ -110,7 +110,7 @@
       <!-- /CETCOMPAT and HighEntropyVA are the two most commonly forgotten
            hardening flags; both are set deliberately. -->
       <AdditionalOptions>/CETCOMPAT %(AdditionalOptions)</AdditionalOptions>
-      <AdditionalDependencies>user32.lib;gdi32.lib;shell32.lib;shlwapi.lib;advapi32.lib;ole32.lib;windowsapp.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>user32.lib;gdi32.lib;shell32.lib;shlwapi.lib;advapi32.lib;ole32.lib;windowsapp.lib;dwmapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <Manifest>
       <AdditionalManifestFiles>$(ProjectDir)app.manifest</AdditionalManifestFiles>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,19 +9,13 @@
 #include <vector>
 
 #include "app_version.h"
+#include "application/production_application.h"
 #include "core/json.h"
 #include "modules/gate/app_gate.h"
 #include "platform/files.h"
 #include "platform/performance_trace.h"
-#include "platform/tray_process.h"
 #include "ui/config/resolved_ui_document.h"
 
-// Phase 0's tray-resident process: one hidden infrastructure window and one
-// tray icon, no UI, no config, no modules. This is the thing whose idle
-// cost gets measured (#13), so it stays genuinely minimal: exactly one
-// thread, a message loop that blocks in GetMessageW, and nothing that wakes
-// when nothing changed.
-//
 // wWinMain rather than main: SubSystem is Windows, so there is no console
 // window to flash on launch. That matters for the ~400 ms cold-start budget
 // and for the silent --tray path.
@@ -30,9 +24,10 @@ namespace {
 // Distinct numeric exit codes for every bootstrap failure, each with a
 // MessageBox — no silent exits. The codes start at 10 so they cannot be
 // confused with a normal 0/1 result.
-[[noreturn]] void BootstrapFailed(unsigned int code, const wchar_t* what) {
-  MessageBoxW(nullptr, what, L"dhepz", MB_OK | MB_ICONERROR);
-  ExitProcess(code);
+int BootstrapFailed(unsigned int code, const core::Status& status) {
+  const std::wstring message = L"Application startup failed.\n\n" + status.Message();
+  MessageBoxW(nullptr, message.c_str(), L"dhepz", MB_OK | MB_ICONERROR);
+  return static_cast<int>(code);
 }
 
 // Build-time validation (#57): resolve the core catalog plus every screen
@@ -129,12 +124,14 @@ int APIENTRY wWinMain(_In_ HINSTANCE instance,
   // Tooling path (#57): validate the UI config and exit, no tray, no window.
   int argc = 0;
   LPWSTR* argv = CommandLineToArgvW(GetCommandLineW(), &argc);
+  bool tray_only = false;
   for (int i = 0; i < argc && argv != nullptr; ++i) {
     if (lstrcmpW(argv[i], L"--validate-embedded") == 0) {
       const int code = RunValidateEmbedded();
       LocalFree(argv);
       return code;
     }
+    if (lstrcmpW(argv[i], L"--tray") == 0) tray_only = true;
   }
   for (int i = 0; i + 2 < argc + 1 && argv != nullptr; ++i) {
     if (lstrcmpW(argv[i], L"--validate-ui") == 0 && i + 2 <= argc - 1) {
@@ -155,23 +152,10 @@ int APIENTRY wWinMain(_In_ HINSTANCE instance,
   const std::int64_t process_entry_qpc = trace::CurrentQpc();
   trace::PerformanceTraceSession session(process_entry_qpc);
 
-  tray::TrayProcess tray_process;
-  switch (tray_process.Start(instance)) {
-    case tray::StartResult::Ok:
-      break;
-    case tray::StartResult::WindowClassFailed:
-      BootstrapFailed(10, L"The infrastructure window class could not be registered.");
-    case tray::StartResult::WindowCreateFailed:
-      BootstrapFailed(11, L"The infrastructure window could not be created.");
-    case tray::StartResult::TaskbarMessageFailed:
-      BootstrapFailed(12, L"The TaskbarCreated message could not be registered.");
-  }
-
-  // Non-fatal by design: a headless session has no shell to host the icon,
-  // and the process must still run (CI, automated runs).
-  tray_process.InstallTray();
-
-  const int result = tray_process.Run();
-  tray_process.Shutdown();
+  application::ProductionApplication application;
+  const core::Status started = application.Start(instance, tray_only);
+  if (!started.ok()) return BootstrapFailed(10, started);
+  const int result = application.Run();
+  application.Shutdown();
   return result;
 }

--- a/src/platform/tray_process.cpp
+++ b/src/platform/tray_process.cpp
@@ -59,6 +59,10 @@ bool TrayProcess::InstallTray() noexcept {
   return tray_icon_added_;
 }
 
+void TrayProcess::set_activate_handler(std::function<void()> handler) {
+  activate_handler_ = std::move(handler);
+}
+
 int TrayProcess::Run() noexcept {
   MSG message{};
   // Blocks in GetMessageW. No timers, no polling, no idle processing: the
@@ -148,8 +152,9 @@ void TrayProcess::HandleTrayCallback(unsigned long long wparam, long long lparam
     ShowMenu();
     return;
   }
-  // NIN_SELECT / NIN_KEYSELECT / WM_LBUTTONUP will activate the main window
-  // once one exists; the tray-only process has nothing to show yet.
+  if (event == NIN_SELECT || event == NIN_KEYSELECT || event == WM_LBUTTONUP) {
+    if (activate_handler_) activate_handler_();
+  }
 }
 
 void TrayProcess::ShowMenu() {

--- a/src/platform/tray_process.h
+++ b/src/platform/tray_process.h
@@ -18,6 +18,8 @@
 // Like all of platform/, this layer keeps windows.h out of the header.
 #pragma once
 
+#include <functional>
+
 namespace trace {
 class PerformanceTraceSession;
 }
@@ -54,6 +56,9 @@ class TrayProcess final {
   // shell refuses (a headless session): the process stays up without a tray.
   bool InstallTray() noexcept;
 
+  // Requests that the parent composition owner show its main window.
+  void set_activate_handler(std::function<void()> handler);
+
   // Blocks in GetMessageW until Exit. No timers, no polling, no idle work.
   int Run() noexcept;
 
@@ -79,6 +84,7 @@ class TrayProcess final {
   void* window_ = nullptr;
   unsigned int taskbar_created_message_ = 0;
   bool tray_icon_added_ = false;
+  std::function<void()> activate_handler_;
 };
 
 }  // namespace tray

--- a/src/ui/shell/app_window.cpp
+++ b/src/ui/shell/app_window.cpp
@@ -149,6 +149,19 @@ void AppWindow::set_content_hittest_handler(std::function<bool(float, float)> ha
   content_hittest_handler_ = std::move(handler);
 }
 
+void AppWindow::set_visibility_handler(std::function<void(bool)> handler) {
+  visibility_handler_ = std::move(handler);
+}
+
+void AppWindow::set_frame_presented_handler(std::function<void()> handler) {
+  frame_presented_handler_ = std::move(handler);
+}
+
+void AppWindow::set_message_handler(
+    std::function<bool(unsigned int, unsigned long long, long long)> handler) {
+  message_handler_ = std::move(handler);
+}
+
 int AppWindow::ButtonCount() const {
   // Left-to-right: pin, [settings], close. Minimise/maximise arrive later
   // as a user toggle; the window is already resizable.
@@ -165,6 +178,7 @@ void AppWindow::Show() {
   GetClientRect(window, &client);
   OnResized(client.right, client.bottom);
   ShowWindow(window, SW_SHOW);
+  if (visibility_handler_) visibility_handler_(true);
 }
 
 void AppWindow::Hide() {
@@ -173,6 +187,7 @@ void AppWindow::Hide() {
   ShowWindow(window, SW_HIDE);
   // The buffer is the one large allocation and scales with window size.
   backend_.ReleaseSurface();
+  if (visibility_handler_) visibility_handler_(false);
 }
 
 void AppWindow::Close() {
@@ -319,6 +334,7 @@ void AppWindow::RenderFullFrame() {
   PaintContent();
   backend_.EndFrame();
   backend_.PresentLayered(hwnd_);
+  if (frame_presented_handler_) frame_presented_handler_();
 }
 
 void AppWindow::PaintContent() {
@@ -411,6 +427,7 @@ long long AppWindow::HandleMessage(void* window_handle, unsigned int message,
     settle_timer_->OnTimer();
     return 0;
   }
+  if (message_handler_ && message_handler_(message, wparam, lparam)) return 0;
   switch (message) {
     case WM_THEMECHANGED:
     case WM_DWMCOLORIZATIONCOLORCHANGED:
@@ -442,6 +459,7 @@ long long AppWindow::HandleMessage(void* window_handle, unsigned int message,
       if (IsIconic(window)) {
         // Minimised is hidden for budget purposes: the buffer goes away too.
         backend_.ReleaseSurface();
+        if (visibility_handler_) visibility_handler_(false);
         return 0;
       }
       // The buffer exists only while visible: Show() renders it before

--- a/src/ui/shell/app_window.h
+++ b/src/ui/shell/app_window.h
@@ -119,6 +119,13 @@ class AppWindow final {
   // otherwise clicks become caption drags and hover never arrives.
   void set_content_hittest_handler(std::function<bool(float x_logical, float y_logical)> handler);
 
+  // Narrow lifecycle seams used by the production composition owner.
+  void set_visibility_handler(std::function<void(bool visible)> handler);
+  void set_frame_presented_handler(std::function<void()> handler);
+  void set_message_handler(
+      std::function<bool(unsigned int message, unsigned long long wparam,
+                         long long lparam)> handler);
+
  private:
   static long long __stdcall WindowProc(void* window, unsigned int message,
                                         unsigned long long wparam, long long lparam);
@@ -151,6 +158,9 @@ class AppWindow final {
   std::function<bool(float, float)> content_move_handler_;
   std::function<bool(float, float)> content_down_handler_;
   std::function<bool(float, float)> content_hittest_handler_;
+  std::function<void(bool)> visibility_handler_;
+  std::function<void()> frame_presented_handler_;
+  std::function<bool(unsigned int, unsigned long long, long long)> message_handler_;
   std::uint32_t last_os_signals_ = 0;
   unsigned int drain_message_ = 0;
   float dpi_ = 96.0f;

--- a/tests/app_icon.rc
+++ b/tests/app_icon.rc
@@ -8,3 +8,6 @@ IDI_APP_ICON ICON "..\\assets\\app.ico"
 
 // Compiled-resource seam for AppGate startup/override integration tests.
 APP_GATE_TEST_UI RCDATA "fixtures\\app_gate_embedded.json"
+
+// Production composition uses the application's exact named resource path.
+EMBEDDED_UI RCDATA "..\\build\\generated\\embedded_ui.tests.json"

--- a/tests/application/production_application_test.cpp
+++ b/tests/application/production_application_test.cpp
@@ -1,0 +1,83 @@
+#include "application/production_application.h"
+
+#include <windows.h>
+#include <shellapi.h>
+
+#include <chrono>
+#include <thread>
+
+#include "framework/test_case.h"
+#include "modules/gate/app_gate.h"
+#include "ui/presenter/screen_presenter.h"
+#include "ui/shell/app_window.h"
+
+namespace {
+void PumpFor(int milliseconds) {
+  const auto deadline = std::chrono::steady_clock::now() +
+                        std::chrono::milliseconds(milliseconds);
+  while (std::chrono::steady_clock::now() < deadline) {
+    MSG message{};
+    while (PeekMessageW(&message, nullptr, 0, 0, PM_REMOVE)) {
+      TranslateMessage(&message);
+      DispatchMessageW(&message);
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }
+}
+}  // namespace
+
+DHEPZ_TEST(ProductionApplication, NormalLaunchComposesAndShowsEmbeddedJsonUi) {
+  application::ProductionApplication app;
+  const core::Status start = app.Start(GetModuleHandleW(nullptr), false);
+  DHEPZ_CHECK_EQ(start.Message(), std::wstring());
+  DHEPZ_CHECK(app.gate() != nullptr);
+  DHEPZ_CHECK(app.gate()->document() != nullptr);
+  DHEPZ_CHECK(app.presenter() != nullptr);
+  DHEPZ_CHECK_EQ(app.presenter()->current_route(), std::wstring(L"home"));
+  DHEPZ_CHECK(app.window() != nullptr);
+  DHEPZ_CHECK(app.window()->visible());
+  DHEPZ_CHECK(app.window()->backend()->buffer_width() > 0);
+  DHEPZ_CHECK(app.startup_trace_complete());
+  app.Shutdown();
+}
+
+DHEPZ_TEST(ProductionApplication, TrayOnlyDefersUiUntilTrayActivation) {
+  application::ProductionApplication app;
+  const core::Status start = app.Start(GetModuleHandleW(nullptr), true);
+  DHEPZ_CHECK_EQ(start.Message(), std::wstring());
+  DHEPZ_CHECK(app.window() == nullptr);
+  DHEPZ_CHECK(app.presenter() == nullptr);
+  DHEPZ_CHECK(app.gate() == nullptr);
+  DHEPZ_CHECK_FALSE(app.startup_trace_complete());
+
+  SendMessageW(static_cast<HWND>(app.tray_window()), WM_APP + 1, 0,
+               MAKELPARAM(NIN_SELECT, 1));
+  PumpFor(20);
+  DHEPZ_CHECK(app.window() != nullptr);
+  DHEPZ_CHECK(app.window()->visible());
+  DHEPZ_CHECK(app.presenter() != nullptr);
+  DHEPZ_CHECK(app.gate() != nullptr);
+  app.Shutdown();
+}
+
+DHEPZ_TEST(ProductionApplication, CloseReleasesAndNextShowRebuildsCompleteFrame) {
+  application::ProductionApplication app;
+  const core::Status start = app.Start(GetModuleHandleW(nullptr), false);
+  DHEPZ_CHECK_EQ(start.Message(), std::wstring());
+  shell::AppWindow* window = app.window();
+  DHEPZ_CHECK(window != nullptr);
+
+  SendMessageW(static_cast<HWND>(window->hwnd()), WM_CLOSE, 0, 0);
+  DHEPZ_CHECK_FALSE(window->visible());
+  DHEPZ_CHECK_EQ(window->backend()->buffer_width(), 0);
+
+  DHEPZ_CHECK(app.ShowMainWindow().ok());
+  DHEPZ_CHECK(window->visible());
+  DHEPZ_CHECK(window->backend()->buffer_width() > 0);
+  const int x = window->backend()->buffer_width() / 2;
+  const int y = window->backend()->buffer_height() / 2;
+  DHEPZ_CHECK_EQ(
+      static_cast<unsigned long long>(window->backend()->PixelAt(x, y) >> 24),
+      0xFFull);
+  app.Shutdown();
+}

--- a/tests/dhepz_tests.vcxproj
+++ b/tests/dhepz_tests.vcxproj
@@ -51,6 +51,10 @@
     <TargetName>dhepz_tests</TargetName>
   </PropertyGroup>
 
+  <Target Name="GenerateEmbeddedUiForTests" BeforeTargets="ResourceCompile">
+    <Exec Command="pwsh -NoProfile -ExecutionPolicy Bypass &quot;$(ProjectDir)..\tools\Merge-UiConfig.ps1&quot; -GenerateEmbedded -RepositoryRoot &quot;$(ProjectDir)..&quot; -EmbeddedOutputPath &quot;$(GeneratedDir)embedded_ui.tests.json&quot;" />
+  </Target>
+
   <ItemDefinitionGroup>
     <ClCompile>
       <!-- The same flag set as the app, on purpose. A test suite compiled under
@@ -81,7 +85,7 @@
       <DataExecutionPrevention>true</DataExecutionPrevention>
       <HighEntropyVA>true</HighEntropyVA>
       <ControlFlowGuard>Guard</ControlFlowGuard>
-      <AdditionalDependencies>user32.lib;gdi32.lib;shell32.lib;shlwapi.lib;advapi32.lib;ole32.lib;windowsapp.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>user32.lib;gdi32.lib;shell32.lib;shlwapi.lib;advapi32.lib;ole32.lib;windowsapp.lib;dwmapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
 
@@ -119,6 +123,7 @@
        the self-registration, leaving a green run with zero tests. -->
   <ItemGroup>
     <ClCompile Include="**\*.cpp" />
+    <ClCompile Include="..\src\application\**\*.cpp" />
     <ClCompile Include="..\src\core\**\*.cpp" />
     <ClCompile Include="..\src\platform\**\*.cpp" />
     <ClCompile Include="..\src\render\**\*.cpp" />

--- a/tools/Merge-UiConfig.ps1
+++ b/tools/Merge-UiConfig.ps1
@@ -18,7 +18,9 @@ param(
 
     [switch] $GenerateEmbedded,
 
-    [string] $RepositoryRoot
+    [string] $RepositoryRoot,
+
+    [string] $EmbeddedOutputPath
 )
 
 Set-StrictMode -Version Latest
@@ -88,10 +90,14 @@ if ($GenerateEmbedded) {
         sources = $sources
         modules = $manifests
     }
-    $outDir = Join-Path $RepositoryRoot 'build\generated'
+    if (-not $PSBoundParameters.ContainsKey('EmbeddedOutputPath')) {
+        $EmbeddedOutputPath = Join-Path $RepositoryRoot 'build\generated\embedded_ui.json'
+    }
+    $EmbeddedOutputPath = [System.IO.Path]::GetFullPath($EmbeddedOutputPath)
+    $outDir = Split-Path -Parent $EmbeddedOutputPath
     $null = New-Item -ItemType Directory -Force -Path $outDir
     $json = ($merged | ConvertTo-Json -Depth 32) + "`n"
-    [System.IO.File]::WriteAllText((Join-Path $outDir 'embedded_ui.json'), $json, (New-Object System.Text.UTF8Encoding($false)))
+    [System.IO.File]::WriteAllText($EmbeddedOutputPath, $json, (New-Object System.Text.UTF8Encoding($false)))
     Write-Host "Embedded UI document written ($componentCount components)."
     exit 0
 }


### PR DESCRIPTION
Closes #110

## Outcome
- normal launch now composes AppGate, AppWindow, and ScreenPresenter through a dedicated ProductionApplication owner
- explicit --tray defers every UI/config/module object until tray activation
- close/minimize releases window lifetime and backing surface; show rebinds and renders before visibility
- startup milestones are emitted from the real production frame path through DwmFlush
- tooling modes still return before runtime/tray composition

## Architecture
ProductionApplication owns application lifecycle and callback wiring only. AppGate remains the module lifecycle/action orchestrator; platform, rendering, settings, and feature logic stay in their existing services.

## Focused local verification
- Debug build and linked embedded RCDATA validation: passed
- ProductionApplication: 3/3
- TrayProcess: 2/2
- AppWindow/lifecycle: 13/13
- visual Debug smoke: one 1008x688 HWND with complete initial JSON frame
- git diff --check: passed

No local full suite was run. The PR CI is the single full Debug/Release regression for this SHA.