### PR TITLE
IC-12: re-gate P3/P4 production composition

### DIFF
--- a/docs/audit.md
+++ b/docs/audit.md
@@ -1,0 +1,137 @@
+# Audit P0-P4 setelah Integration Checkpoint
+
+Tanggal: 2026-08-21
+
+Basis audit: `origin/main` setelah IC-11 (`fb2d977`), dengan rekonsiliasi akhir
+melalui IC-12. Plan kanonis tetap salinan lokal `.docs/plan.md`; file itu
+sengaja tidak dilacak Git.
+
+## Verdict
+
+P3 dan P4 sekarang mempunyai jalur produksi yang sama dengan jalur yang
+digunakan aplikasi. Phase 5 boleh dipecah menjadi issue terurut setelah IC-12
+lulus CI dan rekonsiliasi GitHub selesai. Phase 5 belum dimulai oleh audit ini.
+
+Target G1-G5 adalah target tujuh phase. P0-P4 tidak diharapkan menyelesaikan
+installer, settings UI, UI editor, remaining modules, soak delapan jam, atau
+accessibility yang memang milik P5-P7.
+
+## Jalur produksi yang sekarang berlaku
+
+```text
+wWinMain
+  -> ProductionApplication
+  -> AppWindow + embedded RCDATA
+  -> ScreenPresenter
+  -> AppGate
+  -> ModuleDescriptor (terminal / diagnostics)
+  -> ModuleHost
+  -> parent services (worker, process, folder probe, settings store)
+  -> UI-thread completion
+  -> presenter state patch
+```
+
+Untuk feature modular, dependency dan data flow tetap satu arah:
+
+```text
+child UI JSON -> generic presenter -> parent composition -> AppGate -> child logic
+child logic   -> ModuleHost       -> parent services    -> state   -> presenter
+```
+
+`AppGate` bertanggung jawab atas pair/validate/mount, lazy activation, action
+routing, lifecycle, capability grants, quarantine, dan diagnostics read model.
+Ia tidak melakukan rendering, filesystem IO, process execution, settings IO,
+atau logic terminal. Implementasi efek tersebut berada pada service parent;
+logic WSL/cache berada di helper internal feature terminal.
+
+## Status per phase
+
+| Phase | Status checkpoint | Bukti yang sekarang align | Deferred sesuai plan |
+|---|---|---|---|
+| P0 | PASS untuk fondasi | hardened MSBuild, Status/JSON/platform primitives, CI, tray bootstrap, trace API | angka installed-Release dan packaging final tetap P6 |
+| P1 | PASS untuk shell | production memakai `AppWindow`; hide/close melepas buffer; re-show merender sebelum tampil; worker production nonblocking | minimize/maximize sengaja tidak dipakai berdasarkan keputusan user; soak panjang tetap P6 |
+| P2 | PASS untuk route yang sudah ada | embedded JSON dirender oleh presenter produksi; action, payload, binding, input/combo/toggle, dan state patch aktif | component behavior lain ditambahkan ketika screen pemakainya dibuat; theme monitor belum production-wired dan bukan gate P5 |
+| P3 | PASS setelah IC-01..IC-07 | typed async contract/facets, parent-owned services, symmetric validator, RCDATA `Start`, lifecycle/quarantine/diagnostics, production composition, generic action bridge | module settings dan UI editor adalah P5 |
+| P4 | PASS setelah IC-08..IC-11 | typed PowerShell/Cmd/WSL launch, parent-only effects, folder/venv state, recent persistence, corrected WSL parser, production worker capture/cache/refresh | installed performance/soak dan broader modules bukan P4 |
+
+## Penutupan temuan audit awal
+
+| Temuan | Koreksi | Issue / PR | Status |
+|---|---|---|---|
+| C-01 production hanya tray | composition root membuat JSON window normal; `--tray` tetap lazy | #110 / #122 | closed |
+| H-01 `AppGate::Start()` unsupported | real embedded RCDATA startup dan optional override path | #108 / #120 | closed |
+| H-02 process contract sinkron | typed async process/capture/folder operations, token, generation, cancellation | #105 / #117 | closed |
+| H-03 validation tidak simetris | manifest, descriptor, screen actions/bindings/metadata divalidasi sebagai satu contract | #108 / #120 | closed |
+| H-04 capability hanya string | typed `settings:all` dan `config:write` facets + guarded transaction | #106 / #118 | closed |
+| H-05 child menembus parent | diagnostics memakai read model; terminal hanya mencapai efek lewat `ModuleHost` | #109, #112, #115 / #121, #124, #127 | closed |
+| H-06 lifecycle/quarantine lemah | deterministic release, owned diagnostics, fatal-only quarantine | #109 / #121 | closed |
+| H-07 build hanya parse JSON | post-link embedded validation dan contract/build fixtures | #108 / #120 | closed |
+| H-08 tombol tidak dispatch | JSON action -> presenter callback -> composition -> gate | #111 / #123 | closed |
+| H-09 payload diabaikan | typed payload dan shell-specific request builders | #112 / #124 | closed |
+| H-10 offload hanya test rig | capture/probe memakai production host dispatcher; parallel `TerminalOffload` dihapus | #105, #115 / #117, #127 | closed |
+| H-11 terminal state dead code | recents, folder probe, venv, busy/error bindings terhubung ke route | #113 / #125 | closed |
+| H-12 tidak ada persistence lintas owner | parent-owned atomic `%LOCALAPPDATA%\dhepz\state\settings.json`; fresh owner reloads disk state | #107, #113 / #119, #125 | closed |
+| H-13 distro pertama hilang | headerless `-q` menjaga baris pertama; hanya header dikenal yang dilewati | #114 / #126 | closed |
+| H-14 command tidak shell-aware | builder PowerShell/Cmd/WSL dan venv compatibility terpisah | #112 / #124 | closed |
+
+## Bukti checkpoint yang dipakai
+
+- Setiap IC memakai satu Debug build hanya bila code berubah, kemudian filter
+  affected tests. Full Debug/Release regression hanya dijalankan sekali oleh
+  GitHub CI pada final SHA masing-masing PR.
+- PR #117 sampai #127 telah merged dengan CI hijau. IC-12 menjadi satu gate CI
+  final untuk dokumentasi dan rekonsiliasi checkpoint.
+- Production runtime menunjukkan normal launch dengan visible JSON window,
+  tray-only launch yang menunda window, close/re-show yang membangun frame, dan
+  Terminal route yang memuat `Ubuntu` melalui production WSL capture lalu
+  mencapai status `WSL distros ready`.
+- Production dispatcher evidence membuktikan blocking capture tidak menahan UI
+  message, completion kembali pada UI thread dengan token/generation/Status,
+  cancellation menekan delivery, dan worker kembali ke nol setelah reap.
+- Settings persistence memakai physical file dan fresh store/gate owner, bukan
+  map pada fake yang sama. Terminal menulis recent hanya setelah spawn sukses;
+  failure atau cancellation tidak mengubah history.
+- Build gate membedakan dua stage yang dahulu tercampur: byte-level malformed
+  JSON gagal sebelum runtime dengan lokasi source; contract-invalid tetapi
+  syntactically valid module dikarantina saat composition dan muncul pada
+  diagnostics tanpa merusak module sehat.
+
+Manual UAC prompt, peluncuran setiap distro satu per satu, dan ETL capture tidak
+diulang pada checkpoint. Correctness-nya ditutup oleh typed request/status
+contract, focused tests, production worker evidence, runtime WSL enumeration,
+dan CI. Installed-Release performance/ETW tetap gate P6 sebagaimana plan; build
+tree tidak dipakai untuk mengklaim angka cold/warm/RSS final.
+
+## Koreksi interpretasi P0-P2
+
+- Tidak adanya minimize/maximize bukan defect. Window tetap resizable dan user
+  telah menerima chrome pin/settings/close; issue #20 harus mencatat keputusan
+  ini secara eksplisit.
+- Catalog 14 component types adalah schema/toolkit. Phase 4 hanya wajib
+  merender behavior yang dipakai screen terminal saat ini; screen module baru
+  akan memperluas behavior renderer ketika phase-nya tiba.
+- Theme-monitor waiting thread adalah follow-up G1 berprioritas rendah. Adapter
+  belum production-wired, sehingga bukan blocker P5 dan tidak boleh diaktifkan
+  tanpa lifecycle/idle measurement.
+
+## Rekonsiliasi GitHub untuk menutup IC-12
+
+- #86 dan #99 tetap closed sebagai historical gates, tetapi harus menunjuk
+  #116 sebagai checkpoint yang menggantikan bukti test-rig lama.
+- #97 ditutup setelah menghubungkan terminal recents ke parent persistence dan
+  membuktikan fresh owner membaca kembali physical file.
+- #30 harus menampilkan IC-01 sampai IC-12 dalam urutan linear dan tidak lagi
+  menyebut #97 selesai sementara issue-nya open.
+- #20 harus mencatat keputusan resizable tanpa minimize/maximize.
+- Phase 5 baru boleh masuk working order setelah PR IC-12 hijau dan merged.
+
+## Yang belum dicapai dan memang belum seharusnya dicapai
+
+- settings module, peer settings navigation, autostart reconciliation;
+- UI editor dengan validate/swap/rebuild/Save/Discard;
+- advanced tab settings (#77);
+- named-pipe single instance, Velopack installer/update/uninstall, installed
+  performance budgets, 8-hour soak, DPI/multi-monitor release audit;
+- remaining Chrome/Claude/JSON modules dan UIAutomation accessibility.
+
+Daftar tersebut adalah pekerjaan P5-P7, bukan residual defect P4.

--- a/tests/app_icon.rc
+++ b/tests/app_icon.rc
@@ -8,6 +8,7 @@ IDI_APP_ICON ICON "..\\assets\\app.ico"
 
 // Compiled-resource seam for AppGate startup/override integration tests.
 APP_GATE_TEST_UI RCDATA "fixtures\\app_gate_embedded.json"
+APP_GATE_CHECKPOINT_UI RCDATA "fixtures\\checkpoint_embedded.json"
 
 // Production composition uses the application's exact named resource path.
 EMBEDDED_UI RCDATA "..\\build\\generated\\embedded_ui.tests.json"

--- a/tests/fixtures/checkpoint_embedded.json
+++ b/tests/fixtures/checkpoint_embedded.json
@@ -1,0 +1,49 @@
+{
+  "core": {
+    "schema": "dhepz.ui.core",
+    "version": 1,
+    "tokens": {
+      "dark": { "text": "#ffffff" },
+      "light": { "text": "#000000" }
+    },
+    "allows_children": ["screen"],
+    "components": {
+      "screen": {
+        "properties": {
+          "route_id": { "kind": "string", "required": true },
+          "module_id": { "kind": "string" },
+          "tab_label": { "kind": "string" },
+          "show_in_tabs": { "kind": "bool", "default": false }
+        }
+      }
+    }
+  },
+  "sources": [
+    {
+      "file": "fixtures/healthy/screen.json",
+      "text": "{\"components\":[{\"type\":\"screen\",\"route_id\":\"fixture-healthy\",\"module_id\":\"fixture-healthy\",\"tab_label\":\"Fixture Healthy\",\"show_in_tabs\":false}]}"
+    },
+    {
+      "file": "fixtures/typo/screen.json",
+      "text": "{\"components\":[{\"type\":\"screen\",\"route_id\":\"fixture-typo\",\"module_id\":\"fixture-typo\",\"tab_label\":\"Fixture Typo\",\"show_in_tabs\":false}]}"
+    },
+    {
+      "file": "fixtures/metadata/screen.json",
+      "text": "{\"components\":[{\"type\":\"screen\",\"route_id\":\"fixture-metadata\",\"module_id\":\"fixture-metadata\",\"tab_label\":\"Fixture Metadata\",\"show_in_tabs\":false}]}"
+    }
+  ],
+  "modules": [
+    {
+      "file": "fixtures/healthy/module.json",
+      "text": "{\"moduleId\":\"fixture-healthy\",\"tabLabel\":\"Fixture Healthy\",\"order\":500,\"showInTabs\":false,\"actions\":[\"fixture-launch\"],\"bindings\":[],\"capabilities\":[]}"
+    },
+    {
+      "file": "fixtures/typo/module.json",
+      "text": "{\"moduleId\":\"fixture-typo\",\"tabLabel\":\"Fixture Typo\",\"order\":501,\"showInTabs\":false,\"actions\":[\"fixture-typo-action\"],\"bindings\":[],\"capabilities\":[]}"
+    },
+    {
+      "file": "fixtures/metadata/module.json",
+      "text": "{\"moduleId\":\"fixture-metadata\",\"tabLabel\":\"Fixture Metadata\",\"order\":502,\"showInTabs\":false,\"actions\":[],\"bindings\":[],\"capabilities\":[]}"
+    }
+  ]
+}

--- a/tests/modules/gate/fixtures_test.cpp
+++ b/tests/modules/gate/fixtures_test.cpp
@@ -15,14 +15,6 @@
 
 namespace {
 
-std::wstring W(const char* utf8) {
-  std::wstring wide;
-  for (const char* p = utf8; *p != '\0'; ++p) {
-    wide.push_back(static_cast<wchar_t>(static_cast<unsigned char>(*p)));
-  }
-  return wide;
-}
-
 std::wstring Ws(const std::string& narrow) {
   std::wstring wide;
   for (const char c : narrow) wide.push_back(static_cast<wchar_t>(static_cast<unsigned char>(c)));
@@ -62,6 +54,13 @@ struct Typo {
   // registers under this name, so the gate must reject the module.
   static std::vector<std::wstring> Actions() { return {L"fixture-launhc"}; }
 };
+struct Metadata {
+  static std::wstring_view Id() { return L"fixture-metadata"; }
+  // Deliberately disagrees with the valid embedded manifest.
+  static std::wstring_view Label() { return L"Wrong Metadata"; }
+  static int Order() { return 502; }
+  static std::vector<std::wstring> Actions() { return {}; }
+};
 
 template <typename Base>
 class FixtureModule final : public modules::ModuleDescriptor {
@@ -87,66 +86,53 @@ std::unique_ptr<modules::ModuleDescriptor> MakeHealthy() {
 std::unique_ptr<modules::ModuleDescriptor> MakeTypo() {
   return std::make_unique<FixtureModule<Typo>>();
 }
+std::unique_ptr<modules::ModuleDescriptor> MakeMetadata() {
+  return std::make_unique<FixtureModule<Metadata>>();
+}
 
 }  // namespace
 
-// The three fixture folders (healthy / typo'd action / malformed manifest)
-// drive the gate the way CI does: healthy mounts, broken ones are reported,
-// the app still starts, and the reject list is exported for the CI artifact.
+// Runtime composition consumes compiled RCDATA containing one healthy and two
+// syntactically valid contract-broken modules. Byte-level malformed JSON is a
+// separate build-stage failure and is checked below plus in CI.
 DHEPZ_TEST(ContractFixtures, DegradedModeAcrossThreeFolders) {
   const std::wstring root = RepoRoot();
   const std::wstring fixtures = root + L"\\tests\\fixtures\\modules";
-
-  json::Value core;
-  DHEPZ_CHECK(json::Parse(W(ReadFile(root + L"\\assets\\ui\\core.json").c_str()), &core).ok());
-
-  std::wstring screens;
-  std::wstring manifests;
-  int broken_manifests = 0;
-  const wchar_t* names[3] = {L"fixture-broken", L"fixture-healthy", L"fixture-typo"};
-  for (const wchar_t* name : names) {
-    const std::string manifest_text =
-        ReadFile(fixtures + L"\\" + name + L"\\module.json");
-    json::Value manifest_value;
-    if (!json::Parse(Ws(manifest_text), &manifest_value).ok()) {
-      ++broken_manifests;  // byte-level malformed: fails the build merge, not embedded
-      continue;
-    }
-    if (!manifests.empty()) manifests += L", ";
-    manifests += Ws(manifest_text);
-    const std::string screen_text =
-        ReadFile(fixtures + L"\\" + name + L"\\screen.json");
-    json::Value screen_doc;
-    if (json::Parse(Ws(screen_text), &screen_doc).ok()) {
-      const json::Value* components = screen_doc.Find(L"components");
-      if (components != nullptr) {
-        for (const json::Value& component : components->items()) {
-          if (!screens.empty()) screens += L", ";
-          screens += json::Serialize(component);
-        }
-      }
-    }
-  }
-  DHEPZ_CHECK_EQ(broken_manifests, 1);
+  json::Value malformed;
+  DHEPZ_CHECK_FALSE(json::Parse(
+      Ws(ReadFile(fixtures + L"\\fixture-broken\\module.json")),
+      &malformed).ok());
 
   modules::ResetRegistryForTests();
   modules::RegisterModule(L"fixture-healthy", &MakeHealthy);
   modules::RegisterModule(L"fixture-typo", &MakeTypo);
+  modules::RegisterModule(L"fixture-metadata", &MakeMetadata);
 
-  const std::wstring embedded = L"{ \"core\": " + json::Serialize(core) +
-                                L", \"components\": [ " + screens + L" ], \"modules\": [ " +
-                                manifests + L" ] }";
   modules::AppGate gate;
-  DHEPZ_CHECK(gate.StartWithEmbedded(embedded).ok());
+  DHEPZ_CHECK(gate.StartFromResource(L"APP_GATE_CHECKPOINT_UI").ok());
 
   DHEPZ_CHECK(gate.Mounted(L"fixture-healthy"));
   DHEPZ_CHECK(!gate.Mounted(L"fixture-typo"));
+  DHEPZ_CHECK(!gate.Mounted(L"fixture-metadata"));
+  json::Value patch = json::Value::Object();
+  DHEPZ_CHECK(gate.Dispatch(L"fixture-launch", json::Value::Object(), &patch).ok());
 
   bool saw_typo = false;
+  bool saw_metadata = false;
   for (const modules::RejectEntry& reject : gate.Rejects()) {
-    if (reject.module_id == L"fixture-typo") saw_typo = true;
+    if (reject.module_id == L"fixture-typo") {
+      saw_typo = true;
+      DHEPZ_CHECK_EQ(reject.file, std::wstring(L"fixtures/typo/module.json"));
+      DHEPZ_CHECK(reject.line > 0 && reject.column > 0);
+    }
+    if (reject.module_id == L"fixture-metadata") {
+      saw_metadata = true;
+      DHEPZ_CHECK_EQ(reject.file, std::wstring(L"fixtures/metadata/module.json"));
+      DHEPZ_CHECK(reject.line > 0 && reject.column > 0);
+    }
   }
   DHEPZ_CHECK(saw_typo);
+  DHEPZ_CHECK(saw_metadata);
 
   // CI-readable diagnostics artifact.
   FILE* out = nullptr;


### PR DESCRIPTION
Closes #116

## Outcome
- records the post-correction P0-P4 audit in docs/audit.md
- re-gates degraded mode through compiled RCDATA and AppGate::StartFromResource
- embeds one healthy module plus two syntactically valid contract-broken modules
- proves the healthy action works, both broken modules are absent, and both diagnostics carry source file/line/column
- keeps byte-malformed JSON as a separate build-stage failure
- reconciles the original C/H findings with IC-01 through IC-11 and documents the remaining P5-P7 scope

## Focused local validation
One Debug build after the checkpoint fixture/resource change:
- ContractFixtures: 1/1
- diff/staged-diff checks

The checkpoint reuses evidence already proven on the unchanged final implementations:
- PR #117 through #127 each passed its one full CI gate
- production normal/tray composition and click/state bridges
- production terminal PowerShell/Cmd/WSL structured host paths
- production WSL runtime smoke (Ubuntu, WSL distros ready)
- parent persistence across fresh owners
- production worker UI-thread delivery/cancellation/idle-zero checks
- build-time malformed-source and plug-in add/delete gates

Per the user-locked evidence policy, IC-12 does not repeat manual UAC prompts, every-distro launches, ETL capture, or local full suites. Installed-Release performance and soak remain Phase 6.

After this PR's single CI gate passes and it is merged, GitHub reconciliation will annotate #20/#30/#86/#97/#99 and add the ordered Phase 5 breakdown.