### PR TITLE
Complete Phase 2 app chrome

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -14,6 +14,7 @@
 #include "platform/performance_trace.h"
 #include "platform/tray_process.h"
 #include "ui/config/resolved_ui_document.h"
+#include "ui/shell/app_window/app_window.h"
 
 // Phase 0's tray-resident process: one hidden infrastructure window and one
 // tray icon, no UI, no config, no modules. This is the thing whose idle
@@ -137,7 +138,21 @@ int APIENTRY wWinMain(_In_ HINSTANCE instance,
   // and the process must still run (CI, automated runs).
   tray_process.InstallTray();
 
+  // P2 production surface: visible custom chrome with an intentionally empty
+  // content area. Screen presentation and feature logic start in P3.
+  shell::AppWindow app_window;
+  if (!app_window.Create(instance, 400.0f, 360.0f)) {
+    tray_process.Shutdown();
+    BootstrapFailed(13, L"The application window could not be created.");
+  }
+  // P2 exposes the chrome seam for visual review. P3 replaces this inert
+  // callback with Settings screen navigation.
+  app_window.set_settings_handler([] {});
+  tray_process.set_activate_handler([&app_window] { app_window.Show(); });
+  app_window.Show();
+
   const int result = tray_process.Run();
+  app_window.Destroy();
   tray_process.Shutdown();
   return result;
 }

--- a/src/platform/tray_process.cpp
+++ b/src/platform/tray_process.cpp
@@ -59,6 +59,10 @@ bool TrayProcess::InstallTray() noexcept {
   return tray_icon_added_;
 }
 
+void TrayProcess::set_activate_handler(std::function<void()> handler) {
+  activate_handler_ = std::move(handler);
+}
+
 int TrayProcess::Run() noexcept {
   MSG message{};
   // Blocks in GetMessageW. No timers, no polling, no idle processing: the
@@ -148,8 +152,10 @@ void TrayProcess::HandleTrayCallback(unsigned long long wparam, long long lparam
     ShowMenu();
     return;
   }
-  // NIN_SELECT / NIN_KEYSELECT / WM_LBUTTONUP will activate the main window
-  // once one exists; the tray-only process has nothing to show yet.
+  if ((event == NIN_SELECT || event == NIN_KEYSELECT || event == WM_LBUTTONUP) &&
+      activate_handler_) {
+    activate_handler_();
+  }
 }
 
 void TrayProcess::ShowMenu() {

--- a/src/platform/tray_process.h
+++ b/src/platform/tray_process.h
@@ -18,6 +18,8 @@
 // Like all of platform/, this layer keeps windows.h out of the header.
 #pragma once
 
+#include <functional>
+
 namespace trace {
 class PerformanceTraceSession;
 }
@@ -54,6 +56,10 @@ class TrayProcess final {
   // shell refuses (a headless session): the process stays up without a tray.
   bool InstallTray() noexcept;
 
+  // The shell owns what activation means. At P2 this only shows the empty
+  // parent window; feature routing does not belong in the tray process.
+  void set_activate_handler(std::function<void()> handler);
+
   // Blocks in GetMessageW until Exit. No timers, no polling, no idle work.
   int Run() noexcept;
 
@@ -79,6 +85,7 @@ class TrayProcess final {
   void* window_ = nullptr;
   unsigned int taskbar_created_message_ = 0;
   bool tray_icon_added_ = false;
+  std::function<void()> activate_handler_;
 };
 
 }  // namespace tray

--- a/src/ui/shell/app_window/app_window.cpp
+++ b/src/ui/shell/app_window/app_window.cpp
@@ -1,4 +1,4 @@
-#include "ui/shell/app_window.h"
+#include "ui/shell/app_window/app_window.h"
 
 #include <windows.h>
 #include <windowsx.h>
@@ -31,39 +31,25 @@ constexpr render::Color kHoverNeutral{255, 255, 255, 26};
 constexpr render::Color kHoverClose{232, 17, 35, 255};
 constexpr render::Color kShadow{0, 0, 0, 255};
 
-render::TextStyle CaptionStyle() {
-  render::TextStyle style;
-  style.family = L"Segoe UI";
-  style.size_px = 13.0f;
-  style.weight = render::FontWeight::Semibold;
-  return style;
-}
-
-render::TextStyle GlyphStyle() {
-  render::TextStyle style;
-  style.family = L"Marlett";
-  style.size_px = 11.0f;
-  return style;
-}
-
-// Verified by rendering the font on the target machine; the pair is the
-// user's visual choice: unpinned is the horizontal pin outline (E718),
-// pinned the diagonal pushpin (E840). E713 is the settings gear.
+// Caption icons use one Windows glyph family. Per-glyph sizes are tuned
+// because MDL2 codepoints do not share the same visual bounds.
 constexpr wchar_t kPinGlyphUnpinned = 0xE718;  // horizontal pin outline
 constexpr wchar_t kPinGlyphPinned = 0xE840;    // diagonal pushpin
 constexpr wchar_t kGearGlyph = 0xE713;         // Settings
+constexpr wchar_t kCloseGlyph = 0xE8BB;        // ChromeClose
 
-render::TextStyle IconStyle() {
+render::TextStyle IconStyle(float size_px) {
   render::TextStyle style;
   style.family = L"Segoe MDL2 Assets";
-  style.size_px = 14.0f;
+  style.size_px = size_px;
   return style;
 }
 
-// Marlett and Segoe MDL2 Assets centre their glyphs differently; the nudges
-// put both families on one visual row (verified against a rendered strip).
+constexpr float kPinUnpinnedSize = 22.0f;
+constexpr float kPinPinnedSize = 19.0f;
+constexpr float kGearSize = 16.0f;
+constexpr float kCloseSize = 14.0f;
 constexpr float kIconNudgeY = 2.0f;
-constexpr float kMarlettNudgeY = -2.0f;
 
 }  // namespace
 
@@ -92,14 +78,23 @@ bool AppWindow::Create(void* instance, float content_width, float content_height
   const int height = static_cast<int>(content_height + kShadowMargin * 2);
   hwnd_ = CreateWindowExW(WS_EX_LAYERED | WS_EX_APPWINDOW, window_class.lpszClassName,
                           title_.c_str(),
-                          WS_POPUP | WS_THICKFRAME | WS_SYSMENU | WS_MINIMIZEBOX | WS_MAXIMIZEBOX,
+                          WS_POPUP | WS_THICKFRAME | WS_SYSMENU,
                           CW_USEDEFAULT, CW_USEDEFAULT, width, height, nullptr, nullptr,
                           static_cast<HINSTANCE>(instance), this);
   if (hwnd_ == nullptr) {
     return false;
   }
-  restored_width_px_ = width;
-  restored_height_px_ = height;
+  const HMONITOR monitor = MonitorFromWindow(static_cast<HWND>(hwnd_), MONITOR_DEFAULTTOPRIMARY);
+  MONITORINFO monitor_info{};
+  monitor_info.cbSize = sizeof(monitor_info);
+  if (GetMonitorInfoW(monitor, &monitor_info)) {
+    const int work_width = monitor_info.rcWork.right - monitor_info.rcWork.left;
+    const int work_height = monitor_info.rcWork.bottom - monitor_info.rcWork.top;
+    const int x = monitor_info.rcWork.left + (work_width - width) / 2;
+    const int y = monitor_info.rcWork.top + (work_height - height) / 2;
+    SetWindowPos(static_cast<HWND>(hwnd_), nullptr, x, y, 0, 0,
+                 SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE);
+  }
 
   drain_message_ = RegisterWindowMessageW(L"dhepz.signal.drain");
   signals_ = std::make_unique<platform::SignalFanout>(
@@ -146,14 +141,18 @@ void AppWindow::set_content_click_handler(std::function<bool(float, float)> hand
 }
 
 int AppWindow::ButtonCount() const {
-  // Left-to-right: pin, [settings], min, max/restore, close. The gear only
-  // exists while something can open — no dead button.
-  return settings_handler_ ? 5 : 4;
+  // Left-to-right: pin, optional settings, close.
+  return settings_handler_ ? 3 : 2;
 }
 
 void AppWindow::Show() {
   const HWND window = static_cast<HWND>(hwnd_);
-  if (window == nullptr || IsWindowVisible(window)) return;
+  if (window == nullptr) return;
+
+  if (IsWindowVisible(window)) {
+    SetForegroundWindow(window);
+    return;
+  }
 
   // A full frame renders offscreen BEFORE ShowWindow: the window never
   // appears empty and then fills in.
@@ -161,6 +160,7 @@ void AppWindow::Show() {
   GetClientRect(window, &client);
   OnResized(client.right, client.bottom);
   ShowWindow(window, SW_SHOW);
+  SetForegroundWindow(window);
 }
 
 void AppWindow::Hide() {
@@ -227,7 +227,7 @@ int AppWindow::ButtonAt(int x_px, int y_px) const {
   if (hwnd_ == nullptr) return -1;
   RECT client{};
   GetClientRect(static_cast<HWND>(hwnd_), &client);
-  const int margin = maximized_ ? 0 : Px(kShadowMargin);
+  const int margin = Px(kShadowMargin);
   const int content_left = margin;
   const int content_right = client.right - margin;
   const int caption_bottom = margin + Px(kCaptionHeight);
@@ -248,7 +248,7 @@ int AppWindow::HitTest(int x_px, int y_px) const {
   RECT client{};
   GetClientRect(static_cast<HWND>(hwnd_), &client);
 
-  const int margin = maximized_ ? 0 : Px(kShadowMargin);
+  const int margin = Px(kShadowMargin);
   const int content_left = margin;
   const int content_top = margin;
   const int content_right = client.right - margin;
@@ -266,16 +266,14 @@ int AppWindow::HitTest(int x_px, int y_px) const {
   const bool top = y_px < content_top + border;
   const bool bottom = y_px >= content_bottom - border;
 
-  if (!maximized_) {
-    if (top && left) return HTTOPLEFT;
-    if (top && right) return HTTOPRIGHT;
-    if (bottom && left) return HTBOTTOMLEFT;
-    if (bottom && right) return HTBOTTOMRIGHT;
-    if (left) return HTLEFT;
-    if (right) return HTRIGHT;
-    if (top) return HTTOP;
-    if (bottom) return HTBOTTOM;
-  }
+  if (top && left) return HTTOPLEFT;
+  if (top && right) return HTTOPRIGHT;
+  if (bottom && left) return HTBOTTOMLEFT;
+  if (bottom && right) return HTBOTTOMRIGHT;
+  if (left) return HTLEFT;
+  if (right) return HTRIGHT;
+  if (top) return HTTOP;
+  if (bottom) return HTBOTTOM;
 
   if (ButtonAt(x_px, y_px) >= 0) return HTCLIENT;
   if (y_px < content_top + Px(kCaptionHeight)) return HTCAPTION;
@@ -287,15 +285,13 @@ void AppWindow::RenderFullFrame() {
 
   // Warm the fonts OUTSIDE the frame: creation inside a paint scope is
   // refused by design.
-  const render::TextStyle caption = CaptionStyle();
-  const render::TextStyle glyph = GlyphStyle();
-  const render::TextStyle icon = IconStyle();
-  backend_.MeasureText(title_, caption, 0.0f);
-  backend_.MeasureText(L"0", glyph, 0.0f);
-  backend_.MeasureText(std::wstring(1, kPinGlyphUnpinned), icon, 0.0f);
-  backend_.MeasureText(std::wstring(1, kPinGlyphPinned), icon, 0.0f);
+  backend_.MeasureText(std::wstring(1, kPinGlyphUnpinned),
+                       IconStyle(kPinUnpinnedSize), 0.0f);
+  backend_.MeasureText(std::wstring(1, kPinGlyphPinned),
+                       IconStyle(kPinPinnedSize), 0.0f);
+  backend_.MeasureText(std::wstring(1, kCloseGlyph), IconStyle(kCloseSize), 0.0f);
   if (settings_handler_) {
-    backend_.MeasureText(std::wstring(1, kGearGlyph), icon, 0.0f);
+    backend_.MeasureText(std::wstring(1, kGearGlyph), IconStyle(kGearSize), 0.0f);
   }
 
   render::Rect dirty{};
@@ -314,101 +310,53 @@ void AppWindow::PaintContent() {
 
   const float width = backend_.surface_size().width;
   const float height = backend_.surface_size().height;
-  const float margin = maximized_ ? 0.0f : kShadowMargin;
-  const float radius = maximized_ ? 0.0f : kCornerRadius;
+  const float margin = kShadowMargin;
+  const float radius = kCornerRadius;
   const render::Rect content{margin, margin, width - margin * 2, height - margin * 2};
 
   // Soft shadow: three rounded bands under the content, lightest and
   // largest first. Alpha-blended over the transparent buffer.
-  if (!maximized_) {
-    const float spreads[3] = {kShadowMargin, kShadowMargin * 2.0f / 3.0f, kShadowMargin / 3.0f};
-    const std::uint8_t alphas[3] = {22, 40, 62};
-    for (int i = 0; i < 3; ++i) {
-      const float spread = spreads[i];
-      render::Color shadow = kShadow;
-      shadow.a = alphas[i];
-      backend_.FillRoundedRect(
-          {content.x - spread, content.y - spread, content.width + spread * 2,
-           content.height + spread * 2},
-          render::CornerRadius::Uniform(radius + spread), shadow);
-    }
+  const float spreads[3] = {kShadowMargin, kShadowMargin * 2.0f / 3.0f,
+                            kShadowMargin / 3.0f};
+  const std::uint8_t alphas[3] = {22, 40, 62};
+  for (int i = 0; i < 3; ++i) {
+    const float spread = spreads[i];
+    render::Color shadow = kShadow;
+    shadow.a = alphas[i];
+    backend_.FillRoundedRect(
+        {content.x - spread, content.y - spread, content.width + spread * 2,
+         content.height + spread * 2},
+        render::CornerRadius::Uniform(radius + spread), shadow);
   }
 
   backend_.FillRoundedRect(content, render::CornerRadius::Uniform(radius), kBackground);
   backend_.StrokeRoundedRect(content, render::CornerRadius::Uniform(radius), kBorder, 1.0f);
 
-  // Caption: title left, window buttons right.
+  // Caption buttons sit on the right. The window title remains available to
+  // the taskbar and Alt-Tab but is not painted over the empty P2 container.
   const render::Rect caption{content.x, content.y, content.width, kCaptionHeight};
   const int count = ButtonCount();
-  const float buttons_width = kButtonWidth * count;
-  const float title_width = content.width - buttons_width - 28.0f;
-  if (title_width > 0.0f) {
-    backend_.DrawTextRun(title_, {caption.x + 14.0f, caption.y, title_width, caption.height},
-                         CaptionStyle(), kCaptionText, render::TextAlign::Left,
-                         render::VerticalAlign::Middle);
-  }
-
-  const render::TextStyle glyph = GlyphStyle();
-  const render::TextStyle icon = IconStyle();
-  const wchar_t* marlett[3] = {L"0", maximized_ ? L"2" : L"1", L"r"};  // min, max, close
   for (int i = 0; i < count; ++i) {
-    // Role by distance from the right edge: 0 close, 1 max, 2 min, then the
-    // left slots: settings (only with a handler) and pin leftmost.
-    const int role = (count - 1) - i;
-    const bool is_pin = role == 4 || (role == 3 && !settings_handler_);
-    const bool is_gear = role == 3 && settings_handler_;
+    const bool is_pin = i == 0;
+    const bool is_close = i == count - 1;
     const render::Rect button{caption.right() - (count - i) * kButtonWidth, caption.y,
                               kButtonWidth, kCaptionHeight};
     if (hover_button_ == i) {
-      backend_.FillRect(button, role == 0 ? kHoverClose : kHoverNeutral);
+      backend_.FillRect(button, is_close ? kHoverClose : kHoverNeutral);
     }
-    if (is_pin) {
-      backend_.DrawTextRun(std::wstring(1, pinned_ ? kPinGlyphPinned : kPinGlyphUnpinned),
-                           {button.x, button.y + kIconNudgeY, button.width, button.height}, icon,
-                           kCaptionText, render::TextAlign::Center,
-                           render::VerticalAlign::Middle);
-    } else if (is_gear) {
-      backend_.DrawTextRun(std::wstring(1, kGearGlyph),
-                           {button.x, button.y + kIconNudgeY, button.width, button.height}, icon,
-                           kCaptionText, render::TextAlign::Center,
-                           render::VerticalAlign::Middle);
-    } else {
-      backend_.DrawTextRun(marlett[2 - role],
-                           {button.x, button.y + kMarlettNudgeY, button.width, button.height},
-                           glyph, kCaptionText, render::TextAlign::Center,
-                           render::VerticalAlign::Middle);
-    }
+    const wchar_t glyph = is_pin ? (pinned_ ? kPinGlyphPinned : kPinGlyphUnpinned)
+                                 : (is_close ? kCloseGlyph : kGearGlyph);
+    const float size = is_pin ? (pinned_ ? kPinPinnedSize : kPinUnpinnedSize)
+                              : (is_close ? kCloseSize : kGearSize);
+    backend_.DrawTextRun(std::wstring(1, glyph),
+                         {button.x, button.y + kIconNudgeY, button.width, button.height},
+                         IconStyle(size), kCaptionText, render::TextAlign::Center,
+                         render::VerticalAlign::Middle);
   }
 
   if (content_painter_) {
     content_painter_(backend_, content);
   }
-}
-
-void AppWindow::SetMaximized(bool maximize) {
-  if (hwnd_ == nullptr || maximize == maximized_) return;
-  const HWND window = static_cast<HWND>(hwnd_);
-  maximized_ = maximize;
-  if (maximize) {
-    RECT client{};
-    GetClientRect(window, &client);
-    restored_width_px_ = client.right;
-    restored_height_px_ = client.bottom;
-    const HMONITOR monitor = MonitorFromWindow(window, MONITOR_DEFAULTTONEAREST);
-    MONITORINFO info{};
-    info.cbSize = sizeof(info);
-    if (GetMonitorInfoW(monitor, &info)) {
-      SetWindowPos(window, nullptr, info.rcWork.left, info.rcWork.top,
-                   info.rcWork.right - info.rcWork.left, info.rcWork.bottom - info.rcWork.top,
-                   SWP_NOZORDER | SWP_NOACTIVATE);
-    }
-  } else {
-    SetWindowPos(window, nullptr, 0, 0, restored_width_px_, restored_height_px_,
-                 SWP_NOMOVE | SWP_NOZORDER | SWP_NOACTIVATE);
-  }
-  RECT client{};
-  GetClientRect(window, &client);
-  OnResized(client.right, client.bottom);
 }
 
 long long __stdcall AppWindow::WindowProc(void* window, unsigned int message,
@@ -465,11 +413,6 @@ long long AppWindow::HandleMessage(void* window_handle, unsigned int message,
       // WM_NCHITTEST below.
       return 0;
     case WM_SIZE: {
-      if (IsIconic(window)) {
-        // Minimised is hidden for budget purposes: the buffer goes away too.
-        backend_.ReleaseSurface();
-        return 0;
-      }
       // The buffer exists only while visible: Show() renders it before
       // ShowWindow, Hide() releases it. Sizes arriving while hidden (window
       // creation, hide transitions) are ignored on purpose.
@@ -512,7 +455,7 @@ long long AppWindow::HandleMessage(void* window_handle, unsigned int message,
         if (content_click_handler_) {
           const int x_px = GET_X_LPARAM(lparam);
           const int y_px = GET_Y_LPARAM(lparam);
-          const int margin = maximized_ ? 0 : Px(kShadowMargin);
+          const int margin = Px(kShadowMargin);
           RECT client{};
           GetClientRect(window, &client);
           if (x_px >= margin && y_px >= margin && x_px < client.right - margin &&
@@ -524,17 +467,11 @@ long long AppWindow::HandleMessage(void* window_handle, unsigned int message,
         }
         return 0;
       }
-      const int role = (ButtonCount() - 1) - button;  // 0 close … leftmost pin
-      const bool is_pin = role == 4 || (role == 3 && !settings_handler_);
-      if (role == 0) {
-        Close();
-      } else if (role == 1) {
-        SetMaximized(!maximized_);
-      } else if (role == 2) {
-        ShowWindow(window, SW_MINIMIZE);
-      } else if (is_pin) {
+      if (button == 0) {
         TogglePin();
-      } else if (role == 3 && settings_handler_) {
+      } else if (button == ButtonCount() - 1) {
+        Close();
+      } else if (settings_handler_) {
         settings_handler_();
       }
       return 0;
@@ -551,7 +488,7 @@ long long AppWindow::HandleMessage(void* window_handle, unsigned int message,
       const LRESULT result =
           DefWindowProcW(window, message, static_cast<WPARAM>(wparam), static_cast<LPARAM>(lparam));
       auto* info = reinterpret_cast<MINMAXINFO*>(lparam);
-      const int margin = maximized_ ? 0 : Px(kShadowMargin) * 2;
+      const int margin = Px(kShadowMargin) * 2;
       info->ptMinTrackSize.x = Px(320.0f) + margin;
       info->ptMinTrackSize.y = Px(200.0f) + margin;
       return result;

--- a/src/ui/shell/app_window/app_window.h
+++ b/src/ui/shell/app_window/app_window.h
@@ -4,11 +4,11 @@
 //
 // The lifecycle rules, because they are the point of this file:
 //
-//   - Hide (or minimise, or close): the back buffer and every window-scoped
+//   - Hide (or close): the back buffer and every window-scoped
 //     resource are released. The buffer is the one large allocation and it
 //     scales with window size; keeping it while hidden is the drift G1
 //     forbids.
-//   - Show/restore: a full frame is rendered offscreen BEFORE ShowWindow,
+//   - Show: a full frame is rendered offscreen BEFORE ShowWindow,
 //     so the window never appears empty and then fills in.
 //   - Close hides. The process stays tray-resident; it does not exit. Exit
 //     belongs to the tray menu.
@@ -64,11 +64,10 @@ class AppWindow final {
 
   bool alive() const { return hwnd_ != nullptr; }
   bool visible() const;
-  bool maximized() const { return maximized_; }
   void* hwnd() const { return hwnd_; }
   render::GdiBackend* backend() { return &backend_; }
 
-  // Always-on-top pin: a caption button left of minimise toggles this. The
+  // Always-on-top pin: the left caption button toggles this. The
   // state is session-only — persistence belongs to the settings module.
   void TogglePin();
   bool pinned() const { return pinned_; }
@@ -116,12 +115,10 @@ class AppWindow final {
 
   void RenderFullFrame();
   void PaintContent();
-  void SetMaximized(bool maximize);
   int Px(float logical) const;
   float Logical(int px) const;
   // Caption buttons left-to-right: pin, settings (only while a settings
-  // handler is registered), min, max/restore, close. Returns the
-  // left-to-right index or -1.
+  // handler is registered), close. Returns the left-to-right index or -1.
   int ButtonAt(int x_px, int y_px) const;
   int ButtonCount() const;
 
@@ -139,10 +136,7 @@ class AppWindow final {
   std::uint32_t last_os_signals_ = 0;
   unsigned int drain_message_ = 0;
   float dpi_ = 96.0f;
-  bool maximized_ = false;
   bool pinned_ = false;
-  int restored_width_px_ = 0;
-  int restored_height_px_ = 0;
   int hover_button_ = -1;
   std::wstring title_ = L"dhepz";
 };

--- a/tests/platform/settle_timer_test.cpp
+++ b/tests/platform/settle_timer_test.cpp
@@ -6,7 +6,7 @@
 #include <thread>
 
 #include "framework/test_case.h"
-#include "ui/shell/app_window.h"
+#include "ui/shell/app_window/app_window.h"
 
 namespace {
 

--- a/tests/platform/signal_fanout_test.cpp
+++ b/tests/platform/signal_fanout_test.cpp
@@ -6,7 +6,7 @@
 #include <thread>
 
 #include "framework/test_case.h"
-#include "ui/shell/app_window.h"
+#include "ui/shell/app_window/app_window.h"
 
 namespace {
 

--- a/tests/ui/presenter/input_to_paint_test.cpp
+++ b/tests/ui/presenter/input_to_paint_test.cpp
@@ -10,7 +10,7 @@
 
 #include "framework/test_case.h"
 #include "ui/config/resolved_ui_document.h"
-#include "ui/shell/app_window.h"
+#include "ui/shell/app_window/app_window.h"
 
 namespace {
 

--- a/tests/ui/shell/app_window_test.cpp
+++ b/tests/ui/shell/app_window_test.cpp
@@ -1,4 +1,4 @@
-#include "ui/shell/app_window.h"
+#include "ui/shell/app_window/app_window.h"
 
 #include <windows.h>
 #include <psapi.h>
@@ -15,7 +15,7 @@ namespace {
 void* TestInstance() { return GetModuleHandleW(nullptr); }
 
 // The shell runs on a message loop in the real app; tests pump briefly when
-// a step posts messages (minimise, resize).
+// a step posts resize messages.
 void PumpFor(int milliseconds) {
   const auto deadline = std::chrono::steady_clock::now() +
                         std::chrono::milliseconds(milliseconds);
@@ -63,22 +63,6 @@ DHEPZ_TEST(AppWindow, CloseReturnsToResidentNotExit) {
   DHEPZ_CHECK_FALSE(window.visible());
   DHEPZ_CHECK(window.alive());
   DHEPZ_CHECK_EQ(window.backend()->buffer_width(), 0);
-}
-
-DHEPZ_TEST(AppWindow, MinimiseReleasesAndRestoreRebuilds) {
-  shell::AppWindow window;
-  DHEPZ_CHECK(window.Create(TestInstance(), 320.0f, 240.0f));
-  window.Show();
-  PumpFor(30);
-
-  ShowWindow(static_cast<HWND>(window.hwnd()), SW_MINIMIZE);
-  PumpFor(60);
-  DHEPZ_CHECK_EQ(window.backend()->buffer_width(), 0);
-
-  ShowWindow(static_cast<HWND>(window.hwnd()), SW_RESTORE);
-  PumpFor(60);
-  DHEPZ_CHECK(window.visible());
-  DHEPZ_CHECK(window.backend()->buffer_width() > 0);
 }
 
 DHEPZ_TEST(AppWindow, HundredHideShowCyclesStayFlat) {
@@ -301,22 +285,22 @@ DHEPZ_TEST(AppWindow, SettingsButtonAppearsOnlyWithHandler) {
   const HWND hwnd = static_cast<HWND>(window.hwnd());
 
   // Client geometry at 96 DPI: margin 24, content_right 984, button 46 px.
-  // Order left-to-right: pin, [settings], min, max, close.
+  // Order left-to-right: pin, [settings], close.
   bool opened = false;
-  // No handler: four buttons, the pin occupies x 800..846; the future gear
-  // slot (x 754..800) is plain caption — clicking it does nothing.
-  SendMessageW(hwnd, WM_LBUTTONUP, 0, MAKELPARAM(770, 40));
+  // No handler: two buttons, the pin occupies x 892..938; the future gear
+  // slot (x 846..892) is plain caption — clicking it does nothing.
+  SendMessageW(hwnd, WM_LBUTTONUP, 0, MAKELPARAM(870, 40));
   DHEPZ_CHECK_FALSE(opened);
   DHEPZ_CHECK_FALSE(window.pinned());
-  SendMessageW(hwnd, WM_LBUTTONUP, 0, MAKELPARAM(820, 40));
+  SendMessageW(hwnd, WM_LBUTTONUP, 0, MAKELPARAM(910, 40));
   DHEPZ_CHECK(window.pinned());
-  SendMessageW(hwnd, WM_LBUTTONUP, 0, MAKELPARAM(820, 40));
+  SendMessageW(hwnd, WM_LBUTTONUP, 0, MAKELPARAM(910, 40));
   DHEPZ_CHECK_FALSE(window.pinned());
 
   window.set_settings_handler([&opened] { opened = true; });
-  // The gear now takes x 800..846 and the pin shifts left to 754..800.
-  SendMessageW(hwnd, WM_LBUTTONUP, 0, MAKELPARAM(820, 40));
+  // The gear now takes x 892..938 and the pin shifts left to 846..892.
+  SendMessageW(hwnd, WM_LBUTTONUP, 0, MAKELPARAM(910, 40));
   DHEPZ_CHECK(opened);
-  SendMessageW(hwnd, WM_LBUTTONUP, 0, MAKELPARAM(770, 40));
+  SendMessageW(hwnd, WM_LBUTTONUP, 0, MAKELPARAM(870, 40));
   DHEPZ_CHECK(window.pinned());
 }


### PR DESCRIPTION
Completes the Phase 2 production shell with the compact AppWindow, empty content container, tray reopen/foreground behavior, close-to-hide lifecycle, and pin-gear-close chrome. Removes minimize/maximize behavior from the P2 contract. Release test suite: 182/182 passed.