### PR TITLE
IC-09: integrate terminal folder and recent state

### DIFF
--- a/src/application/production_application.cpp
+++ b/src/application/production_application.cpp
@@ -141,6 +141,8 @@ core::Status ProductionApplication::ComposeWindow() {
       });
   window_->set_content_key_handler(
       [this](int key) { return presenter_->HandleKey(key); });
+  window_->set_content_text_handler(
+      [this](wchar_t character) { return presenter_->HandleText(character); });
   window_->set_content_click_handler(
       [this](float x, float y) { return OnContentClick(x, y); });
   window_->set_content_move_handler(
@@ -264,6 +266,7 @@ void ProductionApplication::DestroyWindowState() {
     window_->set_content_layout({});
     window_->set_content_painter({});
     window_->set_content_key_handler({});
+    window_->set_content_text_handler({});
     window_->set_content_click_handler({});
     window_->set_content_move_handler({});
     window_->set_content_down_handler({});

--- a/src/modules/terminal/module.json
+++ b/src/modules/terminal/module.json
@@ -3,9 +3,9 @@
   "tabLabel": "Terminal",
   "order": 10,
   "showInTabs": true,
-  "actions": ["terminal:launch"],
+  "actions": ["terminal:launch", "terminal:select-folder"],
   "bindings": [
-    "working_folder", "wsl_distros", "wsl_distro", "admin",
+    "working_folder", "recent_folders", "wsl_distros", "wsl_distro", "admin",
     "powershell_venv", "cmd_venv", "venv_available", "venv_enabled",
     "busy", "status", "launch_enabled"
   ],

--- a/src/modules/terminal/screen.json
+++ b/src/modules/terminal/screen.json
@@ -8,7 +8,9 @@
       "show_in_tabs": true,
       "children": [
         { "type": "text", "text": "Terminal", "variant": "title" },
-        { "type": "input", "value_binding": "working_folder", "placeholder": "Working folder (available in IC-09)" },
+        { "type": "input", "id": "working-folder", "value_binding": "working_folder", "placeholder": "Working folder" },
+        { "type": "button", "id": "validate-folder", "label": "Validate folder", "action": "terminal:select-folder", "action_payload": { "folder": { "$bind": "working_folder" } } },
+        { "type": "combo", "items_binding": "recent_folders", "selected_value_binding": "working_folder", "placeholder": "Recent folders" },
         { "type": "toggle", "id": "admin-toggle", "label": "Run as administrator", "checked_binding": "admin" },
         { "type": "toggle", "id": "venv-toggle", "label": "Use virtual environment", "checked_binding": "venv_enabled", "visible": { "$bind": "venv_available" } },
         { "type": "combo", "items_binding": "wsl_distros", "selected_value_binding": "wsl_distro", "placeholder": "WSL distro (populated in IC-11)" },

--- a/src/modules/terminal/terminal_logic.cpp
+++ b/src/modules/terminal/terminal_logic.cpp
@@ -89,7 +89,8 @@ core::Status ParseLaunchPayload(const json::Value& payload, LaunchSpec* out) {
     out->admin = admin->AsBool();
   }
 
-  bool venv_enabled = true;
+  const json::Value* venv_value = payload.Find(L"venv");
+  bool venv_enabled = venv_value != nullptr && !venv_value->is_null();
   if (const json::Value* enabled = payload.Find(L"venv_enabled");
       enabled != nullptr && !enabled->is_null()) {
     if (!enabled->is_bool()) {
@@ -99,7 +100,7 @@ core::Status ParseLaunchPayload(const json::Value& payload, LaunchSpec* out) {
     venv_enabled = enabled->AsBool();
   }
 
-  if (const json::Value* venv = payload.Find(L"venv");
+  if (const json::Value* venv = venv_value;
       venv != nullptr && !venv->is_null()) {
     if (!venv->is_object()) {
       return DHEPZ_ERR(core::ErrorCode::InvalidArgument,
@@ -122,7 +123,12 @@ core::Status ParseLaunchPayload(const json::Value& payload, LaunchSpec* out) {
     out->venv.kind = kind == L"windows" ? PathKind::Windows : PathKind::Linux;
     out->venv.activate_path = path->AsString();
   }
-  if (!venv_enabled) out->venv = {};
+  if (!venv_enabled) {
+    out->venv = {};
+  } else if (out->venv.kind == PathKind::None) {
+    return DHEPZ_ERR(core::ErrorCode::InvalidArgument,
+                     L"enabled venv requires a compatible selection");
+  }
   return core::Ok();
 }
 

--- a/src/modules/terminal/terminal_module.cpp
+++ b/src/modules/terminal/terminal_module.cpp
@@ -1,8 +1,9 @@
-// Terminal feature coordinator. Process work crosses ModuleHost and completes
-// on the UI thread; this child never includes the parent platform layer.
+// Terminal feature coordinator. Every process, settings, and filesystem
+// operation crosses the narrow parent contract and completes on the UI thread.
 #include "modules/contract/module_contract.h"
 #include "modules/registry/module_registry.h"
 #include "modules/terminal/terminal_logic.h"
+#include "modules/terminal/terminal_state.h"
 
 #include <algorithm>
 #include <memory>
@@ -10,6 +11,35 @@
 
 namespace terminal {
 namespace {
+
+constexpr std::wstring_view kPowerShellVenv = L".venv\\Scripts\\Activate.ps1";
+constexpr std::wstring_view kCmdVenv = L".venv\\Scripts\\activate.bat";
+
+json::Value StringArray(const std::vector<std::wstring>& values) {
+  json::Value array = json::Value::Array();
+  for (const std::wstring& value : values) {
+    array.Append(json::Value::String(value));
+  }
+  return array;
+}
+
+json::Value WindowsVenv(std::wstring_view directory,
+                        std::wstring_view relative) {
+  json::Value venv = json::Value::Object();
+  venv.Set(L"kind", json::Value::String(L"windows"));
+  venv.Set(L"activate_path",
+           json::Value::String(std::wstring(directory) + L"\\" +
+                               std::wstring(relative)));
+  return venv;
+}
+
+bool HasFile(const modules::FolderProbeResult& folder,
+             std::wstring_view relative) {
+  for (const modules::RelativeFilePresence& file : folder.files) {
+    if (file.relative_path == relative) return file.present;
+  }
+  return false;
+}
 
 class TerminalModule final : public modules::ModuleDescriptor {
  public:
@@ -19,11 +49,11 @@ class TerminalModule final : public modules::ModuleDescriptor {
   bool ShowInTabs() const override { return true; }
   std::wstring_view SettingsRoute() const override { return {}; }
   std::vector<std::wstring> DeclaredActions() const override {
-    return {L"terminal:launch"};
+    return {L"terminal:launch", L"terminal:select-folder"};
   }
   std::vector<std::wstring> DeclaredBindings() const override {
-    return {L"working_folder", L"wsl_distros", L"wsl_distro", L"admin",
-            L"powershell_venv", L"cmd_venv", L"venv_available",
+    return {L"working_folder", L"recent_folders", L"wsl_distros", L"wsl_distro",
+            L"admin", L"powershell_venv", L"cmd_venv", L"venv_available",
             L"venv_enabled", L"busy", L"status", L"launch_enabled"};
   }
   std::vector<std::wstring> DeclaredCapabilities() const override { return {}; }
@@ -31,35 +61,167 @@ class TerminalModule final : public modules::ModuleDescriptor {
   core::Status Bind(modules::ModuleHost& host) override {
     host_ = &host;
     ++generation_;
-    json::Value defaults = json::Value::Object();
-    defaults.Set(L"working_folder", json::Value::String(L""));
-    defaults.Set(L"wsl_distros", json::Value::Array());
-    defaults.Set(L"wsl_distro", json::Value::Null());
-    defaults.Set(L"admin", json::Value::Bool(false));
-    defaults.Set(L"powershell_venv", json::Value::Null());
-    defaults.Set(L"cmd_venv", json::Value::Null());
-    defaults.Set(L"venv_available", json::Value::Bool(false));
-    defaults.Set(L"venv_enabled", json::Value::Bool(false));
-    defaults.Set(L"busy", json::Value::Bool(false));
-    defaults.Set(L"status", json::Value::String(L"Ready"));
-    defaults.Set(L"launch_enabled", json::Value::Bool(true));
-    const core::Status published = host_->PublishStatePatch(defaults);
-    if (!published.ok() && published.Code() != core::ErrorCode::Unsupported) {
-      host_->ReportStatus(published);
+    recents_ = RecentFolders{};
+    PublishDefaults();
+
+    const std::uint64_t generation = generation_;
+    modules::AsyncRequestToken token;
+    const core::Status started = host_->StartSettingsLoad(
+        [this, generation](const modules::HostOperationCompletion& completion) {
+          if (host_ == nullptr || generation != generation_) return;
+          settings_token_ = {};
+          if (!completion.status.ok()) {
+            host_->ReportStatus(completion.status);
+            return;
+          }
+          recents_.Load(*host_);
+          json::Value patch = json::Value::Object();
+          patch.Set(L"recent_folders", StringArray(recents_.List()));
+          const core::Status published = host_->PublishStatePatch(patch);
+          if (!published.ok()) host_->ReportStatus(published);
+        },
+        &token);
+    if (started.ok()) {
+      settings_token_ = token;
+    } else if (started.Code() != core::ErrorCode::Unsupported) {
+      host_->ReportStatus(started);
     }
     return core::Ok();
   }
 
   core::Status Handle(std::wstring_view action, const json::Value& payload,
                       json::Value* state_patch) override {
-    if (action != L"terminal:launch") {
-      return core::Err(core::ErrorCode::NotFound, L"terminal: unknown action");
-    }
     if (host_ == nullptr || state_patch == nullptr) {
       return core::Err(core::ErrorCode::InvalidArgument,
                        L"terminal module is not bound or patch output is missing");
     }
+    if (action == L"terminal:select-folder") {
+      return SelectFolder(payload, state_patch);
+    }
+    if (action != L"terminal:launch") {
+      return core::Err(core::ErrorCode::NotFound, L"terminal: unknown action");
+    }
+    return Launch(payload, state_patch);
+  }
 
+  void Release() override {
+    ++generation_;
+    if (host_ != nullptr) {
+      if (settings_token_) host_->CancelRequest(settings_token_);
+      if (folder_token_) host_->CancelRequest(folder_token_);
+      for (modules::AsyncRequestToken token : launch_tokens_) {
+        host_->CancelRequest(token);
+      }
+    }
+    settings_token_ = {};
+    folder_token_ = {};
+    launch_tokens_.clear();
+    host_ = nullptr;
+  }
+
+ private:
+  void PublishDefaults() {
+    json::Value patch = json::Value::Object();
+    patch.Set(L"working_folder", json::Value::String(L""));
+    patch.Set(L"recent_folders", json::Value::Array());
+    patch.Set(L"wsl_distros", json::Value::Array());
+    patch.Set(L"wsl_distro", json::Value::Null());
+    patch.Set(L"admin", json::Value::Bool(false));
+    patch.Set(L"powershell_venv", json::Value::Null());
+    patch.Set(L"cmd_venv", json::Value::Null());
+    patch.Set(L"venv_available", json::Value::Bool(false));
+    patch.Set(L"venv_enabled", json::Value::Bool(false));
+    patch.Set(L"busy", json::Value::Bool(false));
+    patch.Set(L"status", json::Value::String(L"Ready"));
+    patch.Set(L"launch_enabled", json::Value::Bool(true));
+    const core::Status published = host_->PublishStatePatch(patch);
+    if (!published.ok() && published.Code() != core::ErrorCode::Unsupported) {
+      host_->ReportStatus(published);
+    }
+  }
+
+  core::Status SelectFolder(const json::Value& payload,
+                            json::Value* state_patch) {
+    if (!payload.is_object()) {
+      return core::Err(core::ErrorCode::InvalidArgument,
+                       L"folder selection payload must be an object");
+    }
+    const json::Value* folder = payload.Find(L"folder");
+    if (folder == nullptr || !folder->is_string() || folder->AsString().empty()) {
+      return core::Err(core::ErrorCode::InvalidArgument,
+                       L"folder selection requires a non-empty folder");
+    }
+    const std::uint64_t selection = ++folder_selection_;
+    const std::uint64_t generation = generation_;
+    modules::FolderProbeRequest request;
+    request.directory = folder->AsString();
+    request.relative_files = {std::wstring(kPowerShellVenv), std::wstring(kCmdVenv)};
+
+    *state_patch = json::Value::Object();
+    state_patch->Set(L"busy", json::Value::Bool(true));
+    state_patch->Set(L"launch_enabled", json::Value::Bool(false));
+    state_patch->Set(L"status", json::Value::String(L"Validating folder..."));
+    modules::AsyncRequestToken token;
+    const core::Status started = host_->StartFolderProbe(
+        request,
+        [this, generation, selection](
+            const modules::HostOperationCompletion& completion) {
+          if (host_ == nullptr || generation != generation_ ||
+              selection != folder_selection_) {
+            return;
+          }
+          folder_token_ = {};
+          json::Value patch = json::Value::Object();
+          patch.Set(L"busy", json::Value::Bool(false));
+          if (!completion.status.ok() || !completion.folder.directory_exists) {
+            const core::Status failure = !completion.status.ok()
+                ? completion.status
+                : core::Err(core::ErrorCode::NotFound,
+                            L"folder does not exist or is inaccessible");
+            patch.Set(L"launch_enabled", json::Value::Bool(false));
+            patch.Set(L"powershell_venv", json::Value::Null());
+            patch.Set(L"cmd_venv", json::Value::Null());
+            patch.Set(L"venv_available", json::Value::Bool(false));
+            patch.Set(L"venv_enabled", json::Value::Bool(false));
+            patch.Set(L"status", json::Value::String(failure.Message()));
+            host_->ReportStatus(failure);
+          } else {
+            const bool powershell_available =
+                HasFile(completion.folder, kPowerShellVenv);
+            const bool cmd_available = HasFile(completion.folder, kCmdVenv);
+            patch.Set(L"working_folder",
+                      json::Value::String(completion.folder.normalized_directory));
+            patch.Set(L"venv_available",
+                      json::Value::Bool(powershell_available || cmd_available));
+            patch.Set(L"venv_enabled", json::Value::Bool(false));
+            patch.Set(L"powershell_venv",
+                      powershell_available
+                          ? WindowsVenv(completion.folder.normalized_directory,
+                                        kPowerShellVenv)
+                          : json::Value::Null());
+            patch.Set(L"cmd_venv",
+                      cmd_available
+                          ? WindowsVenv(completion.folder.normalized_directory,
+                                        kCmdVenv)
+                          : json::Value::Null());
+            patch.Set(L"launch_enabled", json::Value::Bool(true));
+            patch.Set(L"status", json::Value::String(L"Folder ready"));
+            host_->ReportStatus(core::Ok());
+          }
+          const core::Status published = host_->PublishStatePatch(patch);
+          if (!published.ok()) host_->ReportStatus(published);
+        },
+        &token);
+    if (!started.ok()) {
+      state_patch->Set(L"busy", json::Value::Bool(false));
+      state_patch->Set(L"status", json::Value::String(started.Message()));
+      return started;
+    }
+    folder_token_ = token;
+    return core::Ok();
+  }
+
+  core::Status Launch(const json::Value& payload, json::Value* state_patch) {
     LaunchSpec spec;
     DHEPZ_RETURN_IF_ERROR(ParseLaunchPayload(payload, &spec));
     modules::ProcessRequest request;
@@ -69,12 +231,12 @@ class TerminalModule final : public modules::ModuleDescriptor {
     state_patch->Set(L"busy", json::Value::Bool(true));
     state_patch->Set(L"launch_enabled", json::Value::Bool(false));
     state_patch->Set(L"status", json::Value::String(L"Launching terminal..."));
-
-    const std::uint64_t generation = generation_;
     modules::AsyncRequestToken token;
+    const std::uint64_t generation = generation_;
     const core::Status started = host_->StartProcess(
         request,
-        [this, generation](const modules::HostOperationCompletion& completion) {
+        [this, generation, folder = spec.working_dir](
+            const modules::HostOperationCompletion& completion) {
           if (host_ == nullptr || generation != generation_) return;
           std::erase(launch_tokens_, completion.token);
           host_->ReportStatus(completion.status);
@@ -84,6 +246,12 @@ class TerminalModule final : public modules::ModuleDescriptor {
           patch.Set(L"status", json::Value::String(
               completion.status.ok() ? L"Terminal opened"
                                      : completion.status.Message()));
+          if (completion.status.ok() && !folder.empty()) {
+            recents_.Add(folder);
+            const core::Status saved = recents_.Save(*host_);
+            if (!saved.ok()) host_->ReportStatus(saved);
+            patch.Set(L"recent_folders", StringArray(recents_.List()));
+          }
           const core::Status published = host_->PublishStatePatch(patch);
           if (!published.ok()) host_->ReportStatus(published);
         },
@@ -98,20 +266,12 @@ class TerminalModule final : public modules::ModuleDescriptor {
     return core::Ok();
   }
 
-  void Release() override {
-    ++generation_;
-    if (host_ != nullptr) {
-      for (modules::AsyncRequestToken token : launch_tokens_) {
-        host_->CancelRequest(token);
-      }
-    }
-    launch_tokens_.clear();
-    host_ = nullptr;
-  }
-
- private:
   modules::ModuleHost* host_ = nullptr;
+  RecentFolders recents_;
   std::uint64_t generation_ = 0;
+  std::uint64_t folder_selection_ = 0;
+  modules::AsyncRequestToken settings_token_;
+  modules::AsyncRequestToken folder_token_;
   std::vector<modules::AsyncRequestToken> launch_tokens_;
 };
 

--- a/src/modules/terminal/terminal_state.cpp
+++ b/src/modules/terminal/terminal_state.cpp
@@ -1,7 +1,5 @@
 #include "modules/terminal/terminal_state.h"
 
-#include <windows.h>
-
 #include "core/json.h"
 
 namespace terminal {
@@ -9,10 +7,6 @@ namespace {
 
 constexpr std::wstring_view kRecentKey = L"recent_folders";
 constexpr std::size_t kRecentCap = 10;
-
-bool FileExists(const std::wstring& path) {
-  return GetFileAttributesW(path.c_str()) != INVALID_FILE_ATTRIBUTES;
-}
 
 }  // namespace
 
@@ -46,38 +40,12 @@ void RecentFolders::Load(modules::ModuleHost& host) {
   }
 }
 
-void RecentFolders::Save(modules::ModuleHost& host) const {
+core::Status RecentFolders::Save(modules::ModuleHost& host) const {
   json::Value array = json::Value::Array();
   for (const std::wstring& folder : folders_) {
     array.Append(json::Value::String(folder));
   }
-  const core::Status saved = host.SettingsWrite(kRecentKey, json::Serialize(array, false));
-  (void)saved;  // persistence is best-effort; a failed write keeps the session list
-}
-
-bool DetectVenv(const std::wstring& folder) {
-  return FileExists(folder + L"\\Scripts\\activate.bat") ||
-         FileExists(folder + L"\\bin\\activate");
-}
-
-std::wstring VenvActivatePath(const std::wstring& folder) {
-  if (FileExists(folder + L"\\Scripts\\activate.bat")) {
-    return folder + L"\\Scripts\\activate.bat";
-  }
-  return folder + L"\\bin\\activate";
-}
-
-core::Status ValidateFolder(const std::wstring& folder) {
-  const DWORD attributes = GetFileAttributesW(folder.c_str());
-  if (attributes == INVALID_FILE_ATTRIBUTES) {
-    return core::Err(core::ErrorCode::NotFound,
-                     L"folder does not exist: " + folder);
-  }
-  if ((attributes & FILE_ATTRIBUTE_DIRECTORY) == 0) {
-    return core::Err(core::ErrorCode::InvalidArgument,
-                     L"not a directory: " + folder);
-  }
-  return core::Ok();
+  return host.SettingsWrite(kRecentKey, json::Serialize(array, false));
 }
 
 }  // namespace terminal

--- a/src/modules/terminal/terminal_state.h
+++ b/src/modules/terminal/terminal_state.h
@@ -1,7 +1,5 @@
-// Terminal module state (P4-04): recent-folder history persisted in the
-// module's OWN settings section (default reach), venv detection/toggle,
-// folder validation. Filesystem probes are blocking — callers run them on
-// a worker (P4-05).
+// Pure terminal history state. Physical persistence is parent-owned and
+// reached only through the module's narrowed settings section.
 #pragma once
 
 #include <string>
@@ -21,18 +19,10 @@ class RecentFolders final {
   const std::vector<std::wstring>& List() const { return folders_; }
 
   void Load(modules::ModuleHost& host);
-  void Save(modules::ModuleHost& host) const;
+  core::Status Save(modules::ModuleHost& host) const;
 
  private:
   std::vector<std::wstring> folders_;
 };
-
-// Standard virtualenv layouts: <folder>/Scripts/activate.bat (Windows) or
-// <folder>/bin/activate (posix-style checkout). Pure filesystem probes.
-bool DetectVenv(const std::wstring& folder);
-std::wstring VenvActivatePath(const std::wstring& folder);
-
-// Exists + is a directory; human-friendly Status on failure.
-core::Status ValidateFolder(const std::wstring& folder);
 
 }  // namespace terminal

--- a/src/ui/presenter/screen_presenter.cpp
+++ b/src/ui/presenter/screen_presenter.cpp
@@ -496,9 +496,42 @@ void ScreenPresenter::PaintNode(const layout::LayoutNode& node) {
 }
 
 bool ScreenPresenter::HandleKey(int virtual_key) {
+  if (virtual_key == VK_BACK) return EditFocusedInput(0, true);
   if (virtual_key != VK_TAB) return false;
   const bool backward = (GetKeyState(VK_SHIFT) & 0x8000) != 0;
   return !focus_.Advance(route_, backward).empty();
+}
+
+bool ScreenPresenter::HandleText(wchar_t character) {
+  if (character < 0x20 || character == 0x7F) return false;
+  return EditFocusedInput(character, false);
+}
+
+bool ScreenPresenter::EditFocusedInput(wchar_t character, bool backspace) {
+  if (document_ == nullptr) return false;
+  const config::ComponentNode* node =
+      focus_.NodeFor(route_, focus_.Current(route_));
+  if (node == nullptr || node->type() != L"input") return false;
+  const json::Value* binding = node->Property(L"value_binding");
+  if (binding == nullptr || !binding->is_string() || binding->AsString().empty()) {
+    return false;
+  }
+  std::wstring value;
+  if (const json::Value* current = ResolveBinding(route_, binding->AsString());
+      current != nullptr && current->is_string()) {
+    value = current->AsString();
+  }
+  if (backspace) {
+    if (value.empty()) return true;
+    value.pop_back();
+  } else {
+    const long long maximum = node->GetInt(L"maximum_length", 4096);
+    if (static_cast<long long>(value.size()) >= maximum) return true;
+    value.push_back(character);
+  }
+  json::Value patch = json::Value::Object();
+  patch.Set(binding->AsString(), json::Value::String(std::move(value)));
+  return ApplyStatePatch(route_, patch).ok();
 }
 
 const json::Value* ScreenPresenter::ViewStateValue(

--- a/src/ui/presenter/screen_presenter.h
+++ b/src/ui/presenter/screen_presenter.h
@@ -42,6 +42,7 @@ class ScreenPresenter final {
 
   // VK_TAB / Shift+VK_TAB advance focus; returns true when handled.
   bool HandleKey(int virtual_key);
+  bool HandleText(wchar_t character);
   // Hover and press feedback; true when the visual state changed.
   bool HandleMove(float x, float y);
   bool HandleDown(float x, float y);
@@ -91,6 +92,7 @@ class ScreenPresenter final {
                     std::wstring_view property, bool fallback = false) const;
   void InvalidateBoundNodes(const layout::LayoutNode& node,
                             const std::vector<std::wstring>& changed);
+  bool EditFocusedInput(wchar_t character, bool backspace);
   // The style a text node is measured AND painted with; keeping the two
   // identical is what warms the painted font during layout.
   static render::TextStyle StyleForText(const config::ComponentNode& node);

--- a/src/ui/shell/app_window.cpp
+++ b/src/ui/shell/app_window.cpp
@@ -133,6 +133,10 @@ void AppWindow::set_content_key_handler(std::function<bool(int)> handler) {
   content_key_handler_ = std::move(handler);
 }
 
+void AppWindow::set_content_text_handler(std::function<bool(wchar_t)> handler) {
+  content_text_handler_ = std::move(handler);
+}
+
 void AppWindow::set_content_click_handler(std::function<bool(float, float)> handler) {
   content_click_handler_ = std::move(handler);
 }
@@ -555,6 +559,15 @@ long long AppWindow::HandleMessage(void* window_handle, unsigned int message,
     }
     case WM_KEYDOWN: {
       if (content_key_handler_ && content_key_handler_(static_cast<int>(wparam))) {
+        RenderFullFrame();
+        return 0;
+      }
+      return DefWindowProcW(window, message, static_cast<WPARAM>(wparam),
+                            static_cast<LPARAM>(lparam));
+    }
+    case WM_CHAR: {
+      if (content_text_handler_ &&
+          content_text_handler_(static_cast<wchar_t>(wparam))) {
         RenderFullFrame();
         return 0;
       }

--- a/src/ui/shell/app_window.h
+++ b/src/ui/shell/app_window.h
@@ -112,6 +112,7 @@ class AppWindow final {
   // inside a frame. Unset costs nothing.
   void set_content_layout(std::function<void(const render::Rect&)> layout);
   void set_content_key_handler(std::function<bool(int virtual_key)> handler);
+  void set_content_text_handler(std::function<bool(wchar_t character)> handler);
   void set_content_click_handler(std::function<bool(float x_logical, float y_logical)> handler);
   // Hover and press feedback for content components; return true to repaint.
   void set_content_move_handler(std::function<bool(float x_logical, float y_logical)> handler);
@@ -156,6 +157,7 @@ class AppWindow final {
   std::function<void(render::GdiBackend&, const render::Rect&)> content_painter_;
   std::function<void(const render::Rect&)> content_layout_;
   std::function<bool(int)> content_key_handler_;
+  std::function<bool(wchar_t)> content_text_handler_;
   std::function<bool(float, float)> content_click_handler_;
   std::function<bool(float, float)> content_move_handler_;
   std::function<bool(float, float)> content_down_handler_;

--- a/tests/application/production_application_test.cpp
+++ b/tests/application/production_application_test.cpp
@@ -21,10 +21,10 @@ class FakeTerminalModule final : public modules::ModuleDescriptor {
   bool ShowInTabs() const override { return true; }
   std::wstring_view SettingsRoute() const override { return {}; }
   std::vector<std::wstring> DeclaredActions() const override {
-    return {L"terminal:launch"};
+    return {L"terminal:launch", L"terminal:select-folder"};
   }
   std::vector<std::wstring> DeclaredBindings() const override {
-    return {L"working_folder", L"wsl_distros", L"wsl_distro", L"admin",
+    return {L"working_folder", L"recent_folders", L"wsl_distros", L"wsl_distro", L"admin",
             L"powershell_venv", L"cmd_venv", L"venv_available",
             L"venv_enabled", L"busy", L"status", L"launch_enabled"};
   }

--- a/tests/modules/terminal/terminal_scaffold_test.cpp
+++ b/tests/modules/terminal/terminal_scaffold_test.cpp
@@ -3,6 +3,7 @@
 #include <windows.h>
 
 #include <fstream>
+#include <map>
 #include <sstream>
 #include <string>
 
@@ -16,18 +17,31 @@ namespace {
 class FakeLaunchHost final : public modules::ModuleHost {
  public:
   modules::ModuleSurface Surface() override { return {}; }
-  core::Status SettingsRead(std::wstring_view, std::wstring*) override {
-    return core::Err(core::ErrorCode::NotFound, L"not configured");
+  core::Status SettingsRead(std::wstring_view key, std::wstring* out) override {
+    const auto found = settings.find(std::wstring(key));
+    if (found == settings.end()) {
+      return core::Err(core::ErrorCode::NotFound, L"not configured");
+    }
+    *out = found->second;
+    return core::Ok();
   }
   core::Status SettingsReadGlobal(std::wstring_view, std::wstring*) override {
     return core::Err(core::ErrorCode::NotFound, L"not configured");
   }
-  core::Status SettingsWrite(std::wstring_view, std::wstring_view) override {
+  core::Status SettingsWrite(std::wstring_view key,
+                             std::wstring_view value) override {
+    ++settings_writes;
+    settings[std::wstring(key)] = std::wstring(value);
     return core::Ok();
   }
-  core::Status StartSettingsLoad(modules::HostOperationCallback,
-                                 modules::AsyncRequestToken*) override {
-    return core::Err(core::ErrorCode::Unsupported, L"not configured");
+  core::Status StartSettingsLoad(modules::HostOperationCallback completed,
+                                 modules::AsyncRequestToken* token) override {
+    if (!settings_enabled) {
+      return core::Err(core::ErrorCode::Unsupported, L"not configured");
+    }
+    settings_callback = std::move(completed);
+    token->value = 10;
+    return core::Ok();
   }
   core::Status StartProcess(const modules::ProcessRequest& value,
                             modules::HostOperationCallback completed,
@@ -35,13 +49,18 @@ class FakeLaunchHost final : public modules::ModuleHost {
     ++process_calls;
     request = value;
     callback = std::move(completed);
-    token->value = 77;
+    token->value = next_token++;
     return start_status;
   }
-  core::Status StartFolderProbe(const modules::FolderProbeRequest&,
-                                modules::HostOperationCallback,
-                                modules::AsyncRequestToken*) override {
-    return core::Err(core::ErrorCode::Unsupported, L"not configured");
+  core::Status StartFolderProbe(const modules::FolderProbeRequest& value,
+                                modules::HostOperationCallback completed,
+                                modules::AsyncRequestToken* token) override {
+    ++folder_calls;
+    folder_request = value;
+    folder_callback = std::move(completed);
+    token->value = next_token++;
+    folder_token = *token;
+    return core::Ok();
   }
   void CancelRequest(modules::AsyncRequestToken token) override {
     cancelled = token;
@@ -63,13 +82,50 @@ class FakeLaunchHost final : public modules::ModuleHost {
   core::Status RequestRoute(std::wstring_view) override { return core::Ok(); }
   std::vector<modules::PeerInfo> Peers() override { return {}; }
 
+  void CompleteSettings(const core::Status& status = core::Ok()) {
+    modules::HostOperationCompletion completion;
+    completion.token.value = 10;
+    completion.kind = modules::HostOperationKind::SettingsLoad;
+    completion.status = status;
+    settings_callback(completion);
+  }
+
+  void CompleteProcess(const core::Status& status) {
+    modules::HostOperationCompletion completion;
+    completion.token.value = next_token - 1;
+    completion.kind = request.operation == modules::ProcessOperation::ElevatedLaunch
+                          ? modules::HostOperationKind::ElevatedLaunch
+                          : modules::HostOperationKind::Launch;
+    completion.status = status;
+    callback(completion);
+  }
+
+  void CompleteFolder(const core::Status& status,
+                      modules::FolderProbeResult folder) {
+    modules::HostOperationCompletion completion;
+    completion.token = folder_token;
+    completion.kind = modules::HostOperationKind::FolderProbe;
+    completion.status = status;
+    completion.folder = std::move(folder);
+    folder_callback(completion);
+  }
+
   core::Status start_status;
   modules::ProcessRequest request;
   modules::HostOperationCallback callback;
+  modules::HostOperationCallback settings_callback;
+  modules::FolderProbeRequest folder_request;
+  modules::HostOperationCallback folder_callback;
+  modules::AsyncRequestToken folder_token;
   modules::AsyncRequestToken cancelled;
   std::vector<json::Value> patches;
   core::Status reported;
   int process_calls = 0;
+  int folder_calls = 0;
+  int settings_writes = 0;
+  std::uint64_t next_token = 77;
+  bool settings_enabled = false;
+  std::map<std::wstring, std::wstring> settings;
 };
 
 std::wstring Ws(const std::string& narrow) {
@@ -272,4 +328,123 @@ DHEPZ_TEST(TerminalModule, InvalidPayloadNeverInvokesHost) {
   DHEPZ_CHECK_FALSE(status.ok());
   DHEPZ_CHECK_EQ(host.process_calls, 0);
   module->Release();
+}
+
+DHEPZ_TEST(TerminalModule, DefaultsRenderBeforeAsyncRecentFoldersLoad) {
+  FakeLaunchHost host;
+  host.settings_enabled = true;
+  host.settings[L"recent_folders"] = L"[\"C:\\\\old\",\"C:\\\\new\"]";
+  const auto module = terminal::MakeTerminalForTests();
+  DHEPZ_CHECK(module->Bind(host).ok());
+  DHEPZ_CHECK_EQ(host.patches.size(), static_cast<std::size_t>(1));
+  DHEPZ_CHECK_EQ(host.patches[0].StringField(L"status"), std::wstring(L"Ready"));
+  DHEPZ_CHECK_EQ(host.patches[0].ArrayField(L"recent_folders")->size(),
+                 static_cast<std::size_t>(0));
+
+  host.CompleteSettings();
+  DHEPZ_CHECK_EQ(host.patches.size(), static_cast<std::size_t>(2));
+  DHEPZ_CHECK_EQ(host.patches.back().ArrayField(L"recent_folders")->size(),
+                 static_cast<std::size_t>(2));
+  module->Release();
+}
+
+DHEPZ_TEST(TerminalModule, FolderProbePublishesCompatibleVenvCandidates) {
+  FakeLaunchHost host;
+  const auto module = terminal::MakeTerminalForTests();
+  DHEPZ_CHECK(module->Bind(host).ok());
+  host.patches.clear();
+  json::Value payload;
+  DHEPZ_CHECK(json::Parse(LR"({"folder":"C:\\work"})", &payload).ok());
+  json::Value immediate;
+  DHEPZ_CHECK(module->Handle(L"terminal:select-folder", payload, &immediate).ok());
+  DHEPZ_CHECK_EQ(host.folder_calls, 1);
+  DHEPZ_CHECK(immediate.BoolField(L"busy"));
+  DHEPZ_CHECK_EQ(host.folder_request.relative_files.size(),
+                 static_cast<std::size_t>(2));
+
+  modules::FolderProbeResult folder;
+  folder.normalized_directory = L"C:\\work";
+  folder.directory_exists = true;
+  folder.files = {{L".venv\\Scripts\\Activate.ps1", true},
+                  {L".venv\\Scripts\\activate.bat", false}};
+  host.CompleteFolder(core::Ok(), std::move(folder));
+  const json::Value& patch = host.patches.back();
+  DHEPZ_CHECK(patch.BoolField(L"launch_enabled"));
+  DHEPZ_CHECK(patch.BoolField(L"venv_available"));
+  DHEPZ_CHECK(patch.ObjectField(L"powershell_venv") != nullptr);
+  DHEPZ_CHECK(patch.Find(L"cmd_venv")->is_null());
+  module->Release();
+}
+
+DHEPZ_TEST(TerminalModule, InvalidAndStaleFolderResultsCannotEnableLaunch) {
+  FakeLaunchHost host;
+  const auto module = terminal::MakeTerminalForTests();
+  DHEPZ_CHECK(module->Bind(host).ok());
+  host.patches.clear();
+  json::Value old_payload;
+  json::Value new_payload;
+  DHEPZ_CHECK(json::Parse(LR"({"folder":"C:\\old"})", &old_payload).ok());
+  DHEPZ_CHECK(json::Parse(LR"({"folder":"C:\\new"})", &new_payload).ok());
+  json::Value immediate;
+  DHEPZ_CHECK(module->Handle(L"terminal:select-folder", old_payload, &immediate).ok());
+  const auto old_callback = host.folder_callback;
+  const auto old_token = host.folder_token;
+  DHEPZ_CHECK(module->Handle(L"terminal:select-folder", new_payload, &immediate).ok());
+
+  modules::HostOperationCompletion stale;
+  stale.token = old_token;
+  stale.kind = modules::HostOperationKind::FolderProbe;
+  stale.folder.directory_exists = true;
+  stale.folder.normalized_directory = L"C:\\old";
+  old_callback(stale);
+  DHEPZ_CHECK(host.patches.empty());
+
+  modules::FolderProbeResult missing;
+  host.CompleteFolder(core::Ok(), std::move(missing));
+  DHEPZ_CHECK_FALSE(host.patches.back().BoolField(L"launch_enabled", true));
+  DHEPZ_CHECK_FALSE(host.reported.ok());
+  module->Release();
+}
+
+DHEPZ_TEST(TerminalModule, OnlySuccessfulSpawnPersistsRecentFolder) {
+  FakeLaunchHost host;
+  const auto module = terminal::MakeTerminalForTests();
+  DHEPZ_CHECK(module->Bind(host).ok());
+  host.patches.clear();
+  json::Value payload;
+  DHEPZ_CHECK(json::Parse(
+      LR"({"shell":"cmd","working_folder":"C:\\work"})", &payload).ok());
+  json::Value immediate;
+  DHEPZ_CHECK(module->Handle(L"terminal:launch", payload, &immediate).ok());
+  host.CompleteProcess(core::Err(core::ErrorCode::Cancelled, L"cancelled"));
+  DHEPZ_CHECK_EQ(host.settings_writes, 0);
+  DHEPZ_CHECK(host.patches.back().Find(L"recent_folders") == nullptr);
+
+  DHEPZ_CHECK(module->Handle(L"terminal:launch", payload, &immediate).ok());
+  host.CompleteProcess(core::Ok());
+  DHEPZ_CHECK_EQ(host.settings_writes, 1);
+  DHEPZ_CHECK_EQ(host.patches.back().ArrayField(L"recent_folders")->size(),
+                 static_cast<std::size_t>(1));
+  module->Release();
+}
+
+DHEPZ_TEST(TerminalModule, ReleaseInvalidatesOutstandingFolderCallback) {
+  FakeLaunchHost host;
+  const auto module = terminal::MakeTerminalForTests();
+  DHEPZ_CHECK(module->Bind(host).ok());
+  host.patches.clear();
+  json::Value payload;
+  DHEPZ_CHECK(json::Parse(LR"({"folder":"C:\\work"})", &payload).ok());
+  json::Value immediate;
+  DHEPZ_CHECK(module->Handle(L"terminal:select-folder", payload, &immediate).ok());
+  const auto callback = host.folder_callback;
+  const auto token = host.folder_token;
+  module->Release();
+  modules::HostOperationCompletion completion;
+  completion.token = token;
+  completion.kind = modules::HostOperationKind::FolderProbe;
+  completion.folder.directory_exists = true;
+  completion.folder.normalized_directory = L"C:\\work";
+  callback(completion);
+  DHEPZ_CHECK(host.patches.empty());
 }

--- a/tests/modules/terminal/terminal_state_test.cpp
+++ b/tests/modules/terminal/terminal_state_test.cpp
@@ -1,9 +1,5 @@
 #include "modules/terminal/terminal_state.h"
 
-#include <windows.h>
-
-#include <cstdio>
-
 #include <map>
 #include <string>
 
@@ -63,15 +59,6 @@ class FakeHost final : public modules::ModuleHost {
   std::map<std::wstring, std::wstring> settings;
 };
 
-std::wstring TempDir(const wchar_t* name) {
-  wchar_t base[MAX_PATH]{};
-  GetTempPathW(MAX_PATH, base);
-  std::wstring path = std::wstring(base) + L"dhepz-p4-" + name + L"-" +
-                    std::to_wstring(GetTickCount());
-  CreateDirectoryW(path.c_str(), nullptr);
-  return path;
-}
-
 }  // namespace
 
 DHEPZ_TEST(TerminalState, RecentFoldersDedupeCapAndOrder) {
@@ -95,37 +82,10 @@ DHEPZ_TEST(TerminalState, RecentFoldersPersistThroughOwnSection) {
   terminal::RecentFolders recent;
   recent.Add(L"C:\\a");
   recent.Add(L"C:\\b");
-  recent.Save(host);
+  DHEPZ_CHECK(recent.Save(host).ok());
 
   terminal::RecentFolders loaded;
   loaded.Load(host);
   DHEPZ_CHECK_EQ(loaded.List().size(), static_cast<std::size_t>(2));
   DHEPZ_CHECK_EQ(loaded.List()[0], std::wstring(L"C:\\b"));
-}
-
-DHEPZ_TEST(TerminalState, VenvDetectionOnStandardLayouts) {
-  const std::wstring folder = TempDir(L"venv");
-  DHEPZ_CHECK(!terminal::DetectVenv(folder));
-  CreateDirectoryW((folder + L"\\Scripts").c_str(), nullptr);
-  HANDLE file = CreateFileW((folder + L"\\Scripts\\activate.bat").c_str(), GENERIC_WRITE, 0,
-                            nullptr, CREATE_NEW, FILE_ATTRIBUTE_NORMAL, nullptr);
-  DHEPZ_CHECK(file != INVALID_HANDLE_VALUE);
-  CloseHandle(file);
-  DHEPZ_CHECK(terminal::DetectVenv(folder));
-  DHEPZ_CHECK(terminal::VenvActivatePath(folder).find(L"activate.bat") != std::wstring::npos);
-}
-
-DHEPZ_TEST(TerminalState, ValidateFolderDiagnostics) {
-  const std::wstring folder = TempDir(L"valid");
-  DHEPZ_CHECK(terminal::ValidateFolder(folder).ok());
-
-  const core::Status missing = terminal::ValidateFolder(folder + L"\\nope");
-  DHEPZ_CHECK(!missing.ok());
-
-  const std::wstring file_path = folder + L"\\file.txt";
-  HANDLE file = CreateFileW(file_path.c_str(), GENERIC_WRITE, 0, nullptr, CREATE_NEW,
-                            FILE_ATTRIBUTE_NORMAL, nullptr);
-  CloseHandle(file);
-  const core::Status not_dir = terminal::ValidateFolder(file_path);
-  DHEPZ_CHECK(!not_dir.ok());
 }

--- a/tests/ui/presenter/screen_presenter_test.cpp
+++ b/tests/ui/presenter/screen_presenter_test.cpp
@@ -144,6 +144,7 @@ const char* kCore = R"({
     "input": { "properties": {
       "value_binding": { "kind": "binding" },
       "placeholder": { "kind": "string" },
+      "maximum_length": { "kind": "int", "default": 4096 },
       "tab_stop": { "kind": "bool", "default": true } } },
     "combo": { "properties": {
       "items_binding": { "kind": "binding" },
@@ -515,4 +516,38 @@ DHEPZ_TEST(ScreenPresenter, TerminalControlsRenderAndUpdateGenericBindings) {
                  std::wstring(L"Debian"));
   DHEPZ_CHECK(std::find(backend.calls.begin(), backend.calls.end(),
                         std::wstring(L"text:C:\\work")) != backend.calls.end());
+}
+
+DHEPZ_TEST(ScreenPresenter, FocusedInputEditsOnlyItsBoundRouteState) {
+  RecordingBackend backend;
+  json::Value core;
+  DHEPZ_CHECK(json::Parse(W(kCore), &core).ok());
+  std::vector<ui::config::Diagnostic> diagnostics;
+  std::unique_ptr<ui::config::ResolvedUiDocument> document;
+  DHEPZ_CHECK(ui::config::ResolveDocument(
+                  core,
+                  {{L"embedded", W(R"({ "components": [
+                    { "type": "screen", "route_id": "home", "children": [
+                      { "type": "input", "id": "folder",
+                        "value_binding": "working_folder", "maximum_length": 3 }
+                    ] }
+                  ] })")}},
+                  &diagnostics, &document).ok());
+  ui::presenter::ScreenPresenter presenter(&backend);
+  presenter.SetDocument(document.get());
+  presenter.Prepare({0.0f, 0.0f, 400.0f, 300.0f});
+  render::Rect input{};
+  DHEPZ_CHECK(presenter.InteractiveBounds(L"folder", &input));
+  DHEPZ_CHECK(presenter.HandleClick(input.x + 4.0f, input.y + 8.0f));
+  DHEPZ_CHECK(presenter.HandleText(L'a'));
+  DHEPZ_CHECK(presenter.HandleText(L'b'));
+  DHEPZ_CHECK(presenter.HandleText(L'c'));
+  DHEPZ_CHECK(presenter.HandleText(L'd'));  // consumed but capped
+  DHEPZ_CHECK_EQ(
+      presenter.ViewStateValue(L"home", L"working_folder")->AsString(),
+      std::wstring(L"abc"));
+  DHEPZ_CHECK(presenter.HandleKey(0x08));  // VK_BACK
+  DHEPZ_CHECK_EQ(
+      presenter.ViewStateValue(L"home", L"working_folder")->AsString(),
+      std::wstring(L"ab"));
 }


### PR DESCRIPTION
Closes #113

## Outcome
- publishes immediate terminal defaults, then loads recent folders asynchronously from the terminal settings section
- validates folders through the parent folder-probe capability and publishes shell-specific venv candidates
- updates, deduplicates, caps, and persists recents only after a successful spawn
- binds editable folder, validation, busy/error state, and recents through the generic presenter
- removes child-side filesystem probing from terminal state/logic

## Architecture
- terminal child code reaches external effects only through ModuleHost
- AppGate is unchanged at 371 lines

## Focused local validation
One Debug build, then only affected filters:
- TerminalModule: 7/7
- TerminalState: 2/2
- TerminalLogic: 5/5
- ScreenPresenter: 12/12
- AppWindow: 13/13
- ProductionApplication: 4/4
- RepoUiConfig: 1/1
- static child-I/O boundary check
- staged diff check

No local full-suite rerun. The PR CI is the single full regression gate for this SHA.