### PR TITLE
IC-07: bridge JSON actions and route state

### DIFF
--- a/assets/ui/core.json
+++ b/assets/ui/core.json
@@ -259,6 +259,12 @@
         "tab_stop": {
           "kind": "bool",
           "default": true
+        },
+        "action": {
+          "kind": "string"
+        },
+        "action_payload": {
+          "kind": "object"
         }
       }
     },

--- a/src/application/production_application.cpp
+++ b/src/application/production_application.cpp
@@ -98,9 +98,8 @@ core::Status ProductionApplication::ComposeWindow() {
   gate_ = std::make_unique<modules::AppGate>();
   const core::Status host_configured = gate_->ConfigureHostOperations(
       window_->hwnd(), worker_completion_message_,
-      [](std::wstring_view, const json::Value&) {
-        return DHEPZ_ERR(core::ErrorCode::Unsupported,
-                         L"Route state bridge is introduced by IC-07");
+      [this](std::wstring_view module_id, const json::Value& patch) {
+        return OnStatePatch(module_id, patch);
       });
   if (!host_configured.ok()) {
     DestroyWindowState();
@@ -120,11 +119,18 @@ core::Status ProductionApplication::ComposeWindow() {
   trace::TraceConfigResolved();
   startup_stage_ = StartupStage::ConfigResolved;
 
-  // Binding the initial module may quarantine it. That is degraded mode, not
-  // a fatal shell failure; use the gate's resulting live document.
-  (void)gate_->Activate(gate_->document()->initial_route());
   presenter_ = std::make_unique<ui::presenter::ScreenPresenter>(window_->backend());
   presenter_->SetDocument(gate_->document());
+  presenter_->set_action_dispatch_handler(
+      [this](std::wstring_view route, std::wstring_view action,
+             const json::Value& payload, json::Value* state_patch) {
+        return DispatchAction(route, action, payload, state_patch);
+      });
+  presenter_->set_route_changed_handler([this](std::wstring_view route) {
+    if (gate_) (void)gate_->Activate(route);
+  });
+  (void)gate_->Activate(presenter_->current_route());
+  RefreshPresenterDocument();
   presenter_->set_caption_height(40.0f);
 
   window_->set_content_layout(
@@ -136,7 +142,7 @@ core::Status ProductionApplication::ComposeWindow() {
   window_->set_content_key_handler(
       [this](int key) { return presenter_->HandleKey(key); });
   window_->set_content_click_handler(
-      [this](float x, float y) { return presenter_->HandleClick(x, y); });
+      [this](float x, float y) { return OnContentClick(x, y); });
   window_->set_content_move_handler(
       [this](float x, float y) { return presenter_->HandleMove(x, y); });
   window_->set_content_down_handler(
@@ -169,6 +175,51 @@ void ProductionApplication::OnFramePresented() {
   }
 }
 
+core::Status ProductionApplication::DispatchAction(
+    std::wstring_view route, std::wstring_view action,
+    const json::Value& payload, json::Value* state_patch) {
+  if (!gate_ || !presenter_) {
+    return DHEPZ_ERR(core::ErrorCode::InvalidArgument,
+                     L"action bridge is not composed");
+  }
+  DHEPZ_RETURN_IF_ERROR(gate_->Activate(route));
+  return gate_->Dispatch(action, payload, state_patch);
+}
+
+bool ProductionApplication::OnContentClick(float x, float y) {
+  if (!presenter_) return false;
+  const bool handled = presenter_->HandleClick(x, y);
+  RefreshPresenterDocument();
+  return handled;
+}
+
+core::Status ProductionApplication::OnStatePatch(
+    std::wstring_view module_id, const json::Value& patch) {
+  if (!gate_ || !presenter_) {
+    return DHEPZ_ERR(core::ErrorCode::InvalidArgument,
+                     L"state bridge is not composed");
+  }
+  const std::wstring route = gate_->RouteForModule(module_id);
+  if (route.empty()) {
+    return DHEPZ_ERR(core::ErrorCode::NotFound,
+                     L"state patch owner has no mounted route");
+  }
+  DHEPZ_RETURN_IF_ERROR(presenter_->ApplyStatePatch(route, patch));
+  if (window_ && window_->visible() && presenter_->current_route() == route) {
+    window_->Repaint();
+  }
+  return core::Ok();
+}
+
+void ProductionApplication::RefreshPresenterDocument() {
+  if (!presenter_ || !gate_ ||
+      presenter_document_generation_ == gate_->document_generation()) {
+    return;
+  }
+  presenter_->SetDocument(gate_->document());
+  presenter_document_generation_ = gate_->document_generation();
+}
+
 core::Status ProductionApplication::ShowMainWindow() {
   if (!started_) {
     return DHEPZ_ERR(core::ErrorCode::InvalidArgument,
@@ -176,8 +227,11 @@ core::Status ProductionApplication::ShowMainWindow() {
   }
   if (!window_) DHEPZ_RETURN_IF_ERROR(ComposeWindow());
 
+  RefreshPresenterDocument();
+
   // Rebind the current route after close/minimise invalidated window lifetime.
   (void)gate_->Activate(presenter_->current_route());
+  RefreshPresenterDocument();
   HWND hwnd = static_cast<HWND>(window_->hwnd());
   if (window_->visible()) {
     if (IsIconic(hwnd)) ShowWindow(hwnd, SW_RESTORE);
@@ -221,6 +275,7 @@ void ProductionApplication::DestroyWindowState() {
   window_.reset();
   cache_.reset();
   worker_completion_message_ = 0;
+  presenter_document_generation_ = 0;
   startup_stage_ = StartupStage::None;
 }
 

--- a/src/application/production_application.h
+++ b/src/application/production_application.h
@@ -9,6 +9,7 @@
 
 namespace modules { class AppGate; }
 namespace render { class GdiResourceCache; struct Rect; }
+namespace json { class Value; }
 namespace shell { class AppWindow; }
 namespace tray { class TrayProcess; }
 namespace ui::presenter { class ScreenPresenter; }
@@ -48,6 +49,14 @@ class ProductionApplication final {
   void DestroyWindowState();
   void OnLayout(const render::Rect& content);
   void OnFramePresented();
+  bool OnContentClick(float x, float y);
+  core::Status DispatchAction(std::wstring_view route,
+                              std::wstring_view action,
+                              const json::Value& payload,
+                              json::Value* state_patch);
+  core::Status OnStatePatch(std::wstring_view module_id,
+                            const json::Value& patch);
+  void RefreshPresenterDocument();
 
   void* instance_ = nullptr;
   std::unique_ptr<tray::TrayProcess> tray_;
@@ -57,6 +66,7 @@ class ProductionApplication final {
   std::unique_ptr<ui::presenter::ScreenPresenter> presenter_;
   StartupStage startup_stage_ = StartupStage::None;
   unsigned int worker_completion_message_ = 0;
+  std::uint64_t presenter_document_generation_ = 0;
   bool started_ = false;
 };
 

--- a/src/modules/gate/app_gate.cpp
+++ b/src/modules/gate/app_gate.cpp
@@ -176,6 +176,14 @@ bool AppGate::Mounted(std::wstring_view module_id) const {
   return false;
 }
 
+std::wstring AppGate::RouteForModule(std::wstring_view module_id) const {
+  if (document_ == nullptr) return {};
+  for (const ui::config::Route& route : document_->routes()) {
+    if (route.root.GetString(L"module_id") == module_id) return route.id;
+  }
+  return {};
+}
+
 core::Status AppGate::Activate(std::wstring_view route_id) {
   MountedModule* module = FindByRoute(route_id);
   if (module == nullptr) return core::Ok();

--- a/src/modules/gate/app_gate.h
+++ b/src/modules/gate/app_gate.h
@@ -62,6 +62,7 @@ class AppGate final {
   const std::vector<SettingsStoreDiagnostic>& SettingsDiagnostics() const;
   DiagnosticsReadModel Diagnostics() const;
   bool Mounted(std::wstring_view module_id) const;
+  std::wstring RouteForModule(std::wstring_view module_id) const;
 
   // Lazy activation: builds the descriptor and Bind()s it on first visit.
   core::Status Activate(std::wstring_view route_id);

--- a/src/modules/terminal/screen.json
+++ b/src/modules/terminal/screen.json
@@ -8,7 +8,8 @@
       "show_in_tabs": true,
       "children": [
         { "type": "text", "text": "Terminal", "variant": "title" },
-        { "type": "button", "label": "Open PowerShell" }
+        { "type": "button", "id": "launch-terminal", "label": "Open PowerShell", "action": "terminal:launch",
+          "action_payload": {} }
       ]
     }
   ]

--- a/src/ui/config/resolved_ui_document.cpp
+++ b/src/ui/config/resolved_ui_document.cpp
@@ -103,6 +103,13 @@ bool ComponentNode::Has(std::wstring_view name) const {
          }) != properties_.end();
 }
 
+const json::Value* ComponentNode::Property(std::wstring_view name) const {
+  for (const auto& [key, value] : properties_) {
+    if (key == name) return &value;
+  }
+  return nullptr;
+}
+
 std::wstring ComponentNode::GetString(std::wstring_view name,
                                       std::wstring_view fallback) const {
   for (const auto& [key, value] : properties_) {

--- a/src/ui/config/resolved_ui_document.h
+++ b/src/ui/config/resolved_ui_document.h
@@ -46,6 +46,7 @@ class ComponentNode {
   const std::wstring& id() const { return id_; }
 
   bool Has(std::wstring_view name) const;
+  const json::Value* Property(std::wstring_view name) const;
   std::wstring GetString(std::wstring_view name, std::wstring_view fallback = {}) const;
   long long GetInt(std::wstring_view name, long long fallback = 0) const;
   bool GetBool(std::wstring_view name, bool fallback = false) const;

--- a/src/ui/config/ui_schema.cpp
+++ b/src/ui/config/ui_schema.cpp
@@ -35,6 +35,33 @@ bool IsInteger(const json::Value& value) {
   return number == static_cast<long long>(number);
 }
 
+bool IsBindingReference(const json::Value& value) {
+  if (!value.is_object() || value.members().size() != 1) return false;
+  const auto& [key, binding] = value.members().front();
+  return key == L"$bind" && binding.is_string() && !binding.AsString().empty();
+}
+
+void ValidateBindingTemplates(const json::Value& value,
+                              std::vector<Diagnostic>* out) {
+  if (value.is_object()) {
+    if (value.Find(L"$bind") != nullptr) {
+      if (!IsBindingReference(value)) {
+        Add(out, value,
+            L"binding reference must be exactly {\"$bind\": \"name\"}");
+      }
+      return;
+    }
+    for (const auto& [key, member] : value.members()) {
+      (void)key;
+      ValidateBindingTemplates(member, out);
+    }
+  } else if (value.is_array()) {
+    for (const json::Value& item : value.items()) {
+      ValidateBindingTemplates(item, out);
+    }
+  }
+}
+
 bool KindMatches(const json::Value& value, std::wstring_view kind,
                  const json::Value* definition);
 
@@ -97,13 +124,14 @@ const json::Value* CatalogType(const json::Value& core, std::wstring_view type) 
 bool KindMatches(const json::Value& value, std::wstring_view kind,
                  const json::Value* definition) {
   if (kind == L"string") return value.is_string();
-  if (kind == L"text") return value.is_string();
-  if (kind == L"bool") return value.is_bool();
+  if (kind == L"text") return value.is_string() || IsBindingReference(value);
+  if (kind == L"bool") return value.is_bool() || IsBindingReference(value);
   if (kind == L"int") return IsInteger(value);
   if (kind == L"object") return value.is_object();
   if (kind == L"array") return value.is_array();
   if (kind == L"binding") {
-    return value.is_string() || value.is_object() || value.is_bool() || value.is_number();
+    return value.is_string() || value.is_bool() || value.is_number() ||
+           IsBindingReference(value);
   }
   if (kind == L"enum") {
     if (!value.is_string()) return false;
@@ -191,6 +219,8 @@ void ValidateComponent(const json::Value& core, const json::Value& component,
     if (!KindMatches(value, kind, definition)) {
       Add(out, value, L"property '" + name + L"' on component '" + type->AsString() +
                           L"' must be of kind '" + kind + L"'");
+    } else {
+      ValidateBindingTemplates(value, out);
     }
   }
 }

--- a/src/ui/presenter/screen_presenter.cpp
+++ b/src/ui/presenter/screen_presenter.cpp
@@ -2,6 +2,8 @@
 
 #include <windows.h>
 
+#include <algorithm>
+
 #include "ui/layout/backdrop.h"
 
 namespace ui::presenter {
@@ -33,6 +35,54 @@ render::Color Shade(render::Color color, int delta) {
   return render::Color{clamp(color.r + delta), clamp(color.g + delta),
                        clamp(color.b + delta), color.a};
 }
+
+bool IsBindingReference(const json::Value& value, std::wstring* name = nullptr) {
+  if (!value.is_object() || value.members().size() != 1) return false;
+  const auto& [key, binding] = value.members().front();
+  if (key != L"$bind" || !binding.is_string() || binding.AsString().empty()) {
+    return false;
+  }
+  if (name != nullptr) *name = binding.AsString();
+  return true;
+}
+
+bool ReferencesAny(const json::Value& value,
+                   const std::vector<std::wstring>& changed) {
+  std::wstring binding;
+  if (IsBindingReference(value, &binding)) {
+    const std::size_t dot = binding.find(L'.');
+    return std::find(changed.begin(), changed.end(), binding.substr(0, dot)) !=
+           changed.end();
+  }
+  if (value.is_object()) {
+    for (const auto& [key, member] : value.members()) {
+      (void)key;
+      if (ReferencesAny(member, changed)) return true;
+    }
+  } else if (value.is_array()) {
+    for (const json::Value& item : value.items()) {
+      if (ReferencesAny(item, changed)) return true;
+    }
+  }
+  return false;
+}
+
+void MergeObject(json::Value* target, const json::Value& patch) {
+  for (const auto& [key, value] : patch.members()) {
+    if (value.is_null()) {
+      target->Remove(key);
+    } else if (value.is_object()) {
+      json::Value* current = target->Find(key);
+      if (current == nullptr || !current->is_object()) {
+        target->Set(key, json::Value::Object());
+        current = target->Find(key);
+      }
+      MergeObject(current, value);
+    } else {
+      target->Set(key, value);
+    }
+  }
+}
 }  // namespace
 
 void ScreenPresenter::SetDocument(const config::ResolvedUiDocument* document) {
@@ -43,12 +93,16 @@ void ScreenPresenter::SetDocument(const config::ResolvedUiDocument* document) {
     route_ = document_->initial_route();
     focus_.EnterRoute(route_);
   }
+  backend_->InvalidateAll();
 }
 
 void ScreenPresenter::SwitchRoute(std::wstring_view route) {
   if (document_ == nullptr || document_->FindRoute(route) == nullptr) return;
+  if (route_ == route) return;
   route_ = std::wstring(route);
   focus_.EnterRoute(route_);
+  backend_->InvalidateAll();
+  if (route_changed_handler_) route_changed_handler_(route_);
 }
 
 render::Color ScreenPresenter::Token(std::wstring_view name, render::Color fallback) const {
@@ -61,6 +115,7 @@ render::Color ScreenPresenter::Token(std::wstring_view name, render::Color fallb
 
 void ScreenPresenter::Prepare(const render::Rect& content) {
   if (document_ == nullptr || route_.empty()) return;
+  last_content_ = content;
 
   // Tab strip: one tab per route that shows in tabs, anchored left.
   tab_rects_.clear();
@@ -179,13 +234,25 @@ bool ScreenPresenter::ClickNode(const layout::LayoutNode& node, float x, float y
   const config::ComponentNode* source = node.source;
   if (source == nullptr) return false;
   if (!node.bounds.contains({x, y})) return false;
-  if (!(source->GetBool(L"tab_stop") && source->GetBool(L"visible", true) &&
-        source->GetBool(L"enabled", true))) {
+  if (!(source->GetBool(L"tab_stop") && ResolvedBool(*source, L"visible", true) &&
+        ResolvedBool(*source, L"enabled", true))) {
     return false;
   }
   const std::wstring id = focus_.IdFor(route_, source);
-  if (id.empty()) return false;
-  return focus_.SetFocus(route_, id);
+  bool handled = !id.empty() && focus_.SetFocus(route_, id);
+  const std::wstring action = source->GetString(L"action");
+  if (!action.empty() && action_dispatch_handler_) {
+    json::Value payload = json::Value::Object();
+    if (const json::Value* declared = source->Property(L"action_payload")) {
+      payload = ResolveTemplate(*declared);
+    }
+    json::Value patch;
+    last_action_status_ =
+        action_dispatch_handler_(route_, action, payload, &patch);
+    if (patch.is_object()) (void)ApplyStatePatch(route_, patch);
+    handled = true;
+  }
+  return handled;
 }
 
 const config::ComponentNode* ScreenPresenter::FindButton(const layout::LayoutNode& node,
@@ -198,6 +265,25 @@ const config::ComponentNode* ScreenPresenter::FindButton(const layout::LayoutNod
     return node.source;
   }
   return nullptr;
+}
+
+const layout::LayoutNode* ScreenPresenter::FindNodeById(
+    const layout::LayoutNode& node, std::wstring_view id) const {
+  if (node.source != nullptr && node.source->id() == id) return &node;
+  for (const layout::LayoutNode& child : node.children) {
+    if (const layout::LayoutNode* found = FindNodeById(child, id)) return found;
+  }
+  return nullptr;
+}
+
+bool ScreenPresenter::InteractiveBounds(std::wstring_view id,
+                                        render::Rect* out) const {
+  if (out == nullptr || last_tree_ == nullptr) return false;
+  const layout::LayoutNode* node = FindNodeById(*last_tree_, id);
+  if (node == nullptr) return false;
+  *out = {node->bounds.x, node->bounds.y + tab_strip_height_,
+          node->bounds.width, node->bounds.height};
+  return true;
 }
 
 bool ScreenPresenter::HandleMove(float x, float y) {
@@ -256,16 +342,18 @@ bool ScreenPresenter::HandleClick(float x, float y) {
 void ScreenPresenter::PaintNode(const layout::LayoutNode& node) {
   const config::ComponentNode* source = node.source;
   if (source != nullptr) {
+    if (!ResolvedBool(*source, L"visible", true)) return;
     const std::wstring& type = source->type();
     if (type == L"text") {
-      backend_->DrawTextRun(source->GetString(L"text"), node.bounds, StyleForText(*source),
+      backend_->DrawTextRun(ResolvedString(*source, L"text"), node.bounds,
+                            StyleForText(*source),
                             Token(L"text", {255, 255, 255, 255}), render::TextAlign::Left,
                             render::VerticalAlign::Top);
     } else if (type == L"button") {
       // Tab-state model: idle shows only a gray outline; hover brightens the
       // outline; press bumps; selected switches to the accent plus a tint.
       render::Rect box = node.bounds;
-      const bool selected = source->GetBool(L"selected");
+      const bool selected = ResolvedBool(*source, L"selected");
       render::Color outline = Token(L"borderStrong", {70, 76, 88, 255});
       const bool hovered = source == hover_node_;
       if (selected) {
@@ -288,7 +376,8 @@ void ScreenPresenter::PaintNode(const layout::LayoutNode& node) {
         backend_->StrokeRoundedRect(inner, render::CornerRadius::Uniform(5.0f), outline,
                                     2.0f);
       }
-      backend_->DrawTextRun(source->GetString(L"label"), box, render::TextStyle{},
+      backend_->DrawTextRun(ResolvedString(*source, L"label"), box,
+                            render::TextStyle{},
                             Token(L"text", {255, 255, 255, 255}), render::TextAlign::Center,
                             render::VerticalAlign::Middle);
     }
@@ -308,6 +397,125 @@ bool ScreenPresenter::HandleKey(int virtual_key) {
   if (virtual_key != VK_TAB) return false;
   const bool backward = (GetKeyState(VK_SHIFT) & 0x8000) != 0;
   return !focus_.Advance(route_, backward).empty();
+}
+
+const json::Value* ScreenPresenter::ViewStateValue(
+    std::wstring_view route, std::wstring_view binding) const {
+  for (const auto& [state_route, state] : route_states_) {
+    if (state_route != route) continue;
+    const json::Value* value = &state;
+    std::size_t begin = 0;
+    while (begin < binding.size()) {
+      const std::size_t dot = binding.find(L'.', begin);
+      const std::wstring_view part = binding.substr(
+          begin, dot == std::wstring_view::npos ? binding.size() - begin
+                                                : dot - begin);
+      value = value->Find(part);
+      if (value == nullptr) return nullptr;
+      if (dot == std::wstring_view::npos) return value;
+      begin = dot + 1;
+    }
+  }
+  return nullptr;
+}
+
+const json::Value* ScreenPresenter::ResolveBinding(
+    std::wstring_view route, std::wstring_view binding) const {
+  return ViewStateValue(route, binding);
+}
+
+json::Value ScreenPresenter::ResolveTemplate(const json::Value& value) const {
+  std::wstring binding;
+  if (IsBindingReference(value, &binding)) {
+    const json::Value* resolved = ResolveBinding(route_, binding);
+    return resolved != nullptr ? *resolved : json::Value::Null();
+  }
+  if (value.is_array()) {
+    json::Value out = json::Value::Array();
+    for (const json::Value& item : value.items()) out.Append(ResolveTemplate(item));
+    return out;
+  }
+  if (value.is_object()) {
+    json::Value out = json::Value::Object();
+    for (const auto& [key, member] : value.members()) {
+      out.Set(key, ResolveTemplate(member));
+    }
+    return out;
+  }
+  return value;
+}
+
+std::wstring ScreenPresenter::ResolvedString(
+    const config::ComponentNode& node, std::wstring_view property,
+    std::wstring_view fallback) const {
+  const json::Value* value = node.Property(property);
+  if (value == nullptr) return std::wstring(fallback);
+  std::wstring binding;
+  if (IsBindingReference(*value, &binding)) value = ResolveBinding(route_, binding);
+  return value != nullptr && value->is_string() ? value->AsString()
+                                                : std::wstring(fallback);
+}
+
+bool ScreenPresenter::ResolvedBool(const config::ComponentNode& node,
+                                   std::wstring_view property,
+                                   bool fallback) const {
+  const json::Value* value = node.Property(property);
+  if (value == nullptr) return fallback;
+  std::wstring binding;
+  if (IsBindingReference(*value, &binding)) value = ResolveBinding(route_, binding);
+  return value != nullptr && value->is_bool() ? value->AsBool() : fallback;
+}
+
+void ScreenPresenter::InvalidateBoundNodes(
+    const layout::LayoutNode& node,
+    const std::vector<std::wstring>& changed) {
+  if (node.source != nullptr) {
+    bool affected = false;
+    for (const auto& [key, value] : node.source->properties_) {
+      (void)key;
+      if (ReferencesAny(value, changed)) {
+        affected = true;
+        break;
+      }
+    }
+    if (affected) {
+      backend_->Invalidate({last_content_.x + node.bounds.x,
+                            last_content_.y + tab_strip_height_ + node.bounds.y,
+                            node.bounds.width, node.bounds.height});
+    }
+  }
+  for (const layout::LayoutNode& child : node.children) {
+    InvalidateBoundNodes(child, changed);
+  }
+}
+
+core::Status ScreenPresenter::ApplyStatePatch(std::wstring_view route,
+                                              const json::Value& patch) {
+  if (!patch.is_object()) {
+    return DHEPZ_ERR(core::ErrorCode::InvalidArgument,
+                     L"route state patch must be an object");
+  }
+  json::Value* state = nullptr;
+  for (auto& [state_route, value] : route_states_) {
+    if (state_route == route) {
+      state = &value;
+      break;
+    }
+  }
+  if (state == nullptr) {
+    route_states_.emplace_back(std::wstring(route), json::Value::Object());
+    state = &route_states_.back().second;
+  }
+  std::vector<std::wstring> changed;
+  for (const auto& [key, value] : patch.members()) {
+    (void)value;
+    changed.push_back(key);
+  }
+  MergeObject(state, patch);
+  if (route == route_ && last_tree_ != nullptr) {
+    InvalidateBoundNodes(*last_tree_, changed);
+  }
+  return core::Ok();
 }
 
 }  // namespace ui::presenter

--- a/src/ui/presenter/screen_presenter.h
+++ b/src/ui/presenter/screen_presenter.h
@@ -1,13 +1,13 @@
 // The JSON-to-pixels wire (#71): paints the resolved route through the
 // render seam and owns the interactive half (focus ring, Tab traversal,
-// click-to-focus). Action dispatch — what a button DOES — stays inert and
-// declared-only until the module contract (Phase 3); that decision is
-// recorded on issue #71.
+// click-to-focus). Actions leave through an injected callback; this layer
+// never depends on the module gate or module contract.
 //
 // The shell calls Paint inside its frame scope; coordinates are translated
 // so the route origin lands at the content rect's top-left.
 #pragma once
 
+#include <functional>
 #include <string>
 
 #include "render/render_backend.h"
@@ -20,6 +20,11 @@ namespace ui::presenter {
 
 class ScreenPresenter final {
  public:
+  using ActionDispatchHandler = std::function<core::Status(
+      std::wstring_view route, std::wstring_view action,
+      const json::Value& payload, json::Value* state_patch)>;
+  using RouteChangedHandler = std::function<void(std::wstring_view route)>;
+
   explicit ScreenPresenter(render::RenderBackend* backend, std::wstring theme = L"dark");
 
   // Rebuilds focus and drops layout memo for the old document; the current
@@ -43,6 +48,18 @@ class ScreenPresenter final {
   // Click-to-focus on a focusable node; true when focus moved.
   bool HandleClick(float x, float y);
 
+  void set_action_dispatch_handler(ActionDispatchHandler handler) {
+    action_dispatch_handler_ = std::move(handler);
+  }
+  void set_route_changed_handler(RouteChangedHandler handler) {
+    route_changed_handler_ = std::move(handler);
+  }
+  core::Status ApplyStatePatch(std::wstring_view route,
+                               const json::Value& patch);
+  const json::Value* ViewStateValue(std::wstring_view route,
+                                    std::wstring_view binding) const;
+  const core::Status& last_action_status() const { return last_action_status_; }
+
   // The shell reserves its caption row for dragging and the main icons;
   // the tab strip sits below it. Default 0 keeps the strip at the top.
   void set_caption_height(float height) { caption_height_ = height; }
@@ -50,6 +67,7 @@ class ScreenPresenter final {
   // True when the point (content-relative) is over interactive content —
   // the shell uses it to keep such points out of the caption drag zone.
   bool HitTestContent(float x, float y) const;
+  bool InteractiveBounds(std::wstring_view id, render::Rect* out) const;
 
   std::wstring focused() const { return focus_.Current(route_); }
 
@@ -59,8 +77,20 @@ class ScreenPresenter final {
   bool ClickNode(const layout::LayoutNode& node, float x, float y);
   const config::ComponentNode* FindButton(const layout::LayoutNode& node, float x,
                                           float y) const;
+  const layout::LayoutNode* FindNodeById(const layout::LayoutNode& node,
+                                         std::wstring_view id) const;
   int TabAt(float x, float y) const;
   render::Color Token(std::wstring_view name, render::Color fallback) const;
+  const json::Value* ResolveBinding(std::wstring_view route,
+                                    std::wstring_view binding) const;
+  json::Value ResolveTemplate(const json::Value& value) const;
+  std::wstring ResolvedString(const config::ComponentNode& node,
+                              std::wstring_view property,
+                              std::wstring_view fallback = {}) const;
+  bool ResolvedBool(const config::ComponentNode& node,
+                    std::wstring_view property, bool fallback = false) const;
+  void InvalidateBoundNodes(const layout::LayoutNode& node,
+                            const std::vector<std::wstring>& changed);
   // The style a text node is measured AND painted with; keeping the two
   // identical is what warms the painted font during layout.
   static render::TextStyle StyleForText(const config::ComponentNode& node);
@@ -82,6 +112,11 @@ class ScreenPresenter final {
   float caption_height_ = 0.0f;
   float tab_strip_height_ = 0.0f;
   layout::PaintPlan plan_;
+  std::vector<std::pair<std::wstring, json::Value>> route_states_;
+  ActionDispatchHandler action_dispatch_handler_;
+  RouteChangedHandler route_changed_handler_;
+  core::Status last_action_status_;
+  render::Rect last_content_{};
   std::wstring route_;
   std::wstring theme_;
 };

--- a/src/ui/shell/app_window.cpp
+++ b/src/ui/shell/app_window.cpp
@@ -196,6 +196,10 @@ void AppWindow::Close() {
   Hide();
 }
 
+void AppWindow::Repaint() {
+  if (visible()) RenderFullFrame();
+}
+
 void AppWindow::TogglePin() {
   if (hwnd_ == nullptr) return;
   pinned_ = !pinned_;

--- a/src/ui/shell/app_window.h
+++ b/src/ui/shell/app_window.h
@@ -59,6 +59,8 @@ class AppWindow final {
   void Hide();
   // Resident semantics: Close() is Hide(). The process stays up.
   void Close();
+  // Re-renders a visible window after a parent-owned state patch.
+  void Repaint();
   // Real teardown.
   void Destroy();
 

--- a/tests/application/production_application_test.cpp
+++ b/tests/application/production_application_test.cpp
@@ -8,10 +8,39 @@
 
 #include "framework/test_case.h"
 #include "modules/gate/app_gate.h"
+#include "modules/registry/module_registry.h"
 #include "ui/presenter/screen_presenter.h"
 #include "ui/shell/app_window.h"
 
 namespace {
+class FakeTerminalModule final : public modules::ModuleDescriptor {
+ public:
+  std::wstring_view ModuleId() const override { return L"terminal"; }
+  std::wstring_view TabLabel() const override { return L"Terminal"; }
+  int Order() const override { return 10; }
+  bool ShowInTabs() const override { return true; }
+  std::wstring_view SettingsRoute() const override { return {}; }
+  std::vector<std::wstring> DeclaredActions() const override {
+    return {L"terminal:launch"};
+  }
+  std::vector<std::wstring> DeclaredBindings() const override { return {}; }
+  std::vector<std::wstring> DeclaredCapabilities() const override { return {}; }
+  core::Status Bind(modules::ModuleHost&) override { return core::Ok(); }
+  core::Status Handle(std::wstring_view action, const json::Value&,
+                      json::Value*) override {
+    if (action != L"terminal:launch") {
+      return core::Err(core::ErrorCode::NotFound, L"unexpected action");
+    }
+    return core::Err(core::ErrorCode::InvalidArgument,
+                     L"fake terminal dispatch observed");
+  }
+  void Release() override {}
+};
+
+std::unique_ptr<modules::ModuleDescriptor> MakeFakeTerminal() {
+  return std::make_unique<FakeTerminalModule>();
+}
+
 void PumpFor(int milliseconds) {
   const auto deadline = std::chrono::steady_clock::now() +
                         std::chrono::milliseconds(milliseconds);
@@ -80,4 +109,29 @@ DHEPZ_TEST(ProductionApplication, CloseReleasesAndNextShowRebuildsCompleteFrame)
       static_cast<unsigned long long>(window->backend()->PixelAt(x, y) >> 24),
       0xFFull);
   app.Shutdown();
+}
+
+DHEPZ_TEST(ProductionApplication, TerminalJsonActionReachesGateStatusPath) {
+  modules::ResetRegistryForTests();
+  modules::RegisterModule(L"terminal", &MakeFakeTerminal);
+  application::ProductionApplication app;
+  const core::Status start = app.Start(GetModuleHandleW(nullptr), false);
+  DHEPZ_CHECK_EQ(start.Message(), std::wstring());
+
+  app.presenter()->SwitchRoute(L"terminal");
+  app.window()->Repaint();
+  render::Rect button{};
+  DHEPZ_CHECK(app.presenter()->InteractiveBounds(L"launch-terminal", &button));
+  DHEPZ_CHECK(app.presenter()->HandleClick(
+      button.x + button.width / 2.0f,
+      button.y + button.height / 2.0f));
+  DHEPZ_CHECK_FALSE(app.presenter()->last_action_status().ok());
+  DHEPZ_CHECK_CONTAINS(app.presenter()->last_action_status().Message(),
+                       std::wstring(L"dispatch observed"));
+  DHEPZ_CHECK_EQ(app.gate()->Diagnostics().statuses.size(),
+                 static_cast<std::size_t>(1));
+  DHEPZ_CHECK_FALSE(app.gate()->Diagnostics().statuses[0].ok);
+  DHEPZ_CHECK(app.window()->visible());
+  app.Shutdown();
+  modules::ResetRegistryForTests();
 }

--- a/tests/modules/gate/app_gate_test.cpp
+++ b/tests/modules/gate/app_gate_test.cpp
@@ -292,6 +292,26 @@ DHEPZ_TEST(AppGateContract, UndeclaredScreenReferencesAreRejected) {
   modules::ResetRegistryForTests();
 }
 
+DHEPZ_TEST(AppGateContract, UndeclaredActionPayloadBindingIsRejectedAtSource) {
+  modules::ResetRegistryForTests();
+  modules::RegisterModule(L"ref-module", &MakeRefModule);
+  const std::wstring screen =
+      L"{\n  \"type\": \"screen\", \"route_id\": \"ref-home\", "
+      L"\"module_id\": \"ref-module\", \"children\": [\n"
+      L"    { \"type\": \"button\", \"label\": \"x\", "
+      L"\"action_payload\": { \"folder\": { \"$bind\": \"missing\" } } }\n"
+      L"  ] }";
+  modules::AppGate gate;
+  DHEPZ_CHECK(gate.StartWithEmbedded(
+                      EmbeddedWith(screen, ManifestFor(L"ref-module")))
+                  .ok());
+  DHEPZ_CHECK_FALSE(gate.Mounted(L"ref-module"));
+  DHEPZ_CHECK_CONTAINS(gate.Rejects()[0].reason,
+                       std::wstring(L"undeclared binding 'missing'"));
+  DHEPZ_CHECK(gate.Rejects()[0].line > 0);
+  modules::ResetRegistryForTests();
+}
+
 DHEPZ_TEST(AppGateContract, DuplicateActionRejectsSecondOwnerAndItsRoute) {
   modules::ResetRegistryForTests();
   modules::RegisterModule(L"alpha", &MakeAlpha);

--- a/tests/ui/config/ui_schema_test.cpp
+++ b/tests/ui/config/ui_schema_test.cpp
@@ -163,3 +163,38 @@ DHEPZ_TEST(UiSchema, CoreCatalogRejectsBadKindAndEnumWithoutValues) {
   DHEPZ_CHECK(!ui::config::ValidateCore(core, &diagnostics).ok());
   DHEPZ_CHECK(diagnostics.size() >= 2);
 }
+
+DHEPZ_TEST(UiSchema, ActionPayloadAcceptsLiteralAndExactBindingTemplates) {
+  const json::Value core = LoadCore();
+  const json::Value screen = ParseScreenText(R"({
+    "components": [
+      { "type": "button", "label": { "$bind": "caption" },
+        "action": "terminal:launch",
+        "action_payload": {
+          "shell": "powershell",
+          "admin": false,
+          "folder": { "$bind": "folder" },
+          "nested": [1, { "$bind": "choice" }]
+        } }
+    ]
+  })");
+  std::vector<ui::config::Diagnostic> diagnostics;
+  DHEPZ_CHECK(ui::config::ValidateScreen(core, screen, &diagnostics).ok());
+  DHEPZ_CHECK(diagnostics.empty());
+}
+
+DHEPZ_TEST(UiSchema, MalformedBindingTemplateIsRejectedAtItsSource) {
+  const json::Value core = LoadCore();
+  const json::Value screen = ParseScreenText(
+      "{\n"
+      "  \"components\": [\n"
+      "    { \"type\": \"button\", \"label\": \"x\",\n"
+      "      \"action_payload\": { \"folder\": { \"$bind\": \"folder\", \"extra\": true } } }\n"
+      "  ]\n"
+      "}\n");
+  std::vector<ui::config::Diagnostic> diagnostics;
+  DHEPZ_CHECK_FALSE(ui::config::ValidateScreen(core, screen, &diagnostics).ok());
+  DHEPZ_CHECK_EQ(diagnostics.size(), static_cast<std::size_t>(1));
+  DHEPZ_CHECK_EQ(diagnostics[0].line, 4);
+  DHEPZ_CHECK_CONTAINS(diagnostics[0].message, std::wstring(L"exactly"));
+}

--- a/tests/ui/presenter/screen_presenter_test.cpp
+++ b/tests/ui/presenter/screen_presenter_test.cpp
@@ -1,11 +1,52 @@
 #include "ui/presenter/screen_presenter.h"
 
+#include <algorithm>
 #include <string>
 #include <vector>
 
 #include "framework/test_case.h"
+#include "modules/gate/app_gate.h"
+#include "modules/registry/module_registry.h"
 
 namespace {
+
+class BridgeModule final : public modules::ModuleDescriptor {
+ public:
+  std::wstring_view ModuleId() const override { return L"bridge"; }
+  std::wstring_view TabLabel() const override { return L"bridge"; }
+  int Order() const override { return 1; }
+  bool ShowInTabs() const override { return true; }
+  std::wstring_view SettingsRoute() const override { return {}; }
+  std::vector<std::wstring> DeclaredActions() const override {
+    return {L"bridge:run"};
+  }
+  std::vector<std::wstring> DeclaredBindings() const override {
+    return {L"status"};
+  }
+  std::vector<std::wstring> DeclaredCapabilities() const override { return {}; }
+  core::Status Bind(modules::ModuleHost& host) override {
+    host_ = &host;
+    return core::Ok();
+  }
+  core::Status Handle(std::wstring_view action, const json::Value& payload,
+                      json::Value* patch) override {
+    if (action != L"bridge:run") {
+      return core::Err(core::ErrorCode::NotFound, L"unknown bridge action");
+    }
+    *patch = json::Value::Object();
+    patch->Set(L"status", json::Value::String(
+        L"Dispatched " + payload.StringField(L"before")));
+    return core::Ok();
+  }
+  void Release() override { host_ = nullptr; }
+
+ private:
+  modules::ModuleHost* host_ = nullptr;
+};
+
+std::unique_ptr<modules::ModuleDescriptor> MakeBridgeModule() {
+  return std::make_unique<BridgeModule>();
+}
 
 // Records call order so the z-order (backdrop before content) is assertable.
 class RecordingBackend final : public render::RenderBackend {
@@ -17,10 +58,17 @@ class RecordingBackend final : public render::RenderBackend {
   void BeginFrame(const render::Rect&) override {}
   void EndFrame() override {}
   void Present(void*) override {}
-  void Invalidate(const render::Rect&) override {}
-  void InvalidateAll() override {}
-  bool HasInvalidation() const override { return false; }
-  bool TakeInvalidation(render::Rect&) override { return false; }
+  void Invalidate(const render::Rect& rect) override { invalidations.push_back(rect); }
+  void InvalidateAll() override { invalidated_all = true; }
+  bool HasInvalidation() const override {
+    return !invalidations.empty() || invalidated_all;
+  }
+  bool TakeInvalidation(render::Rect& rect) override {
+    if (invalidations.empty()) return false;
+    rect = invalidations.front();
+    invalidations.erase(invalidations.begin());
+    return true;
+  }
   render::ImageHandle LoadImageFile(std::wstring_view) override {
     return render::ImageHandle::Invalid;
   }
@@ -57,6 +105,8 @@ class RecordingBackend final : public render::RenderBackend {
   std::vector<std::wstring> calls;
   std::vector<std::pair<render::Rect, render::Color>> fills;
   std::vector<std::pair<render::Rect, render::Color>> strokes;
+  std::vector<render::Rect> invalidations;
+  bool invalidated_all = false;
 };
 
 std::wstring W(const char* utf8) {
@@ -81,12 +131,15 @@ const char* kCore = R"({
   "components": {
     "screen": { "properties": {
       "route_id": { "kind": "string", "required": true },
+      "module_id": { "kind": "string" },
       "backdrop": { "kind": "string" } } },
     "container": { "properties": { "gap": { "kind": "int", "default": 8 } } },
     "text": { "properties": { "text": { "kind": "text", "required": true } } },
     "button": { "properties": {
       "label": { "kind": "text", "required": true },
       "selected": { "kind": "binding" },
+      "action": { "kind": "string" },
+      "action_payload": { "kind": "object" },
       "tab_stop": { "kind": "bool", "default": true } } }
   }
 })";
@@ -276,4 +329,128 @@ DHEPZ_TEST(ScreenPresenter, RouteSwitchChangesTheDrawSet) {
     if (call == L"text:second") saw_second = true;
   }
   DHEPZ_CHECK(saw_second);
+}
+
+DHEPZ_TEST(ScreenPresenter, ActionPayloadResolvesAndImmediatePatchUpdatesBoundText) {
+  RecordingBackend backend;
+  json::Value core;
+  DHEPZ_CHECK(json::Parse(W(kCore), &core).ok());
+  std::vector<ui::config::Diagnostic> diagnostics;
+  std::unique_ptr<ui::config::ResolvedUiDocument> document;
+  DHEPZ_CHECK(ui::config::ResolveDocument(
+                  core,
+                  {{L"embedded", W(R"({ "components": [
+                    { "type": "screen", "route_id": "home", "children": [
+                      { "type": "button", "id": "go",
+                        "label": { "$bind": "label" },
+                        "action": "demo:go",
+                        "action_payload": {
+                          "literal": 7,
+                          "folder": { "$bind": "folder" },
+                          "nested": [true, { "$bind": "label" }] }
+                      }
+                    ] }
+                  ] })")}},
+                  &diagnostics, &document).ok());
+
+  ui::presenter::ScreenPresenter presenter(&backend);
+  presenter.SetDocument(document.get());
+  json::Value initial = json::Value::Object();
+  initial.Set(L"label", json::Value::String(L"Open"));
+  initial.Set(L"folder", json::Value::String(L"C:\\work"));
+  DHEPZ_CHECK(presenter.ApplyStatePatch(L"home", initial).ok());
+
+  json::Value captured;
+  presenter.set_action_dispatch_handler(
+      [&](std::wstring_view route, std::wstring_view action,
+          const json::Value& payload, json::Value* state_patch) {
+        DHEPZ_CHECK_EQ(std::wstring(route), std::wstring(L"home"));
+        DHEPZ_CHECK_EQ(std::wstring(action), std::wstring(L"demo:go"));
+        captured = payload;
+        *state_patch = json::Value::Object();
+        state_patch->Set(L"label", json::Value::String(L"Opened"));
+        return core::Ok();
+      });
+  presenter.Prepare({10.0f, 20.0f, 400.0f, 300.0f});
+  backend.invalidations.clear();
+  backend.invalidated_all = false;
+  DHEPZ_CHECK(presenter.HandleClick(50.0f, 48.0f));
+
+  DHEPZ_CHECK_EQ(captured.NumberField(L"literal"), 7.0);
+  DHEPZ_CHECK_EQ(captured.StringField(L"folder"), std::wstring(L"C:\\work"));
+  DHEPZ_CHECK_EQ(captured.ArrayField(L"nested")->items()[1].AsString(),
+                 std::wstring(L"Open"));
+  DHEPZ_CHECK_EQ(presenter.ViewStateValue(L"home", L"label")->AsString(),
+                 std::wstring(L"Opened"));
+  DHEPZ_CHECK_EQ(backend.invalidations.size(), static_cast<std::size_t>(1));
+  DHEPZ_CHECK_FALSE(backend.invalidated_all);
+}
+
+DHEPZ_TEST(ScreenPresenter, AsyncPatchInvalidatesOnlyBoundNode) {
+  RecordingBackend backend;
+  json::Value core;
+  DHEPZ_CHECK(json::Parse(W(kCore), &core).ok());
+  std::vector<ui::config::Diagnostic> diagnostics;
+  std::unique_ptr<ui::config::ResolvedUiDocument> document;
+  DHEPZ_CHECK(ui::config::ResolveDocument(
+                  core,
+                  {{L"embedded", W(R"({ "components": [
+                    { "type": "screen", "route_id": "home", "children": [
+                      { "type": "text", "text": "static" },
+                      { "type": "button", "label": { "$bind": "status" } }
+                    ] }
+                  ] })")}},
+                  &diagnostics, &document).ok());
+  ui::presenter::ScreenPresenter presenter(&backend);
+  presenter.SetDocument(document.get());
+  presenter.Prepare({0.0f, 0.0f, 400.0f, 300.0f});
+  backend.invalidated_all = false;
+
+  json::Value patch = json::Value::Object();
+  patch.Set(L"status", json::Value::String(L"done"));
+  DHEPZ_CHECK(presenter.ApplyStatePatch(L"home", patch).ok());
+  DHEPZ_CHECK_EQ(backend.invalidations.size(), static_cast<std::size_t>(1));
+  DHEPZ_CHECK(backend.invalidations[0].height < 300.0f);
+  DHEPZ_CHECK_FALSE(backend.invalidated_all);
+}
+
+DHEPZ_TEST(ScreenPresenter, SyntheticClickTravelsThroughGateAndModulePatch) {
+  modules::ResetRegistryForTests();
+  modules::RegisterModule(L"bridge", &MakeBridgeModule);
+  const std::wstring embedded =
+      L"{ \"core\": " + W(kCore) +
+      L", \"components\": ["
+      L"{ \"type\": \"screen\", \"route_id\": \"bridge\", "
+      L"\"module_id\": \"bridge\", \"children\": ["
+      L"{ \"type\": \"button\", \"id\": \"run\", "
+      L"\"label\": { \"$bind\": \"status\" }, \"action\": \"bridge:run\", "
+      L"\"action_payload\": { \"before\": { \"$bind\": \"status\" } } } ] }"
+      L"], \"modules\": ["
+      L"{ \"moduleId\": \"bridge\", \"tabLabel\": \"bridge\", "
+      L"\"order\": 1, \"showInTabs\": true, "
+      L"\"actions\": [\"bridge:run\"], \"bindings\": [\"status\"], "
+      L"\"capabilities\": [] } ] }";
+  modules::AppGate gate;
+  DHEPZ_CHECK(gate.StartWithEmbedded(embedded).ok());
+  DHEPZ_CHECK(gate.Mounted(L"bridge"));
+
+  RecordingBackend backend;
+  ui::presenter::ScreenPresenter presenter(&backend);
+  presenter.SetDocument(gate.document());
+  json::Value initial = json::Value::Object();
+  initial.Set(L"status", json::Value::String(L"Ready"));
+  DHEPZ_CHECK(presenter.ApplyStatePatch(L"bridge", initial).ok());
+  presenter.set_action_dispatch_handler(
+      [&](std::wstring_view route, std::wstring_view action,
+          const json::Value& payload, json::Value* state_patch) {
+        DHEPZ_RETURN_IF_ERROR(gate.Activate(route));
+        return gate.Dispatch(action, payload, state_patch);
+      });
+  presenter.Prepare({0.0f, 0.0f, 400.0f, 300.0f});
+  DHEPZ_CHECK(presenter.HandleClick(50.0f, 48.0f));
+  DHEPZ_CHECK_EQ(presenter.ViewStateValue(L"bridge", L"status")->AsString(),
+                 std::wstring(L"Dispatched Ready"));
+  DHEPZ_CHECK_EQ(gate.Diagnostics().statuses.size(), static_cast<std::size_t>(1));
+  DHEPZ_CHECK(gate.Diagnostics().statuses[0].ok);
+  modules::ResetRegistryForTests();
 }


### PR DESCRIPTION
Closes #111

## Outcome
- component schema now validates action, action_payload, and exact binding templates
- ScreenPresenter owns generic route view state and resolves literals/bindings without including module or gate headers
- production composition injects action, route, and async state-patch callbacks
- terminal screen declares terminal:launch in JSON
- module quarantine refreshes the presenter document before the next frame

## Architecture
The path is child UI JSON -> generic presenter callback -> parent composition -> AppGate -> child module. Async state returns child module -> ModuleHost -> parent composition -> presenter. AppGate only resolves ownership/lifecycle/dispatch; it gained one read-only module-to-route query and no rendering, filesystem, process, or settings work.

## Focused local verification
- Debug build and embedded validation: passed
- UiSchema: 9/9
- AppGateContract: 8/8
- ScreenPresenter: 10/10
- ProductionApplication: 4/4, including real embedded terminal JSON -> presenter -> production callback -> gate -> fake terminal descriptor -> diagnostics
- git diff --check: passed

No local full suite was run. PR CI is the single full Debug/Release regression for this SHA.