### PR TITLE
IC-08: route typed terminal launches through the host

### DIFF
--- a/src/modules/terminal/module.json
+++ b/src/modules/terminal/module.json
@@ -4,6 +4,10 @@
   "order": 10,
   "showInTabs": true,
   "actions": ["terminal:launch"],
-  "bindings": [],
+  "bindings": [
+    "working_folder", "wsl_distros", "wsl_distro", "admin",
+    "powershell_venv", "cmd_venv", "venv_available", "venv_enabled",
+    "busy", "status", "launch_enabled"
+  ],
   "capabilities": []
 }

--- a/src/modules/terminal/screen.json
+++ b/src/modules/terminal/screen.json
@@ -8,8 +8,14 @@
       "show_in_tabs": true,
       "children": [
         { "type": "text", "text": "Terminal", "variant": "title" },
-        { "type": "button", "id": "launch-terminal", "label": "Open PowerShell", "action": "terminal:launch",
-          "action_payload": {} }
+        { "type": "input", "value_binding": "working_folder", "placeholder": "Working folder (available in IC-09)" },
+        { "type": "toggle", "id": "admin-toggle", "label": "Run as administrator", "checked_binding": "admin" },
+        { "type": "toggle", "id": "venv-toggle", "label": "Use virtual environment", "checked_binding": "venv_enabled", "visible": { "$bind": "venv_available" } },
+        { "type": "combo", "items_binding": "wsl_distros", "selected_value_binding": "wsl_distro", "placeholder": "WSL distro (populated in IC-11)" },
+        { "type": "button", "id": "launch-powershell", "label": "PowerShell", "enabled": { "$bind": "launch_enabled" }, "action": "terminal:launch", "action_payload": { "shell": "powershell", "admin": { "$bind": "admin" }, "working_folder": { "$bind": "working_folder" }, "venv_enabled": { "$bind": "venv_enabled" }, "venv": { "$bind": "powershell_venv" } } },
+        { "type": "button", "id": "launch-cmd", "label": "Cmd", "enabled": { "$bind": "launch_enabled" }, "action": "terminal:launch", "action_payload": { "shell": "cmd", "admin": { "$bind": "admin" }, "working_folder": { "$bind": "working_folder" }, "venv_enabled": { "$bind": "venv_enabled" }, "venv": { "$bind": "cmd_venv" } } },
+        { "type": "button", "id": "launch-wsl", "label": "WSL", "enabled": { "$bind": "launch_enabled" }, "action": "terminal:launch", "action_payload": { "shell": "wsl", "admin": false, "wsl_distro": { "$bind": "wsl_distro" }, "working_folder": null, "venv_enabled": false, "venv": null } },
+        { "type": "text", "text": { "$bind": "status" }, "variant": "caption" }
       ]
     }
   ]

--- a/src/modules/terminal/terminal_logic.cpp
+++ b/src/modules/terminal/terminal_logic.cpp
@@ -1,27 +1,216 @@
 #include "modules/terminal/terminal_logic.h"
 
-#include "platform/strings.h"
+#include <cwctype>
+#include <set>
 
 namespace terminal {
+namespace {
 
-std::wstring BuildCommandLine(const LaunchSpec& spec) {
-  std::wstring command;
-  switch (spec.shell) {
-    case Shell::PowerShell:
-      command = L"powershell.exe -NoExit";
-      break;
-    case Shell::Cmd:
-      command = L"cmd.exe";
-      break;
-    case Shell::Wsl:
-      command = L"wsl.exe -d " + str::QuoteArg(spec.wsl_distro);
-      break;
+bool EndsWithInsensitive(std::wstring_view value, std::wstring_view suffix) {
+  if (suffix.size() > value.size()) return false;
+  const std::size_t offset = value.size() - suffix.size();
+  for (std::size_t i = 0; i < suffix.size(); ++i) {
+    if (std::towlower(value[offset + i]) != std::towlower(suffix[i])) return false;
   }
-  if (spec.venv_enabled && !spec.venv_activate_path.empty()) {
-    command += L" -NoExit -Command " + str::QuoteArg(spec.venv_activate_path);
+  return true;
+}
+
+bool IsWindowsPath(std::wstring_view path) {
+  return path.empty() ||
+         (path.size() >= 3 && std::iswalpha(path[0]) && path[1] == L':' &&
+          (path[2] == L'\\' || path[2] == L'/')) ||
+         path.rfind(L"\\\\", 0) == 0;
+}
+
+bool IsLinuxPath(std::wstring_view path) {
+  return !path.empty() && path.front() == L'/';
+}
+
+core::Status OptionalString(const json::Value& payload, std::wstring_view key,
+                            std::wstring* out) {
+  const json::Value* value = payload.Find(key);
+  if (value == nullptr || value->is_null()) {
+    out->clear();
+    return core::Ok();
   }
-  (void)spec.working_dir;  // applied as the child's working directory at launch
-  return command;
+  if (!value->is_string()) {
+    return DHEPZ_ERR(core::ErrorCode::InvalidArgument,
+                     L"terminal payload '" + std::wstring(key) +
+                         L"' must be a string or null");
+  }
+  *out = value->AsString();
+  return core::Ok();
+}
+
+}  // namespace
+
+core::Status ParseLaunchPayload(const json::Value& payload, LaunchSpec* out) {
+  if (out == nullptr) {
+    return DHEPZ_ERR(core::ErrorCode::InvalidArgument,
+                     L"terminal launch output is required");
+  }
+  *out = {};
+  if (!payload.is_object()) {
+    return DHEPZ_ERR(core::ErrorCode::InvalidArgument,
+                     L"terminal launch payload must be an object");
+  }
+  static const std::set<std::wstring> allowed = {
+      L"shell", L"wsl_distro", L"admin", L"working_folder", L"venv_enabled",
+      L"venv"};
+  for (const auto& [key, value] : payload.members()) {
+    (void)value;
+    if (!allowed.contains(key)) {
+      return DHEPZ_ERR(core::ErrorCode::InvalidArgument,
+                       L"unknown terminal payload field '" + key + L"'");
+    }
+  }
+
+  const json::Value* shell = payload.Find(L"shell");
+  if (shell == nullptr || !shell->is_string()) {
+    return DHEPZ_ERR(core::ErrorCode::InvalidArgument,
+                     L"terminal payload requires string 'shell'");
+  }
+  if (shell->AsString() == L"powershell") out->shell = Shell::PowerShell;
+  else if (shell->AsString() == L"cmd") out->shell = Shell::Cmd;
+  else if (shell->AsString() == L"wsl") out->shell = Shell::Wsl;
+  else {
+    return DHEPZ_ERR(core::ErrorCode::InvalidArgument,
+                     L"terminal shell must be powershell, cmd, or wsl");
+  }
+
+  DHEPZ_RETURN_IF_ERROR(OptionalString(payload, L"wsl_distro", &out->wsl_distro));
+  DHEPZ_RETURN_IF_ERROR(OptionalString(payload, L"working_folder", &out->working_dir));
+  if (const json::Value* admin = payload.Find(L"admin");
+      admin != nullptr && !admin->is_null()) {
+    if (!admin->is_bool()) {
+      return DHEPZ_ERR(core::ErrorCode::InvalidArgument,
+                       L"terminal payload 'admin' must be a bool or null");
+    }
+    out->admin = admin->AsBool();
+  }
+
+  bool venv_enabled = true;
+  if (const json::Value* enabled = payload.Find(L"venv_enabled");
+      enabled != nullptr && !enabled->is_null()) {
+    if (!enabled->is_bool()) {
+      return DHEPZ_ERR(core::ErrorCode::InvalidArgument,
+                       L"terminal payload 'venv_enabled' must be a bool or null");
+    }
+    venv_enabled = enabled->AsBool();
+  }
+
+  if (const json::Value* venv = payload.Find(L"venv");
+      venv != nullptr && !venv->is_null()) {
+    if (!venv->is_object()) {
+      return DHEPZ_ERR(core::ErrorCode::InvalidArgument,
+                       L"terminal payload 'venv' must be an object or null");
+    }
+    for (const auto& [key, value] : venv->members()) {
+      (void)value;
+      if (key != L"kind" && key != L"activate_path") {
+        return DHEPZ_ERR(core::ErrorCode::InvalidArgument,
+                         L"unknown terminal venv field '" + key + L"'");
+      }
+    }
+    const std::wstring kind = venv->StringField(L"kind");
+    const json::Value* path = venv->Find(L"activate_path");
+    if ((kind != L"windows" && kind != L"linux") || path == nullptr ||
+        !path->is_string() || path->AsString().empty()) {
+      return DHEPZ_ERR(core::ErrorCode::InvalidArgument,
+                       L"venv requires kind windows/linux and activate_path");
+    }
+    out->venv.kind = kind == L"windows" ? PathKind::Windows : PathKind::Linux;
+    out->venv.activate_path = path->AsString();
+  }
+  if (!venv_enabled) out->venv = {};
+  return core::Ok();
+}
+
+core::Status BuildProcessRequest(const LaunchSpec& spec,
+                                 modules::ProcessRequest* out) {
+  if (out == nullptr) {
+    return DHEPZ_ERR(core::ErrorCode::InvalidArgument,
+                     L"process request output is required");
+  }
+  *out = {};
+  out->operation = spec.admin ? modules::ProcessOperation::ElevatedLaunch
+                              : modules::ProcessOperation::Launch;
+
+  if (spec.shell == Shell::Wsl) {
+    if (spec.admin) {
+      return DHEPZ_ERR(core::ErrorCode::InvalidArgument,
+                       L"elevated launch is not supported for WSL");
+    }
+    if (spec.wsl_distro.empty()) {
+      return DHEPZ_ERR(core::ErrorCode::InvalidArgument,
+                       L"WSL launch requires a distro");
+    }
+    if (!spec.working_dir.empty() && !IsLinuxPath(spec.working_dir)) {
+      return DHEPZ_ERR(core::ErrorCode::InvalidArgument,
+                       L"WSL working folder must be an absolute Linux path");
+    }
+    if (spec.venv.kind != PathKind::None &&
+        (spec.venv.kind != PathKind::Linux ||
+         !IsLinuxPath(spec.venv.activate_path) ||
+         !EndsWithInsensitive(spec.venv.activate_path, L"/bin/activate"))) {
+      return DHEPZ_ERR(core::ErrorCode::InvalidArgument,
+                       L"WSL venv must use an absolute Linux bin/activate path");
+    }
+    out->executable = L"wsl.exe";
+    out->arguments = {L"-d", spec.wsl_distro};
+    if (!spec.working_dir.empty()) {
+      out->arguments.push_back(L"--cd");
+      out->arguments.push_back(spec.working_dir);
+    }
+    if (spec.venv.kind == PathKind::Linux) {
+      out->arguments.insert(out->arguments.end(),
+                            {L"--", L"bash", L"-lc",
+                             L". \"$1\"; exec bash", L"dhepz",
+                             spec.venv.activate_path});
+    }
+    return core::Ok();
+  }
+
+  if (!spec.wsl_distro.empty()) {
+    return DHEPZ_ERR(core::ErrorCode::InvalidArgument,
+                     L"wsl_distro is valid only for WSL launches");
+  }
+  if (!IsWindowsPath(spec.working_dir)) {
+    return DHEPZ_ERR(core::ErrorCode::InvalidArgument,
+                     L"PowerShell/Cmd working folder must be an absolute Windows path");
+  }
+  if (spec.venv.kind == PathKind::Linux) {
+    return DHEPZ_ERR(core::ErrorCode::InvalidArgument,
+                     L"Linux venv cannot be used by PowerShell or Cmd");
+  }
+  out->working_directory = spec.working_dir;
+  if (spec.shell == Shell::PowerShell) {
+    out->executable = L"powershell.exe";
+    out->arguments = {L"-NoExit"};
+    if (spec.venv.kind == PathKind::Windows) {
+      if (!IsWindowsPath(spec.venv.activate_path) ||
+          !EndsWithInsensitive(spec.venv.activate_path,
+                               L"\\Scripts\\Activate.ps1")) {
+        return DHEPZ_ERR(core::ErrorCode::InvalidArgument,
+                         L"PowerShell venv must select Scripts\\Activate.ps1");
+      }
+      out->arguments.insert(out->arguments.end(),
+                            {L"-ExecutionPolicy", L"Bypass", L"-File",
+                             spec.venv.activate_path});
+    }
+  } else {
+    out->executable = L"cmd.exe";
+    if (spec.venv.kind == PathKind::Windows) {
+      if (!IsWindowsPath(spec.venv.activate_path) ||
+          !EndsWithInsensitive(spec.venv.activate_path,
+                               L"\\Scripts\\activate.bat")) {
+        return DHEPZ_ERR(core::ErrorCode::InvalidArgument,
+                         L"Cmd venv must select Scripts\\activate.bat");
+      }
+      out->arguments = {L"/K", spec.venv.activate_path};
+    }
+  }
+  return core::Ok();
 }
 
 }  // namespace terminal

--- a/src/modules/terminal/terminal_logic.h
+++ b/src/modules/terminal/terminal_logic.h
@@ -1,23 +1,34 @@
-// Terminal feature logic — no UI types (plan: terminal_logic.* is the
-// feature itself). Command lines are built strictly through QuoteArg.
+// Pure terminal launch modelling. It parses screen payload data into a typed
+// spec and emits the parent contract's executable + argv request. Quoting and
+// process creation remain parent-owned.
 #pragma once
 
 #include <string>
 
+#include "core/json.h"
+#include "core/status.h"
+#include "modules/contract/module_contract.h"
+
 namespace terminal {
 
 enum class Shell { PowerShell, Cmd, Wsl };
+enum class PathKind { None, Windows, Linux };
+
+struct VenvSelection {
+  PathKind kind = PathKind::None;
+  std::wstring activate_path;
+};
 
 struct LaunchSpec {
   Shell shell = Shell::PowerShell;
   std::wstring working_dir;
-  std::wstring wsl_distro;   // used when shell == Wsl
-  bool admin = false;       // elevation handled by ShellLaunch (P4-02)
-  bool venv_enabled = false;
-  std::wstring venv_activate_path;
+  std::wstring wsl_distro;
+  bool admin = false;
+  VenvSelection venv;
 };
 
-// Builds the child command line; every argument quoted via str::QuoteArg.
-std::wstring BuildCommandLine(const LaunchSpec& spec);
+core::Status ParseLaunchPayload(const json::Value& payload, LaunchSpec* out);
+core::Status BuildProcessRequest(const LaunchSpec& spec,
+                                 modules::ProcessRequest* out);
 
 }  // namespace terminal

--- a/src/modules/terminal/terminal_module.cpp
+++ b/src/modules/terminal/terminal_module.cpp
@@ -1,12 +1,12 @@
-// Self-registering logic half of the terminal module. terminal:launch opens
-// an external console (P4-02); RunCapture-based flows (WSL enumeration etc.)
-// land with worker offload (P4-05).
+// Terminal feature coordinator. Process work crosses ModuleHost and completes
+// on the UI thread; this child never includes the parent platform layer.
 #include "modules/contract/module_contract.h"
 #include "modules/registry/module_registry.h"
 #include "modules/terminal/terminal_logic.h"
-#include "platform/process.h"
 
+#include <algorithm>
 #include <memory>
+#include <vector>
 
 namespace terminal {
 namespace {
@@ -18,28 +18,101 @@ class TerminalModule final : public modules::ModuleDescriptor {
   int Order() const override { return 10; }
   bool ShowInTabs() const override { return true; }
   std::wstring_view SettingsRoute() const override { return {}; }
-  std::vector<std::wstring> DeclaredActions() const override { return {L"terminal:launch"}; }
-  std::vector<std::wstring> DeclaredBindings() const override { return {}; }
+  std::vector<std::wstring> DeclaredActions() const override {
+    return {L"terminal:launch"};
+  }
+  std::vector<std::wstring> DeclaredBindings() const override {
+    return {L"working_folder", L"wsl_distros", L"wsl_distro", L"admin",
+            L"powershell_venv", L"cmd_venv", L"venv_available",
+            L"venv_enabled", L"busy", L"status", L"launch_enabled"};
+  }
   std::vector<std::wstring> DeclaredCapabilities() const override { return {}; }
 
   core::Status Bind(modules::ModuleHost& host) override {
     host_ = &host;
+    ++generation_;
+    json::Value defaults = json::Value::Object();
+    defaults.Set(L"working_folder", json::Value::String(L""));
+    defaults.Set(L"wsl_distros", json::Value::Array());
+    defaults.Set(L"wsl_distro", json::Value::Null());
+    defaults.Set(L"admin", json::Value::Bool(false));
+    defaults.Set(L"powershell_venv", json::Value::Null());
+    defaults.Set(L"cmd_venv", json::Value::Null());
+    defaults.Set(L"venv_available", json::Value::Bool(false));
+    defaults.Set(L"venv_enabled", json::Value::Bool(false));
+    defaults.Set(L"busy", json::Value::Bool(false));
+    defaults.Set(L"status", json::Value::String(L"Ready"));
+    defaults.Set(L"launch_enabled", json::Value::Bool(true));
+    const core::Status published = host_->PublishStatePatch(defaults);
+    if (!published.ok() && published.Code() != core::ErrorCode::Unsupported) {
+      host_->ReportStatus(published);
+    }
     return core::Ok();
   }
 
-  core::Status Handle(std::wstring_view action, const json::Value&, json::Value*) override {
+  core::Status Handle(std::wstring_view action, const json::Value& payload,
+                      json::Value* state_patch) override {
     if (action != L"terminal:launch") {
       return core::Err(core::ErrorCode::NotFound, L"terminal: unknown action");
     }
+    if (host_ == nullptr || state_patch == nullptr) {
+      return core::Err(core::ErrorCode::InvalidArgument,
+                       L"terminal module is not bound or patch output is missing");
+    }
+
     LaunchSpec spec;
-    const std::wstring command = BuildCommandLine(spec);
-    return process::Launch(L"", command, spec.working_dir, process::WindowMode::NewConsole);
+    DHEPZ_RETURN_IF_ERROR(ParseLaunchPayload(payload, &spec));
+    modules::ProcessRequest request;
+    DHEPZ_RETURN_IF_ERROR(BuildProcessRequest(spec, &request));
+
+    *state_patch = json::Value::Object();
+    state_patch->Set(L"busy", json::Value::Bool(true));
+    state_patch->Set(L"launch_enabled", json::Value::Bool(false));
+    state_patch->Set(L"status", json::Value::String(L"Launching terminal..."));
+
+    const std::uint64_t generation = generation_;
+    modules::AsyncRequestToken token;
+    const core::Status started = host_->StartProcess(
+        request,
+        [this, generation](const modules::HostOperationCompletion& completion) {
+          if (host_ == nullptr || generation != generation_) return;
+          std::erase(launch_tokens_, completion.token);
+          host_->ReportStatus(completion.status);
+          json::Value patch = json::Value::Object();
+          patch.Set(L"busy", json::Value::Bool(false));
+          patch.Set(L"launch_enabled", json::Value::Bool(true));
+          patch.Set(L"status", json::Value::String(
+              completion.status.ok() ? L"Terminal opened"
+                                     : completion.status.Message()));
+          const core::Status published = host_->PublishStatePatch(patch);
+          if (!published.ok()) host_->ReportStatus(published);
+        },
+        &token);
+    if (!started.ok()) {
+      state_patch->Set(L"busy", json::Value::Bool(false));
+      state_patch->Set(L"launch_enabled", json::Value::Bool(true));
+      state_patch->Set(L"status", json::Value::String(started.Message()));
+      return started;
+    }
+    launch_tokens_.push_back(token);
+    return core::Ok();
   }
 
-  void Release() override { host_ = nullptr; }
+  void Release() override {
+    ++generation_;
+    if (host_ != nullptr) {
+      for (modules::AsyncRequestToken token : launch_tokens_) {
+        host_->CancelRequest(token);
+      }
+    }
+    launch_tokens_.clear();
+    host_ = nullptr;
+  }
 
  private:
   modules::ModuleHost* host_ = nullptr;
+  std::uint64_t generation_ = 0;
+  std::vector<modules::AsyncRequestToken> launch_tokens_;
 };
 
 std::unique_ptr<modules::ModuleDescriptor> Make() {

--- a/src/ui/layout/layout_engine.cpp
+++ b/src/ui/layout/layout_engine.cpp
@@ -68,16 +68,37 @@ LayoutNode LayoutEngine::Build(const config::ComponentNode& node, const render::
   if (type == L"text") {
     const render::TextStyle style =
         text_style_provider_ ? text_style_provider_(node) : render::TextStyle{};
-    const render::Size size = MeasureText(node, node.GetString(L"text"), &style);
-    out.bounds.width = std::min(size.width, available.width);
+    const json::Value* text_value = Property(node, L"text");
+    const bool dynamic_text = text_value != nullptr && !text_value->is_string();
+    const render::Size size = MeasureText(
+        node, dynamic_text ? std::wstring_view(L"M")
+                           : std::wstring_view(node.GetString(L"text")),
+        &style);
+    out.bounds.width = dynamic_text ? available.width
+                                    : std::min(size.width, available.width);
     out.bounds.height = size.height;
     return out;
   }
 
   if (type == L"button") {
-    const render::Size size = MeasureText(node, node.GetString(L"label"));
+    const json::Value* label = Property(node, L"label");
+    const render::Size size = MeasureText(
+        node, label != nullptr && !label->is_string()
+                  ? std::wstring_view(L"Button")
+                  : std::wstring_view(node.GetString(L"label")));
     out.bounds.width = std::min(size.width + 16.0f, available.width);
     out.bounds.height = std::max(size.height + 8.0f, 24.0f);
+    return out;
+  }
+
+  if (type == L"input" || type == L"combo" || type == L"checkbox" ||
+      type == L"toggle") {
+    const std::wstring text = node.GetString(
+        L"label", node.GetString(L"placeholder", type));
+    const render::Size size = MeasureText(node, text);
+    out.bounds.width = std::min(std::max(size.width + 24.0f, 160.0f),
+                                available.width);
+    out.bounds.height = std::max(size.height + 10.0f, 30.0f);
     return out;
   }
 

--- a/src/ui/presenter/screen_presenter.cpp
+++ b/src/ui/presenter/screen_presenter.cpp
@@ -67,6 +67,22 @@ bool ReferencesAny(const json::Value& value,
   return false;
 }
 
+bool NamedBindingReferences(std::wstring_view property,
+                            const json::Value& value,
+                            const std::vector<std::wstring>& changed) {
+  if (property != L"value_binding" && property != L"items_binding" &&
+      property != L"selected_value_binding" &&
+      property != L"checked_binding" &&
+      property != L"selected_id_binding") {
+    return false;
+  }
+  if (!value.is_string()) return false;
+  const std::wstring& binding = value.AsString();
+  const std::size_t dot = binding.find(L'.');
+  return std::find(changed.begin(), changed.end(), binding.substr(0, dot)) !=
+         changed.end();
+}
+
 void MergeObject(json::Value* target, const json::Value& patch) {
   for (const auto& [key, value] : patch.members()) {
     if (value.is_null()) {
@@ -240,6 +256,50 @@ bool ScreenPresenter::ClickNode(const layout::LayoutNode& node, float x, float y
   }
   const std::wstring id = focus_.IdFor(route_, source);
   bool handled = !id.empty() && focus_.SetFocus(route_, id);
+  const std::wstring& type = source->type();
+  if (type == L"combo") {
+    const json::Value* items_binding = source->Property(L"items_binding");
+    const json::Value* selected_binding =
+        source->Property(L"selected_value_binding");
+    if (items_binding != nullptr && items_binding->is_string() &&
+        selected_binding != nullptr && selected_binding->is_string()) {
+      const json::Value* items = ResolveBinding(route_, items_binding->AsString());
+      if (items != nullptr && items->is_array() && !items->items().empty()) {
+        std::wstring selected;
+        if (const json::Value* current =
+                ResolveBinding(route_, selected_binding->AsString());
+            current != nullptr && current->is_string()) {
+          selected = current->AsString();
+        }
+        std::size_t next = 0;
+        for (std::size_t i = 0; i < items->items().size(); ++i) {
+          if (items->items()[i].is_string() &&
+              items->items()[i].AsString() == selected) {
+            next = (i + 1) % items->items().size();
+            break;
+          }
+        }
+        if (items->items()[next].is_string()) {
+          json::Value patch = json::Value::Object();
+          patch.Set(selected_binding->AsString(), items->items()[next]);
+          handled = ApplyStatePatch(route_, patch).ok() || handled;
+        }
+      }
+    }
+  } else if (type == L"toggle" || type == L"checkbox") {
+    const json::Value* checked_binding = source->Property(L"checked_binding");
+    if (checked_binding != nullptr && checked_binding->is_string()) {
+      bool checked = false;
+      if (const json::Value* current =
+              ResolveBinding(route_, checked_binding->AsString());
+          current != nullptr && current->is_bool()) {
+        checked = current->AsBool();
+      }
+      json::Value patch = json::Value::Object();
+      patch.Set(checked_binding->AsString(), json::Value::Bool(!checked));
+      handled = ApplyStatePatch(route_, patch).ok() || handled;
+    }
+  }
   const std::wstring action = source->GetString(L"action");
   if (!action.empty() && action_dispatch_handler_) {
     json::Value payload = json::Value::Object();
@@ -380,6 +440,48 @@ void ScreenPresenter::PaintNode(const layout::LayoutNode& node) {
                             render::TextStyle{},
                             Token(L"text", {255, 255, 255, 255}), render::TextAlign::Center,
                             render::VerticalAlign::Middle);
+    } else if (type == L"input" || type == L"combo") {
+      backend_->StrokeRoundedRect(node.bounds, render::CornerRadius::Uniform(5.0f),
+                                  Token(L"borderStrong", {70, 76, 88, 255}), 1.0f);
+      const std::wstring binding_property =
+          type == L"input" ? L"value_binding" : L"selected_value_binding";
+      std::wstring value;
+      if (const json::Value* binding = source->Property(binding_property);
+          binding != nullptr && binding->is_string()) {
+        if (const json::Value* resolved = ResolveBinding(route_, binding->AsString());
+            resolved != nullptr && resolved->is_string()) {
+          value = resolved->AsString();
+        }
+      }
+      if (value.empty()) value = source->GetString(L"placeholder");
+      if (type == L"combo" && !value.empty()) value += L"  \u25BE";
+      backend_->DrawTextRun(value, node.bounds, render::TextStyle{},
+                            Token(L"text", {255, 255, 255, 255}),
+                            render::TextAlign::Left, render::VerticalAlign::Middle);
+    } else if (type == L"toggle" || type == L"checkbox") {
+      bool checked = false;
+      if (const json::Value* binding = source->Property(L"checked_binding");
+          binding != nullptr && binding->is_string()) {
+        if (const json::Value* value = ResolveBinding(route_, binding->AsString());
+            value != nullptr && value->is_bool()) {
+          checked = value->AsBool();
+        }
+      }
+      const render::Rect mark{node.bounds.x, node.bounds.y + 6.0f, 18.0f, 18.0f};
+      backend_->StrokeRoundedRect(mark, render::CornerRadius::Uniform(5.0f),
+                                  Token(L"borderStrong", {70, 76, 88, 255}), 1.0f);
+      if (checked) {
+        const render::Rect fill{mark.x + 3.0f, mark.y + 3.0f,
+                                mark.width - 6.0f, mark.height - 6.0f};
+        backend_->FillRoundedRect(fill, render::CornerRadius::Uniform(3.0f),
+                                  Token(L"accent", {96, 165, 250, 255}));
+      }
+      const render::Rect label{node.bounds.x + 26.0f, node.bounds.y,
+                               std::max(0.0f, node.bounds.width - 26.0f),
+                               node.bounds.height};
+      backend_->DrawTextRun(ResolvedString(*source, L"label"), label,
+                            render::TextStyle{}, Token(L"text", {255, 255, 255, 255}),
+                            render::TextAlign::Left, render::VerticalAlign::Middle);
     }
     if (source == focused_node_) {
       const render::Rect ring{node.bounds.x - 2.0f, node.bounds.y - 2.0f,
@@ -472,8 +574,8 @@ void ScreenPresenter::InvalidateBoundNodes(
   if (node.source != nullptr) {
     bool affected = false;
     for (const auto& [key, value] : node.source->properties_) {
-      (void)key;
-      if (ReferencesAny(value, changed)) {
+      if (ReferencesAny(value, changed) ||
+          NamedBindingReferences(key, value, changed)) {
         affected = true;
         break;
       }

--- a/tests/application/production_application_test.cpp
+++ b/tests/application/production_application_test.cpp
@@ -23,7 +23,11 @@ class FakeTerminalModule final : public modules::ModuleDescriptor {
   std::vector<std::wstring> DeclaredActions() const override {
     return {L"terminal:launch"};
   }
-  std::vector<std::wstring> DeclaredBindings() const override { return {}; }
+  std::vector<std::wstring> DeclaredBindings() const override {
+    return {L"working_folder", L"wsl_distros", L"wsl_distro", L"admin",
+            L"powershell_venv", L"cmd_venv", L"venv_available",
+            L"venv_enabled", L"busy", L"status", L"launch_enabled"};
+  }
   std::vector<std::wstring> DeclaredCapabilities() const override { return {}; }
   core::Status Bind(modules::ModuleHost&) override { return core::Ok(); }
   core::Status Handle(std::wstring_view action, const json::Value&,
@@ -121,7 +125,7 @@ DHEPZ_TEST(ProductionApplication, TerminalJsonActionReachesGateStatusPath) {
   app.presenter()->SwitchRoute(L"terminal");
   app.window()->Repaint();
   render::Rect button{};
-  DHEPZ_CHECK(app.presenter()->InteractiveBounds(L"launch-terminal", &button));
+  DHEPZ_CHECK(app.presenter()->InteractiveBounds(L"launch-powershell", &button));
   DHEPZ_CHECK(app.presenter()->HandleClick(
       button.x + button.width / 2.0f,
       button.y + button.height / 2.0f));

--- a/tests/modules/terminal/terminal_scaffold_test.cpp
+++ b/tests/modules/terminal/terminal_scaffold_test.cpp
@@ -13,6 +13,65 @@
 
 namespace {
 
+class FakeLaunchHost final : public modules::ModuleHost {
+ public:
+  modules::ModuleSurface Surface() override { return {}; }
+  core::Status SettingsRead(std::wstring_view, std::wstring*) override {
+    return core::Err(core::ErrorCode::NotFound, L"not configured");
+  }
+  core::Status SettingsReadGlobal(std::wstring_view, std::wstring*) override {
+    return core::Err(core::ErrorCode::NotFound, L"not configured");
+  }
+  core::Status SettingsWrite(std::wstring_view, std::wstring_view) override {
+    return core::Ok();
+  }
+  core::Status StartSettingsLoad(modules::HostOperationCallback,
+                                 modules::AsyncRequestToken*) override {
+    return core::Err(core::ErrorCode::Unsupported, L"not configured");
+  }
+  core::Status StartProcess(const modules::ProcessRequest& value,
+                            modules::HostOperationCallback completed,
+                            modules::AsyncRequestToken* token) override {
+    ++process_calls;
+    request = value;
+    callback = std::move(completed);
+    token->value = 77;
+    return start_status;
+  }
+  core::Status StartFolderProbe(const modules::FolderProbeRequest&,
+                                modules::HostOperationCallback,
+                                modules::AsyncRequestToken*) override {
+    return core::Err(core::ErrorCode::Unsupported, L"not configured");
+  }
+  void CancelRequest(modules::AsyncRequestToken token) override {
+    cancelled = token;
+  }
+  core::Status PublishStatePatch(const json::Value& patch) override {
+    patches.push_back(patch);
+    return core::Ok();
+  }
+  core::Status GetSettingsAllFacet(modules::SettingsAllFacet** facet) override {
+    *facet = nullptr;
+    return core::Err(core::ErrorCode::PermissionDenied, L"not granted");
+  }
+  core::Status GetConfigWriteFacet(modules::ConfigWriteFacet** facet) override {
+    *facet = nullptr;
+    return core::Err(core::ErrorCode::PermissionDenied, L"not granted");
+  }
+  void ReportStatus(const core::Status& value) override { reported = value; }
+  void Log(std::wstring_view, std::wstring_view) override {}
+  core::Status RequestRoute(std::wstring_view) override { return core::Ok(); }
+  std::vector<modules::PeerInfo> Peers() override { return {}; }
+
+  core::Status start_status;
+  modules::ProcessRequest request;
+  modules::HostOperationCallback callback;
+  modules::AsyncRequestToken cancelled;
+  std::vector<json::Value> patches;
+  core::Status reported;
+  int process_calls = 0;
+};
+
 std::wstring Ws(const std::string& narrow) {
   std::wstring wide;
   for (const char c : narrow) wide.push_back(static_cast<wchar_t>(static_cast<unsigned char>(c)));
@@ -65,10 +124,152 @@ DHEPZ_TEST(TerminalScaffold, SelfRegistersAndIsDiscoverable) {
   modules::ResetRegistryForTests();
 }
 
-DHEPZ_TEST(TerminalLogic, WslCommandLineQuotesTheDistro) {
+DHEPZ_TEST(TerminalLogic, WslBuilderKeepsDistroAsOneStructuredArgument) {
   terminal::LaunchSpec spec;
   spec.shell = terminal::Shell::Wsl;
   spec.wsl_distro = L"My Distro";
-  const std::wstring command = terminal::BuildCommandLine(spec);
-  DHEPZ_CHECK(command.find(L"\"My Distro\"") != std::wstring::npos);
+  modules::ProcessRequest request;
+  DHEPZ_CHECK(terminal::BuildProcessRequest(spec, &request).ok());
+  DHEPZ_CHECK_EQ(request.executable, std::wstring(L"wsl.exe"));
+  DHEPZ_CHECK_EQ(request.arguments.size(), static_cast<std::size_t>(2));
+  DHEPZ_CHECK_EQ(request.arguments[1], std::wstring(L"My Distro"));
+}
+
+DHEPZ_TEST(TerminalLogic, TypedPayloadBuildsEveryShellAndElevationMode) {
+  struct Case {
+    const wchar_t* json;
+    const wchar_t* executable;
+    modules::ProcessOperation operation;
+  };
+  const Case cases[] = {
+      {LR"({"shell":"powershell","admin":false,"working_folder":"C:\\work","venv":null})",
+       L"powershell.exe", modules::ProcessOperation::Launch},
+      {LR"({"shell":"cmd","admin":true,"working_folder":"C:\\work","venv":null})",
+       L"cmd.exe", modules::ProcessOperation::ElevatedLaunch},
+      {LR"({"shell":"wsl","wsl_distro":"Ubuntu","admin":false,"working_folder":"/work","venv":null})",
+       L"wsl.exe", modules::ProcessOperation::Launch},
+  };
+  for (const Case& item : cases) {
+    json::Value payload;
+    DHEPZ_CHECK(json::Parse(item.json, &payload).ok());
+    terminal::LaunchSpec spec;
+    DHEPZ_CHECK(terminal::ParseLaunchPayload(payload, &spec).ok());
+    modules::ProcessRequest request;
+    DHEPZ_CHECK(terminal::BuildProcessRequest(spec, &request).ok());
+    DHEPZ_CHECK_EQ(request.executable, std::wstring(item.executable));
+    DHEPZ_CHECK(request.operation == item.operation);
+  }
+}
+
+DHEPZ_TEST(TerminalLogic, ShellSpecificVenvArgumentsAndInvalidCombinations) {
+  terminal::LaunchSpec powershell;
+  powershell.shell = terminal::Shell::PowerShell;
+  powershell.venv = {terminal::PathKind::Windows,
+                     L"C:\\work\\.venv\\Scripts\\Activate.ps1"};
+  modules::ProcessRequest request;
+  DHEPZ_CHECK(terminal::BuildProcessRequest(powershell, &request).ok());
+  DHEPZ_CHECK_EQ(request.arguments.back(), powershell.venv.activate_path);
+
+  terminal::LaunchSpec cmd = powershell;
+  cmd.shell = terminal::Shell::Cmd;
+  cmd.venv.activate_path = L"C:\\work\\.venv\\Scripts\\activate.bat";
+  DHEPZ_CHECK(terminal::BuildProcessRequest(cmd, &request).ok());
+  DHEPZ_CHECK_EQ(request.arguments[0], std::wstring(L"/K"));
+
+  terminal::LaunchSpec wsl;
+  wsl.shell = terminal::Shell::Wsl;
+  wsl.wsl_distro = L"Ubuntu";
+  wsl.venv = {terminal::PathKind::Linux, L"/work/.venv/bin/activate"};
+  DHEPZ_CHECK(terminal::BuildProcessRequest(wsl, &request).ok());
+  DHEPZ_CHECK_EQ(request.arguments.back(), wsl.venv.activate_path);
+
+  wsl.working_dir = L"C:\\work";
+  DHEPZ_CHECK_FALSE(terminal::BuildProcessRequest(wsl, &request).ok());
+  wsl.working_dir.clear();
+  wsl.admin = true;
+  DHEPZ_CHECK_FALSE(terminal::BuildProcessRequest(wsl, &request).ok());
+  powershell.venv = {terminal::PathKind::Linux, L"/work/.venv/bin/activate"};
+  DHEPZ_CHECK_FALSE(terminal::BuildProcessRequest(powershell, &request).ok());
+}
+
+DHEPZ_TEST(TerminalLogic, DisabledVenvDoesNotReachTheProcessRequest) {
+  json::Value payload;
+  DHEPZ_CHECK(json::Parse(
+      LR"({"shell":"powershell","venv_enabled":false,"venv":{"kind":"windows","activate_path":"C:\\work\\.venv\\Scripts\\Activate.ps1"}})",
+      &payload).ok());
+  terminal::LaunchSpec spec;
+  DHEPZ_CHECK(terminal::ParseLaunchPayload(payload, &spec).ok());
+  DHEPZ_CHECK(spec.venv.kind == terminal::PathKind::None);
+  modules::ProcessRequest request;
+  DHEPZ_CHECK(terminal::BuildProcessRequest(spec, &request).ok());
+  DHEPZ_CHECK_EQ(request.arguments.size(), static_cast<std::size_t>(1));
+  DHEPZ_CHECK_EQ(request.arguments[0], std::wstring(L"-NoExit"));
+}
+
+DHEPZ_TEST(TerminalLogic, InvalidPayloadFailsBeforeARequestCanBeBuilt) {
+  const wchar_t* cases[] = {
+      LR"({})", LR"({"shell":"fish"})", LR"({"shell":"wsl"})",
+      LR"({"shell":"cmd","admin":"yes"})",
+      LR"({"shell":"cmd","surprise":true})",
+      LR"({"shell":"powershell","venv":{"kind":"windows"}})"};
+  for (const wchar_t* text : cases) {
+    json::Value payload;
+    DHEPZ_CHECK(json::Parse(text, &payload).ok());
+    terminal::LaunchSpec spec;
+    const core::Status parsed = terminal::ParseLaunchPayload(payload, &spec);
+    if (std::wstring_view(text).find(L"\"shell\":\"wsl\"") !=
+        std::wstring_view::npos && parsed.ok()) {
+      modules::ProcessRequest request;
+      DHEPZ_CHECK_FALSE(terminal::BuildProcessRequest(spec, &request).ok());
+    } else {
+      DHEPZ_CHECK_FALSE(parsed.ok());
+    }
+  }
+}
+
+DHEPZ_TEST(TerminalModule, UsesHostRequestAndPublishesCancelledCompletion) {
+  FakeLaunchHost host;
+  const std::unique_ptr<modules::ModuleDescriptor> module =
+      terminal::MakeTerminalForTests();
+  DHEPZ_CHECK(module->Bind(host).ok());
+  DHEPZ_CHECK_EQ(host.patches.size(), static_cast<std::size_t>(1));
+
+  json::Value payload;
+  DHEPZ_CHECK(json::Parse(
+      LR"({"shell":"cmd","admin":true,"working_folder":"C:\\work","venv_enabled":false,"venv":null})",
+      &payload).ok());
+  json::Value immediate;
+  DHEPZ_CHECK(module->Handle(L"terminal:launch", payload, &immediate).ok());
+  DHEPZ_CHECK_EQ(host.process_calls, 1);
+  DHEPZ_CHECK_EQ(host.request.executable, std::wstring(L"cmd.exe"));
+  DHEPZ_CHECK(host.request.operation == modules::ProcessOperation::ElevatedLaunch);
+  DHEPZ_CHECK_EQ(host.request.working_directory, std::wstring(L"C:\\work"));
+  DHEPZ_CHECK(immediate.BoolField(L"busy"));
+
+  modules::HostOperationCompletion completion;
+  completion.token.value = 77;
+  completion.kind = modules::HostOperationKind::ElevatedLaunch;
+  completion.status = core::Err(core::ErrorCode::Cancelled, L"UAC was cancelled");
+  host.callback(completion);
+  DHEPZ_CHECK(host.reported.Code() == core::ErrorCode::Cancelled);
+  DHEPZ_CHECK_EQ(host.patches.size(), static_cast<std::size_t>(2));
+  DHEPZ_CHECK_FALSE(host.patches.back().BoolField(L"busy"));
+  DHEPZ_CHECK_CONTAINS(host.patches.back().StringField(L"status"),
+                       std::wstring(L"UAC"));
+  module->Release();
+}
+
+DHEPZ_TEST(TerminalModule, InvalidPayloadNeverInvokesHost) {
+  FakeLaunchHost host;
+  const std::unique_ptr<modules::ModuleDescriptor> module =
+      terminal::MakeTerminalForTests();
+  DHEPZ_CHECK(module->Bind(host).ok());
+  json::Value payload;
+  DHEPZ_CHECK(json::Parse(LR"({"shell":"wsl","admin":true})", &payload).ok());
+  json::Value patch;
+  const core::Status status =
+      module->Handle(L"terminal:launch", payload, &patch);
+  DHEPZ_CHECK_FALSE(status.ok());
+  DHEPZ_CHECK_EQ(host.process_calls, 0);
+  module->Release();
 }

--- a/tests/ui/presenter/screen_presenter_test.cpp
+++ b/tests/ui/presenter/screen_presenter_test.cpp
@@ -140,6 +140,19 @@ const char* kCore = R"({
       "selected": { "kind": "binding" },
       "action": { "kind": "string" },
       "action_payload": { "kind": "object" },
+      "tab_stop": { "kind": "bool", "default": true } } },
+    "input": { "properties": {
+      "value_binding": { "kind": "binding" },
+      "placeholder": { "kind": "string" },
+      "tab_stop": { "kind": "bool", "default": true } } },
+    "combo": { "properties": {
+      "items_binding": { "kind": "binding" },
+      "selected_value_binding": { "kind": "binding" },
+      "placeholder": { "kind": "string" },
+      "tab_stop": { "kind": "bool", "default": true } } },
+    "toggle": { "properties": {
+      "label": { "kind": "text" },
+      "checked_binding": { "kind": "binding" },
       "tab_stop": { "kind": "bool", "default": true } } }
   }
 })";
@@ -453,4 +466,53 @@ DHEPZ_TEST(ScreenPresenter, SyntheticClickTravelsThroughGateAndModulePatch) {
   DHEPZ_CHECK_EQ(gate.Diagnostics().statuses.size(), static_cast<std::size_t>(1));
   DHEPZ_CHECK(gate.Diagnostics().statuses[0].ok);
   modules::ResetRegistryForTests();
+}
+
+DHEPZ_TEST(ScreenPresenter, TerminalControlsRenderAndUpdateGenericBindings) {
+  RecordingBackend backend;
+  json::Value core;
+  DHEPZ_CHECK(json::Parse(W(kCore), &core).ok());
+  std::vector<ui::config::Diagnostic> diagnostics;
+  std::unique_ptr<ui::config::ResolvedUiDocument> document;
+  DHEPZ_CHECK(ui::config::ResolveDocument(
+                  core,
+                  {{L"embedded", W(R"({ "components": [
+                    { "type": "screen", "route_id": "home", "children": [
+                      { "type": "input", "id": "folder",
+                        "value_binding": "folder", "placeholder": "Folder" },
+                      { "type": "toggle", "id": "admin", "label": "Admin",
+                        "checked_binding": "admin" },
+                      { "type": "combo", "id": "distro",
+                        "items_binding": "distros",
+                        "selected_value_binding": "selected",
+                        "placeholder": "Distro" }
+                    ] }
+                  ] })")}},
+                  &diagnostics, &document).ok());
+  ui::presenter::ScreenPresenter presenter(&backend);
+  presenter.SetDocument(document.get());
+  json::Value state = json::Value::Object();
+  state.Set(L"folder", json::Value::String(L"C:\\work"));
+  state.Set(L"admin", json::Value::Bool(false));
+  json::Value distros = json::Value::Array();
+  distros.Append(json::Value::String(L"Ubuntu"));
+  distros.Append(json::Value::String(L"Debian"));
+  state.Set(L"distros", std::move(distros));
+  state.Set(L"selected", json::Value::String(L"Ubuntu"));
+  DHEPZ_CHECK(presenter.ApplyStatePatch(L"home", state).ok());
+  presenter.Prepare({0.0f, 0.0f, 400.0f, 300.0f});
+  presenter.Paint({0.0f, 0.0f, 400.0f, 300.0f});
+
+  render::Rect admin{};
+  DHEPZ_CHECK(presenter.InteractiveBounds(L"admin", &admin));
+  DHEPZ_CHECK(presenter.HandleClick(admin.x + 4.0f, admin.y + 8.0f));
+  DHEPZ_CHECK(presenter.ViewStateValue(L"home", L"admin")->AsBool());
+
+  render::Rect distro{};
+  DHEPZ_CHECK(presenter.InteractiveBounds(L"distro", &distro));
+  DHEPZ_CHECK(presenter.HandleClick(distro.x + 4.0f, distro.y + 8.0f));
+  DHEPZ_CHECK_EQ(presenter.ViewStateValue(L"home", L"selected")->AsString(),
+                 std::wstring(L"Debian"));
+  DHEPZ_CHECK(std::find(backend.calls.begin(), backend.calls.end(),
+                        std::wstring(L"text:C:\\work")) != backend.calls.end());
 }


### PR DESCRIPTION
Closes #112

## Outcome
- terminal launch payload is parsed into typed shell/elevation/folder/venv models
- shell-specific builders emit executable plus argv; no child command-line quoting
- every launch uses ModuleHost::StartProcess and completion returns to route state/diagnostics
- UAC cancellation is preserved as Cancelled and does not quarantine the module
- terminal JSON exposes folder, Admin, venv, WSL, PowerShell, Cmd, and status controls
- generic layout/presenter now gives input/combo/toggle/checkbox real metrics, painting, and binding interaction

## Architecture
Terminal module has no platform/process include or process call. The child emits ProcessRequest only; the parent dispatcher owns QuoteArg, ShellExecute runas, process creation, and completion delivery. AppGate remains unchanged at 371 lines.

## Focused local verification
- Debug build and embedded contract validation: passed
- TerminalLogic: 5/5
- TerminalModule: 2/2
- TerminalScaffold: 2/2
- ScreenPresenter: 11/11
- LayoutEngine: 4/4
- ProductionApplication: 4/4
- RepoUiConfig: 1/1
- static child boundary check: no platform/process, process::, QuoteArg, or BuildCommandLine
- visual Debug smoke: complete Terminal route at 1008x688; no launch/UAC action invoked
- git diff --check: passed

Folder/venv sourcing remains IC-09 and WSL enumeration remains IC-11 as required. No local full suite was run; PR CI is the single full Debug/Release regression for this SHA.