### PR TITLE
IC-10: preserve headerless WSL distro output

### DIFF
--- a/src/modules/terminal/wsl.cpp
+++ b/src/modules/terminal/wsl.cpp
@@ -1,10 +1,35 @@
 #include "modules/terminal/wsl.h"
 
+#include <algorithm>
+#include <cwctype>
+
 namespace terminal {
 namespace {
 
 core::Status DefaultRunner(std::wstring_view command_line, process::RunResult* out) {
   return process::RunCapture(command_line, L"", 10000, out);
+}
+
+}  // namespace
+
+namespace {
+
+std::wstring TrimLine(std::wstring line) {
+  line.erase(std::remove(line.begin(), line.end(), L'\0'), line.end());
+  while (!line.empty() && (std::iswspace(line.back()) || line.back() == L'\uFEFF')) {
+    line.pop_back();
+  }
+  std::size_t first = 0;
+  while (first < line.size() && (std::iswspace(line[first]) || line[first] == L'\uFEFF')) {
+    ++first;
+  }
+  line.erase(0, first);
+  return line;
+}
+
+bool IsRecognizedHeader(const std::wstring& line) {
+  return line == L"Windows Subsystem for Linux Distributions:" ||
+         line == L"Windows Subsystem for Linux Distributions";
 }
 
 }  // namespace
@@ -16,24 +41,17 @@ WslEnumerator::WslEnumerator(Runner runner) : runner_(std::move(runner)) {}
 std::vector<std::wstring> WslEnumerator::ParseListOutput(const std::wstring& output) {
   std::vector<std::wstring> distros;
   std::wstring line;
-  bool first_content = true;
   const auto flush = [&] {
-    std::wstring name = line;
-    // strip \r and surrounding whitespace
-    while (!name.empty() && (name.back() == L'\r' || name.back() == L' ')) name.pop_back();
-    while (!name.empty() && (name.front() == L' ')) name.erase(name.begin());
-    // remove a trailing " (Default)" marker wherever it sits
-    const std::wstring marker = L"(Default)";
-    const auto pos = name.find(marker);
-    if (pos != std::wstring::npos) {
-      name.erase(pos);
-      while (!name.empty() && (name.back() == L' ')) name.pop_back();
+    std::wstring name = TrimLine(line);
+    if (name.empty() || IsRecognizedHeader(name)) return;
+
+    constexpr std::wstring_view marker = L" (Default)";
+    if (name.size() >= marker.size() &&
+        name.compare(name.size() - marker.size(), marker.size(), marker) == 0) {
+      name.erase(name.size() - marker.size());
+      name = TrimLine(std::move(name));
     }
-    if (first_content) {
-      first_content = false;  // the header line ("Windows Subsystem ...")
-      return;
-    }
-    if (!name.empty()) distros.push_back(name);
+    if (!name.empty()) distros.push_back(std::move(name));
   };
   for (const wchar_t c : output) {
     if (c == L'\n') {

--- a/src/modules/terminal/wsl.h
+++ b/src/modules/terminal/wsl.h
@@ -32,8 +32,8 @@ class WslEnumerator final {
   const std::vector<std::wstring>& Distros() const { return distros_; }
   bool cached() const { return cached_; }
 
-  // Pure parse, exposed for tests: tolerates UTF-16-decoded input, skips
-  // the header line, blank lines, and "(Default)" markers.
+  // Pure parse, exposed for tests: keeps headerless -q output intact, tolerates
+  // decoded UTF-16 BOM/NULs, and skips only positively recognized old headers.
   static std::vector<std::wstring> ParseListOutput(const std::wstring& output);
 
  private:

--- a/tests/modules/terminal/wsl_test.cpp
+++ b/tests/modules/terminal/wsl_test.cpp
@@ -7,18 +7,33 @@
 namespace {
 
 const std::wstring kTwoDistros =
-    L"Windows Subsystem for Linux Distributions:\nUbuntu (Default)\r\nDebian\r\n";
+    L"Ubuntu\r\nDebian\r\n";
 const std::wstring kThreeDistros =
-    L"Windows Subsystem for Linux Distributions:\nUbuntu (Default)\r\nDebian\r\nAlpine\r\n";
+    L"Ubuntu\r\nDebian\r\nAlpine\r\n";
 
 }  // namespace
 
-DHEPZ_TEST(Wsl, ParseSkipsHeaderBlankLinesAndDefaultMarker) {
+DHEPZ_TEST(Wsl, HeaderlessOutputKeepsFirstDistroAndFinalUnterminatedLine) {
+  std::wstring output = L"\uFEFF";
+  output.push_back(L'\0');
+  output.append(L"Ubuntu");
+  output.push_back(L'\0');
+  output.append(L"\r\n\r\n  Debian  ");
   const std::vector<std::wstring> distros =
-      terminal::WslEnumerator::ParseListOutput(kTwoDistros);
+      terminal::WslEnumerator::ParseListOutput(output);
   DHEPZ_CHECK_EQ(distros.size(), static_cast<std::size_t>(2));
   DHEPZ_CHECK_EQ(distros[0], std::wstring(L"Ubuntu"));
   DHEPZ_CHECK_EQ(distros[1], std::wstring(L"Debian"));
+}
+
+DHEPZ_TEST(Wsl, RecognizedHeaderAndDefaultSuffixAreCompatibilityOnly) {
+  const std::vector<std::wstring> distros = terminal::WslEnumerator::ParseListOutput(
+      L"Windows Subsystem for Linux Distributions:\r\nUbuntu (Default)\r\n"
+      L"Windows Subsystem distro\r\nLiteral(Default)\r\n");
+  DHEPZ_CHECK_EQ(distros.size(), static_cast<std::size_t>(3));
+  DHEPZ_CHECK_EQ(distros[0], std::wstring(L"Ubuntu"));
+  DHEPZ_CHECK_EQ(distros[1], std::wstring(L"Windows Subsystem distro"));
+  DHEPZ_CHECK_EQ(distros[2], std::wstring(L"Literal(Default)"));
 }
 
 DHEPZ_TEST(Wsl, RefreshCachesPerSession) {
@@ -43,7 +58,10 @@ DHEPZ_TEST(Wsl, FailedRefreshKeepsThePreviousCache) {
     return core::Err(core::ErrorCode::IoError, L"wsl missing");
   });
   DHEPZ_CHECK(enumerator.Refresh().ok());
-  DHEPZ_CHECK(!enumerator.Refresh().ok());
+  const core::Status failure = enumerator.Refresh();
+  DHEPZ_CHECK(!failure.ok());
+  DHEPZ_CHECK_EQ(failure.Code(), core::ErrorCode::IoError);
+  DHEPZ_CHECK_EQ(failure.Message(), std::wstring(L"wsl missing"));
   DHEPZ_CHECK_EQ(enumerator.Distros().size(), static_cast<std::size_t>(2));
 }
 


### PR DESCRIPTION
Closes #114

## Outcome
- preserves the first nonblank distro from real headerless wsl.exe -l -q output
- skips only the positively recognized legacy English header
- trims decoded BOM, embedded NULs, CRLF/whitespace, blank lines, and unterminated final lines
- strips only a trailing compatibility  (Default) suffix
- preserves cached distros and the original error status on failed refresh

## Focused local validation
- one Debug build after the parser change
- Wsl filter: 6/6
- staged diff check
- actual machine comparison: wsl.exe -l -q reported Ubuntu then docker-desktop; both names were retained by the corrected headerless semantics

No local full-suite or Release rerun. The PR CI is the single full regression gate for this SHA.