### PR TITLE
Phase 4: complete modular Terminal UI and logic

### DIFF
--- a/assets/ui/core.json
+++ b/assets/ui/core.json
@@ -36,6 +36,11 @@
       "accessible_name": { "kind": "string" },
       "width": { "kind": "int" },
       "height": { "kind": "int" },
+      "join_edge": {
+        "kind": "enum",
+        "values": ["none", "start", "end", "both"],
+        "default": "none"
+      },
       "action": { "kind": "string" }
     }
   },
@@ -119,12 +124,16 @@
         },
         "selected_binding": { "kind": "binding" },
         "press_selects": { "kind": "bool", "default": false },
+        "font_family": { "kind": "string", "default": "Segoe UI" },
+        "font_size": { "kind": "int", "default": 14 },
         "tab_stop": { "kind": "bool", "default": true }
       }
     },
     "input": {
       "properties": {
         "value_binding": { "kind": "binding", "required": true },
+        "suggestions_binding": { "kind": "binding" },
+        "maximum_visible_items": { "kind": "int", "default": 6 },
         "mode": {
           "kind": "enum",
           "values": ["single_line", "multiline"],

--- a/src/dhepz.vcxproj
+++ b/src/dhepz.vcxproj
@@ -156,6 +156,7 @@
     <ClInclude Include="**\*.h" />
     <None Include="app.manifest" />
     <ResourceCompile Include="app.rc" />
+    <ResourceCompile Include="modules\**\*.rc" />
   </ItemGroup>
 
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,6 +6,7 @@
 
 #include "app_version.h"
 #include "orchestrator/window_orchestrator.h"
+#include "parent/logic/module_registry.h"
 #include "platform/performance_trace.h"
 #include "platform/tray_process.h"
 #include "parent/ui/config/embedded_settings_loader.h"
@@ -80,6 +81,34 @@ int APIENTRY wWinMain(_In_ HINSTANCE instance,
     BootstrapFailed(15, message.c_str());
   }
 
+  const auto& module_descriptors = modules::ModuleRegistry::All();
+  if (module_descriptors.empty()) {
+    tray_process.Shutdown();
+    BootstrapFailed(16, L"No feature module is registered.");
+  }
+  std::vector<ui::config::EmbeddedScreenResource> module_resources;
+  module_resources.reserve(module_descriptors.size());
+  for (const modules::ModuleDescriptor* descriptor : module_descriptors) {
+    module_resources.push_back(
+        {std::wstring(descriptor->screen_name), descriptor->ui_resource_id});
+  }
+  std::vector<ui::config::Diagnostic> feature_diagnostics;
+  std::unique_ptr<ui::config::ResolvedUiDocument> feature_document;
+  const core::Status feature_status = ui::config::LoadEmbeddedFeatureDocument(
+      instance, module_resources, &feature_diagnostics, &feature_document);
+  if (!feature_status.ok()) {
+    tray_process.Shutdown();
+    const std::wstring message = L"The feature UI could not be loaded.\n\n" +
+                                 feature_status.Message();
+    BootstrapFailed(17, message.c_str());
+  }
+  for (const modules::ModuleDescriptor* descriptor : module_descriptors) {
+    if (feature_document->FindRoute(descriptor->route_id) == nullptr) {
+      tray_process.Shutdown();
+      BootstrapFailed(18, L"A module route is missing from its UI document.");
+    }
+  }
+
   // Non-fatal by design: a headless session has no shell to host the icon,
   // and the process must still run (CI, automated runs).
   tray_process.InstallTray();
@@ -87,7 +116,9 @@ int APIENTRY wWinMain(_In_ HINSTANCE instance,
   // One resident owner PID hosts every window. A secondary EXE invocation
   // asks the orchestrator for another window, then exits without a tray of
   // its own.
-  orchestrator::WindowOrchestrator windows(instance, settings_document.get());
+  orchestrator::WindowOrchestrator windows(instance, settings_document.get(),
+                                            feature_document.get(),
+                                            module_descriptors.front());
 
   tray_process.set_launch_handler([&] {
     if (!windows.OpenWindow()) {
@@ -97,7 +128,7 @@ int APIENTRY wWinMain(_In_ HINSTANCE instance,
   });
   if (!windows.OpenWindow()) {
     tray_process.Shutdown();
-    BootstrapFailed(16, L"The application window could not be created.");
+    BootstrapFailed(19, L"The application window could not be created.");
   }
 
   const int result = tray_process.Run();

--- a/src/modules/terminal/terminal.json
+++ b/src/modules/terminal/terminal.json
@@ -1,0 +1,108 @@
+{
+  "components": [
+    {
+      "type": "window",
+      "title": "dhepz",
+      "initial_route": "terminal"
+    },
+    {
+      "type": "screen",
+      "route_id": "terminal",
+      "show_in_tabs": false,
+      "children": [
+        {
+          "type": "container",
+          "id": "terminal-frame",
+          "direction": "column",
+          "padding": { "left": 3, "top": 3, "right": 3, "bottom": 3 },
+          "gap": 0,
+          "children": [
+            {
+              "type": "container",
+              "id": "terminal-content",
+              "direction": "column",
+              "padding": { "left": 13, "top": 9, "right": 13, "bottom": 9 },
+              "gap": 9,
+              "children": [
+                {
+                  "type": "container",
+                  "id": "path-row",
+                  "direction": "row",
+                  "gap": -1,
+                  "height": 36,
+                  "children": [
+                    {
+                      "type": "input",
+                      "id": "terminal-path",
+                      "value_binding": "terminal.path",
+                      "suggestions_binding": "terminal.recent_paths",
+                      "maximum_visible_items": 6,
+                      "placeholder": "Folder path",
+                      "join_edge": "end",
+                      "width": 323,
+                      "height": 36
+                    },
+                    {
+                      "type": "button",
+                      "id": "browse-folder",
+                      "label": "",
+                      "action": "terminal.browse",
+                      "variant": "default",
+                      "join_edge": "start",
+                      "font_family": "Segoe MDL2 Assets",
+                      "font_size": 16,
+                      "accessible_name": "Browse folder",
+                      "width": 46,
+                      "height": 36
+                    }
+                  ]
+                },
+                {
+                  "type": "toggle",
+                  "id": "prepare-venv",
+                  "label": "Check / create Python venv",
+                  "checked_binding": "terminal.venv",
+                  "action": "terminal.venv.changed",
+                  "height": 26
+                },
+                {
+                  "type": "button",
+                  "id": "windows-terminal-admin",
+                  "label": "Windows Terminal Admin",
+                  "action": "terminal.launch.admin",
+                  "width": 368,
+                  "height": 40
+                },
+                {
+                  "type": "button",
+                  "id": "windows-terminal",
+                  "label": "Windows Terminal",
+                  "action": "terminal.launch.default",
+                  "width": 368,
+                  "height": 40
+                },
+                {
+                  "type": "button",
+                  "id": "ubuntu-wsl",
+                  "label": "Ubuntu (WSL)",
+                  "action": "terminal.launch.wsl",
+                  "width": 368,
+                  "height": 40
+                },
+                {
+                  "type": "text",
+                  "id": "terminal-status",
+                  "text_binding": "terminal.status",
+                  "variant": "caption",
+                  "align": "center",
+                  "width": 368,
+                  "height": 18
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/modules/terminal/terminal.rc
+++ b/src/modules/terminal/terminal.rc
@@ -1,0 +1,5 @@
+#include <windows.h>
+
+#include "terminal_resources.h"
+
+IDR_TERMINAL_SCREEN_JSON RCDATA "terminal.json"

--- a/src/modules/terminal/terminal_module.cpp
+++ b/src/modules/terminal/terminal_module.cpp
@@ -1,0 +1,346 @@
+#include "parent/logic/module_registry.h"
+
+#include <algorithm>
+#include <cwctype>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "modules/terminal/terminal_resources.h"
+
+namespace modules::terminal {
+namespace {
+
+enum class LaunchKind { Default, Admin, Wsl };
+
+ui::application::UiPatch Patch(std::wstring path, ui::application::UiValue value) {
+  ui::application::UiPatch patch;
+  patch.changes.push_back({std::move(path), std::move(value)});
+  return patch;
+}
+
+void Add(ui::application::UiPatch* patch, std::wstring path,
+         ui::application::UiValue value) {
+  patch->changes.push_back({std::move(path), std::move(value)});
+}
+
+bool EqualsInsensitive(std::wstring_view left, std::wstring_view right) {
+  return left.size() == right.size() &&
+         std::equal(left.begin(), left.end(), right.begin(), right.end(),
+                    [](wchar_t a, wchar_t b) { return std::towlower(a) == std::towlower(b); });
+}
+
+std::wstring Trim(std::wstring_view text) {
+  const std::size_t first = text.find_first_not_of(L" \t\r\n");
+  if (first == std::wstring_view::npos) return {};
+  const std::size_t last = text.find_last_not_of(L" \t\r\n");
+  return std::wstring(text.substr(first, last - first + 1));
+}
+
+std::vector<std::wstring> RecentPaths(const ui::application::UiState& state,
+                                      std::wstring_view selected) {
+  std::vector<std::wstring> recent;
+  const std::wstring current = Trim(selected);
+  if (!current.empty()) recent.push_back(current);
+  const std::vector<std::wstring>* existing = state.Strings(L"terminal.recent_paths");
+  if (existing != nullptr) {
+    for (const std::wstring& path : *existing) {
+      if (path.empty() || std::any_of(recent.begin(), recent.end(), [&path](const auto& item) {
+            return EqualsInsensitive(item, path);
+          })) {
+        continue;
+      }
+      recent.push_back(path);
+      if (recent.size() == 8) break;
+    }
+  }
+  return recent;
+}
+
+std::wstring UserMessage(const core::Status& status) {
+  if (status.ok()) return {};
+  std::wstring message = status.Message();
+  const std::size_t context = message.find(L" [");
+  if (context != std::wstring::npos) message.resize(context);
+  return message;
+}
+
+std::vector<std::wstring> NonEmptyLines(std::wstring text) {
+  text.erase(std::remove(text.begin(), text.end(), L'\0'), text.end());
+  std::vector<std::wstring> lines;
+  std::size_t start = 0;
+  while (start <= text.size()) {
+    const std::size_t end = text.find(L'\n', start);
+    std::wstring line = Trim(text.substr(start, end == std::wstring::npos ? end : end - start));
+    if (!line.empty()) lines.push_back(std::move(line));
+    if (end == std::wstring::npos) break;
+    start = end + 1;
+  }
+  return lines;
+}
+
+struct WslTarget {
+  std::wstring distribution;
+  std::wstring linux_path;
+};
+
+bool ParseWslUnc(std::wstring_view input, WslTarget* target) {
+  if (target == nullptr) return false;
+  constexpr std::wstring_view prefixes[]{L"\\\\wsl.localhost\\", L"\\\\wsl$\\"};
+  for (std::wstring_view prefix : prefixes) {
+    if (input.size() <= prefix.size()) continue;
+    bool match = true;
+    for (std::size_t index = 0; index < prefix.size(); ++index) {
+      if (std::towlower(input[index]) != std::towlower(prefix[index])) {
+        match = false;
+        break;
+      }
+    }
+    if (!match) continue;
+    const std::size_t separator = input.find(L'\\', prefix.size());
+    target->distribution = std::wstring(input.substr(
+        prefix.size(), separator == std::wstring_view::npos ? input.size() - prefix.size()
+                                                                 : separator - prefix.size()));
+    target->linux_path = L"/";
+    if (separator != std::wstring_view::npos) {
+      target->linux_path.append(input.substr(separator + 1));
+      std::replace(target->linux_path.begin(), target->linux_path.end(), L'\\', L'/');
+    }
+    return !target->distribution.empty();
+  }
+  return false;
+}
+
+core::Status ResolveWslTarget(const BackgroundCapabilities& capabilities,
+                              std::wstring_view path, WslTarget* target) {
+  if (target == nullptr) {
+    return DHEPZ_ERR(core::ErrorCode::InvalidArgument, L"WSL target output is required");
+  }
+  if (ParseWslUnc(path, target)) return core::Ok();
+
+  ProcessRequest list;
+  list.executable = L"wsl.exe";
+  list.arguments = {L"-l", L"-q"};
+  list.hidden = true;
+  std::wstring output;
+  DHEPZ_RETURN_IF_ERROR(capabilities.RunProcess(list, &output));
+  const std::vector<std::wstring> distributions = NonEmptyLines(std::move(output));
+  if (distributions.empty()) {
+    return DHEPZ_ERR(core::ErrorCode::NotFound, L"No WSL distribution is installed");
+  }
+  target->distribution = distributions.front();
+  const auto ubuntu = std::find_if(distributions.begin(), distributions.end(),
+                                   [](const std::wstring& item) {
+                                     return EqualsInsensitive(item, L"Ubuntu") ||
+                                            item.rfind(L"Ubuntu-", 0) == 0;
+                                   });
+  if (ubuntu != distributions.end()) target->distribution = *ubuntu;
+
+  ProcessRequest convert;
+  convert.executable = L"wsl.exe";
+  std::wstring portable_path(path);
+  std::replace(portable_path.begin(), portable_path.end(), L'\\', L'/');
+  convert.arguments = {L"-d", target->distribution, L"--", L"wslpath", L"-a", L"-u",
+                       std::move(portable_path)};
+  convert.hidden = true;
+  DHEPZ_RETURN_IF_ERROR(capabilities.RunProcess(convert, &output));
+  target->linux_path = Trim(output);
+  if (target->linux_path.empty()) {
+    return DHEPZ_ERR(core::ErrorCode::InvalidArgument, L"WSL could not resolve the folder path");
+  }
+  return core::Ok();
+}
+
+core::Status EnsureWindowsVenv(const BackgroundCapabilities& capabilities,
+                               std::wstring_view path) {
+  const std::wstring root(path);
+  const std::wstring python = root + L"\\.venv\\Scripts\\python.exe";
+  if (capabilities.FileExists(python)) return core::Ok();
+  ProcessRequest create;
+  create.executable = L"py.exe";
+  create.arguments = {L"-3", L"-m", L"venv", root + L"\\.venv"};
+  create.working_directory = root;
+  create.hidden = true;
+  std::wstring ignored;
+  core::Status status = capabilities.RunProcess(create, &ignored);
+  if (status.ok()) return status;
+  create.executable = L"python.exe";
+  create.arguments = {L"-m", L"venv", root + L"\\.venv"};
+  ignored.clear();
+  return capabilities.RunProcess(create, &ignored);
+}
+
+core::Status EnsureWslVenv(const BackgroundCapabilities& capabilities,
+                           const WslTarget& target, std::wstring_view environment) {
+  ProcessRequest create;
+  create.executable = L"wsl.exe";
+  create.arguments = {L"-d", target.distribution, L"--cd", target.linux_path, L"--", L"sh",
+                      L"-lc", L"test -x " + std::wstring(environment) +
+                                    L"/bin/python || python3 -m venv --prompt .venv " +
+                                    std::wstring(environment)};
+  create.hidden = true;
+  std::wstring ignored;
+  return capabilities.RunProcess(create, &ignored);
+}
+
+core::Status Launch(const BackgroundCapabilities& capabilities, LaunchKind kind,
+                     std::wstring path, bool prepare_venv,
+                     const std::atomic<bool>& cancelled,
+                     const std::atomic<bool>* request_cancelled) {
+  const auto is_cancelled = [&] {
+    return cancelled.load() ||
+           (request_cancelled != nullptr && request_cancelled->load());
+  };
+  path = Trim(path);
+  if (path.empty()) {
+    return DHEPZ_ERR(core::ErrorCode::InvalidArgument, L"Choose a terminal folder first");
+  }
+  if (!capabilities.DirectoryExists(path)) {
+    return DHEPZ_ERR(core::ErrorCode::NotFound, L"The selected folder does not exist");
+  }
+  if (is_cancelled()) return DHEPZ_ERR(core::ErrorCode::Cancelled, L"Launch cancelled");
+
+  if (kind == LaunchKind::Wsl) {
+    ProcessRequest request;
+    request.executable = L"wt.exe";
+    request.working_directory = path;
+    if (!prepare_venv) {
+      request.arguments = {L"-w", L"new", L"new-tab", L"-p", L"Ubuntu", L"-d", path};
+      return capabilities.StartProcess(request);
+    }
+
+    WslTarget wsl;
+    DHEPZ_RETURN_IF_ERROR(ResolveWslTarget(capabilities, path, &wsl));
+    if (is_cancelled()) return DHEPZ_ERR(core::ErrorCode::Cancelled, L"Launch cancelled");
+    std::wstring environment = L".venv";
+    if (capabilities.FileExists(path + L"\\.venv\\Scripts\\python.exe")) {
+      environment = L".venv-wsl";
+    }
+    DHEPZ_RETURN_IF_ERROR(EnsureWslVenv(capabilities, wsl, environment));
+    if (is_cancelled()) return DHEPZ_ERR(core::ErrorCode::Cancelled, L"Launch cancelled");
+    request.arguments = {L"-w", L"new", L"new-tab", L"-p", L"Ubuntu", L"wsl.exe",
+                         L"-d", wsl.distribution, L"--cd", wsl.linux_path};
+    const std::wstring startup =
+        L"exec bash --rcfile <(printf '%s\\n' 'source ~/.bashrc' 'source " +
+        environment + L"/bin/activate') -i";
+    request.arguments.insert(request.arguments.end(), {L"--", L"bash", L"-lc", startup});
+    return capabilities.StartProcess(request);
+  }
+
+  if (prepare_venv) DHEPZ_RETURN_IF_ERROR(EnsureWindowsVenv(capabilities, path));
+  if (is_cancelled()) return DHEPZ_ERR(core::ErrorCode::Cancelled, L"Launch cancelled");
+  ProcessRequest request;
+  request.executable = L"wt.exe";
+  request.arguments = {L"-w", L"new", L"new-tab", L"-p", L"PowerShell", L"-d", path};
+  if (prepare_venv) {
+    request.arguments.insert(request.arguments.end(),
+                             {L"pwsh.exe", L"-NoExit", L"-ExecutionPolicy", L"Bypass",
+                              L"-Command", L"& '.\\.venv\\Scripts\\Activate.ps1'"});
+  }
+  request.working_directory = path;
+  request.elevated = kind == LaunchKind::Admin;
+  return capabilities.StartProcess(request);
+}
+
+class TerminalController final : public ModuleController {
+ public:
+  ui::application::UiPatch InitialState(const ModuleHost& host) const override {
+    ui::application::UiPatch patch;
+    const std::wstring default_directory = host.DefaultDirectory();
+    Add(&patch, L"terminal.path", default_directory);
+    Add(&patch, L"terminal.recent_paths",
+        default_directory.empty() ? std::vector<std::wstring>{}
+                                  : std::vector<std::wstring>{default_directory});
+    Add(&patch, L"terminal.venv", false);
+    Add(&patch, L"terminal.status", std::wstring{});
+    Add(&patch, L"terminal.busy", false);
+    return patch;
+  }
+
+  core::Status Bind(ModuleHost* host, ui::application::UiActionRegistry* actions) override {
+    if (host == nullptr || actions == nullptr) {
+      return DHEPZ_ERR(core::ErrorCode::InvalidArgument, L"Terminal module requires its parent contract");
+    }
+    host_ = host;
+    if (!actions->Register(L"terminal.browse", [this](const auto&, const auto& state) {
+          const auto selected = host_->PickFolder(state.Text(L"terminal.path"));
+          if (!selected.has_value()) return ui::application::UiPatch{};
+          ui::application::UiPatch patch = Patch(L"terminal.path", *selected);
+           Add(&patch, L"terminal.recent_paths", RecentPaths(state, *selected));
+           return patch;
+         }) ||
+        !actions->Register(L"terminal.venv.changed", [this](const auto&, const auto& state) {
+          if (state.Bool(L"terminal.venv")) return ui::application::UiPatch{};
+          CancelPendingVenv();
+          ui::application::UiPatch patch;
+          Add(&patch, L"terminal.busy", false);
+          Add(&patch, L"terminal.status", std::wstring{});
+          return patch;
+        }) ||
+        !RegisterLaunch(actions, L"terminal.launch.admin", LaunchKind::Admin) ||
+        !RegisterLaunch(actions, L"terminal.launch.default", LaunchKind::Default) ||
+        !RegisterLaunch(actions, L"terminal.launch.wsl", LaunchKind::Wsl)) {
+      return DHEPZ_ERR(core::ErrorCode::AlreadyExists, L"Terminal action registration failed");
+    }
+    return core::Ok();
+  }
+
+ private:
+  bool RegisterLaunch(ui::application::UiActionRegistry* actions, std::wstring action,
+                       LaunchKind kind) {
+    return actions->Register(std::move(action), [this, kind](const auto&, const auto& state) {
+      const std::wstring path = state.Text(L"terminal.path");
+      const bool prepare_venv = state.Bool(L"terminal.venv");
+      CancelPendingVenv();
+      std::shared_ptr<std::atomic<bool>> request_cancelled;
+      if (prepare_venv) {
+        request_cancelled = std::make_shared<std::atomic<bool>>(false);
+        pending_venv_ = request_cancelled;
+      }
+      host_->RunBackground(
+          [kind, path, prepare_venv, request_cancelled](
+              const BackgroundCapabilities& capabilities,
+              const std::atomic<bool>& cancelled) {
+            return Launch(capabilities, kind, path, prepare_venv, cancelled,
+                          request_cancelled.get());
+          },
+          [this, request_cancelled](const core::Status& status) {
+            if (request_cancelled != nullptr && request_cancelled->load()) return;
+            if (pending_venv_ == request_cancelled) pending_venv_.reset();
+            ui::application::UiPatch complete;
+            Add(&complete, L"terminal.busy", false);
+            Add(&complete, L"terminal.status", UserMessage(status));
+            host_->Publish(std::move(complete));
+            if (status.ok()) host_->CloseWindowIfUnpinned();
+          });
+      ui::application::UiPatch pending;
+      Add(&pending, L"terminal.busy", true);
+      Add(&pending, L"terminal.recent_paths", RecentPaths(state, path));
+      Add(&pending, L"terminal.status",
+          prepare_venv ? std::wstring(L"Checking Python venv...")
+                       : std::wstring(L"Opening terminal..."));
+      return pending;
+    });
+  }
+
+  void CancelPendingVenv() {
+    if (pending_venv_ != nullptr) pending_venv_->store(true);
+    pending_venv_.reset();
+  }
+
+  ModuleHost* host_ = nullptr;
+  std::shared_ptr<std::atomic<bool>> pending_venv_;
+};
+
+std::unique_ptr<ModuleController> CreateTerminalController() {
+  return std::make_unique<TerminalController>();
+}
+
+const ModuleDescriptor kTerminalDescriptor{
+    L"terminal", L"terminal", L"modules/terminal/terminal.json", IDR_TERMINAL_SCREEN_JSON,
+    &CreateTerminalController};
+const ModuleRegistrar kTerminalRegistration(&kTerminalDescriptor);
+
+}  // namespace
+}  // namespace modules::terminal

--- a/src/modules/terminal/terminal_resources.h
+++ b/src/modules/terminal/terminal_resources.h
@@ -1,0 +1,3 @@
+#pragma once
+
+#define IDR_TERMINAL_SCREEN_JSON 3101

--- a/src/orchestrator/module_host.cpp
+++ b/src/orchestrator/module_host.cpp
@@ -1,0 +1,121 @@
+#include "orchestrator/module_host.h"
+
+#include <windows.h>
+
+#include "parent/ui/runtime/parent_ui.h"
+#include "platform/folder_picker.h"
+#include "platform/paths.h"
+#include "platform/process.h"
+#include "platform/worker.h"
+#include "ui/app_window/app_window.h"
+
+namespace orchestrator {
+
+ModuleHostAdapter::ModuleHostAdapter(shell::AppWindow* window,
+                                     ui::containers::ParentUi* parent)
+    : window_(window), parent_(parent) {}
+
+ModuleHostAdapter::~ModuleHostAdapter() { Shutdown(); }
+
+core::Status ModuleHostAdapter::Start() {
+  if (window_ == nullptr || !window_->alive() || parent_ == nullptr) {
+    return DHEPZ_ERR(core::ErrorCode::InvalidArgument, L"Module host requires a live window");
+  }
+  completion_message_ = RegisterWindowMessageW(L"dhepz.module.background.complete.v1");
+  if (completion_message_ == 0) {
+    return DHEPZ_ERR(core::ErrorCode::Internal, L"Module completion message registration failed");
+  }
+  worker_ = std::make_unique<worker::Worker>(window_->hwnd(), completion_message_);
+  generation_ = worker_->CreateGeneration();
+  window_->set_native_message_handler([this](unsigned int message, long long lparam) {
+    if (message != completion_message_ || worker_ == nullptr) return false;
+    worker::Worker::Settle(lparam);
+    worker_->JoinFinished();
+    return true;
+  });
+  return core::Ok();
+}
+
+void ModuleHostAdapter::Deactivate() {
+  if (worker_ == nullptr) return;
+  worker_->InvalidateGeneration(generation_);
+  worker_->JoinFinished();
+  MSG message{};
+  const HWND window = window_ != nullptr ? static_cast<HWND>(window_->hwnd()) : nullptr;
+  if (window != nullptr) {
+    while (PeekMessageW(&message, window, completion_message_, completion_message_, PM_REMOVE)) {
+      worker::Worker::Settle(message.lParam);
+    }
+  }
+}
+
+bool ModuleHostAdapter::Idle() {
+  if (worker_ == nullptr) return true;
+  worker_->JoinFinished();
+  return worker_->ThreadCount() == 0;
+}
+
+void ModuleHostAdapter::Shutdown() {
+  if (worker_ == nullptr) return;
+  Deactivate();
+  worker_->Shutdown();
+  MSG message{};
+  const HWND window = window_ != nullptr ? static_cast<HWND>(window_->hwnd()) : nullptr;
+  if (window != nullptr) {
+    while (PeekMessageW(&message, window, completion_message_, completion_message_, PM_REMOVE)) {
+      worker::Worker::Settle(message.lParam);
+    }
+    window_->set_native_message_handler({});
+  }
+  worker_.reset();
+  generation_ = 0;
+}
+
+std::wstring ModuleHostAdapter::DefaultDirectory() const { return paths::ExecutableDir(); }
+
+std::optional<std::wstring> ModuleHostAdapter::PickFolder(std::wstring_view initial_path) {
+  return folder_picker::Pick(window_ != nullptr ? window_->hwnd() : nullptr, initial_path);
+}
+
+void ModuleHostAdapter::RunBackground(modules::BackgroundWork work,
+                                      modules::BackgroundComplete complete) {
+  if (worker_ == nullptr || !work) return;
+  worker_->Submit(
+      [this, work = std::move(work)](const std::atomic<bool>& cancelled) {
+        return std::make_shared<core::Status>(work(*this, cancelled));
+      },
+      [complete = std::move(complete)](std::shared_ptr<void> cargo) {
+        const auto status = std::static_pointer_cast<core::Status>(std::move(cargo));
+        if (complete && status != nullptr) complete(*status);
+      },
+      generation_);
+}
+
+void ModuleHostAdapter::Publish(ui::application::UiPatch patch) {
+  if (parent_ != nullptr) parent_->ApplyPatch(patch);
+}
+
+void ModuleHostAdapter::CloseWindowIfUnpinned() {
+  if (window_ != nullptr && window_->alive() && !window_->pinned()) {
+    window_->Close();
+  }
+}
+
+bool ModuleHostAdapter::DirectoryExists(std::wstring_view path) const {
+  return paths::DirectoryExists(path);
+}
+
+bool ModuleHostAdapter::FileExists(std::wstring_view path) const {
+  return paths::FileExists(path);
+}
+
+core::Status ModuleHostAdapter::StartProcess(const modules::ProcessRequest& request) const {
+  return process::Start(request);
+}
+
+core::Status ModuleHostAdapter::RunProcess(const modules::ProcessRequest& request,
+                                           std::wstring* standard_output) const {
+  return process::Run(request, standard_output);
+}
+
+}  // namespace orchestrator

--- a/src/orchestrator/module_host.h
+++ b/src/orchestrator/module_host.h
@@ -1,0 +1,57 @@
+#pragma once
+
+#include <cstdint>
+#include <memory>
+
+#include "parent/logic/module_contract.h"
+
+namespace shell {
+class AppWindow;
+}
+
+namespace ui::containers {
+class ParentUi;
+}
+
+namespace worker {
+class Worker;
+}
+
+namespace orchestrator {
+
+class ModuleHostAdapter final : public modules::ModuleHost,
+                                public modules::BackgroundCapabilities {
+ public:
+  ModuleHostAdapter(shell::AppWindow* window, ui::containers::ParentUi* parent);
+  ~ModuleHostAdapter() override;
+
+  ModuleHostAdapter(const ModuleHostAdapter&) = delete;
+  ModuleHostAdapter& operator=(const ModuleHostAdapter&) = delete;
+
+  core::Status Start();
+  void Deactivate();
+  bool Idle();
+  void Shutdown();
+
+  std::wstring DefaultDirectory() const override;
+  std::optional<std::wstring> PickFolder(std::wstring_view initial_path) override;
+  void RunBackground(modules::BackgroundWork work,
+                     modules::BackgroundComplete complete) override;
+  void Publish(ui::application::UiPatch patch) override;
+  void CloseWindowIfUnpinned() override;
+
+  bool DirectoryExists(std::wstring_view path) const override;
+  bool FileExists(std::wstring_view path) const override;
+  core::Status StartProcess(const modules::ProcessRequest& request) const override;
+  core::Status RunProcess(const modules::ProcessRequest& request,
+                          std::wstring* standard_output) const override;
+
+ private:
+  shell::AppWindow* window_ = nullptr;
+  ui::containers::ParentUi* parent_ = nullptr;
+  std::unique_ptr<worker::Worker> worker_;
+  unsigned int completion_message_ = 0;
+  std::uint64_t generation_ = 0;
+};
+
+}  // namespace orchestrator

--- a/src/orchestrator/window_orchestrator.cpp
+++ b/src/orchestrator/window_orchestrator.cpp
@@ -5,6 +5,10 @@
 #include <algorithm>
 
 #include "core/status.h"
+#include "orchestrator/module_host.h"
+#include "parent/logic/module_contract.h"
+#include "parent/ui/contracts/ui_action_registry.h"
+#include "parent/ui/runtime/parent_ui.h"
 #include "ui/app_window/app_window.h"
 #include "ui/settings/settings_window.h"
 
@@ -13,22 +17,46 @@ namespace orchestrator {
 struct WindowOrchestrator::WindowSession {
   shell::AppWindow window;
   ui::settings::SettingsWindow settings;
+  ui::containers::ParentUi parent_ui;
+  ui::application::UiActionRegistry actions;
+  std::unique_ptr<ModuleHostAdapter> host;
+  std::unique_ptr<modules::ModuleController> module;
+
+  ~WindowSession() {
+    if (host != nullptr) host->Shutdown();
+    parent_ui.Detach();
+  }
 };
 
 WindowOrchestrator::WindowOrchestrator(
-    void* instance, const ui::config::ResolvedUiDocument* settings_document)
-    : instance_(instance), settings_document_(settings_document) {}
+    void* instance, const ui::config::ResolvedUiDocument* settings_document,
+    const ui::config::ResolvedUiDocument* feature_document,
+    const modules::ModuleDescriptor* feature)
+    : instance_(instance),
+      settings_document_(settings_document),
+      feature_document_(feature_document),
+      feature_(feature) {}
 
 WindowOrchestrator::~WindowOrchestrator() { CloseAll(); }
 
 bool WindowOrchestrator::OpenWindow() {
-  if (instance_ == nullptr || settings_document_ == nullptr) return false;
+  if (instance_ == nullptr || settings_document_ == nullptr || feature_document_ == nullptr ||
+      feature_ == nullptr || feature_->create == nullptr) {
+    return false;
+  }
   std::erase_if(windows_, [](const std::unique_ptr<WindowSession>& item) {
-    return !item->window.alive();
+    return !item->window.alive() && (item->host == nullptr || item->host->Idle());
   });
 
   auto item = std::make_unique<WindowSession>();
   if (!item->window.Create(instance_, 400.0f, 360.0f)) return false;
+  item->host = std::make_unique<ModuleHostAdapter>(&item->window, &item->parent_ui);
+  if (!item->host->Start().ok()) return false;
+  item->module = feature_->create();
+  if (item->module == nullptr) return false;
+  item->parent_ui.ApplyPatch(item->module->InitialState(*item->host));
+  if (!item->module->Bind(item->host.get(), &item->actions).ok()) return false;
+  if (!item->parent_ui.Attach(&item->window, feature_document_, &item->actions).ok()) return false;
   WindowSession* const paired = item.get();
   item->window.set_settings_handler([this, paired] {
     const core::Status opened =
@@ -39,6 +67,8 @@ bool WindowOrchestrator::OpenWindow() {
     }
   });
   item->window.set_close_handler([paired] {
+    if (paired->host != nullptr) paired->host->Deactivate();
+    paired->parent_ui.Detach();
     paired->settings.Close();
     paired->window.Destroy();
   });

--- a/src/orchestrator/window_orchestrator.h
+++ b/src/orchestrator/window_orchestrator.h
@@ -7,13 +7,19 @@ namespace ui::config {
 class ResolvedUiDocument;
 }
 
+namespace modules {
+struct ModuleDescriptor;
+}
+
 namespace orchestrator {
 
 // Owns production window composition. The tray only requests a new app
 // window; pairing AppWindow with its core Settings window belongs here.
 class WindowOrchestrator final {
  public:
-  WindowOrchestrator(void* instance, const ui::config::ResolvedUiDocument* settings_document);
+  WindowOrchestrator(void* instance, const ui::config::ResolvedUiDocument* settings_document,
+                     const ui::config::ResolvedUiDocument* feature_document,
+                     const modules::ModuleDescriptor* feature);
   ~WindowOrchestrator();
 
   WindowOrchestrator(const WindowOrchestrator&) = delete;
@@ -27,6 +33,8 @@ class WindowOrchestrator final {
 
   void* instance_ = nullptr;
   const ui::config::ResolvedUiDocument* settings_document_ = nullptr;
+  const ui::config::ResolvedUiDocument* feature_document_ = nullptr;
+  const modules::ModuleDescriptor* feature_ = nullptr;
   std::vector<std::unique_ptr<WindowSession>> windows_;
 };
 

--- a/src/parent/logic/module_contract.h
+++ b/src/parent/logic/module_contract.h
@@ -1,0 +1,63 @@
+#pragma once
+
+#include <atomic>
+#include <functional>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "core/status.h"
+#include "parent/ui/contracts/ui_action_registry.h"
+
+namespace modules {
+
+struct ProcessRequest {
+  std::wstring executable;
+  std::vector<std::wstring> arguments;
+  std::wstring working_directory;
+  bool elevated = false;
+  bool hidden = false;
+};
+
+class BackgroundCapabilities {
+ public:
+  virtual ~BackgroundCapabilities() = default;
+  virtual bool DirectoryExists(std::wstring_view path) const = 0;
+  virtual bool FileExists(std::wstring_view path) const = 0;
+  virtual core::Status StartProcess(const ProcessRequest& request) const = 0;
+  virtual core::Status RunProcess(const ProcessRequest& request,
+                                  std::wstring* standard_output) const = 0;
+};
+
+using BackgroundWork = std::function<core::Status(
+    const BackgroundCapabilities& capabilities, const std::atomic<bool>& cancelled)>;
+using BackgroundComplete = std::function<void(const core::Status& status)>;
+
+class ModuleHost {
+ public:
+  virtual ~ModuleHost() = default;
+  virtual std::wstring DefaultDirectory() const = 0;
+  virtual std::optional<std::wstring> PickFolder(std::wstring_view initial_path) = 0;
+  virtual void RunBackground(BackgroundWork work, BackgroundComplete complete) = 0;
+  virtual void Publish(ui::application::UiPatch patch) = 0;
+  virtual void CloseWindowIfUnpinned() = 0;
+};
+
+class ModuleController {
+ public:
+  virtual ~ModuleController() = default;
+  virtual ui::application::UiPatch InitialState(const ModuleHost& host) const = 0;
+  virtual core::Status Bind(ModuleHost* host,
+                            ui::application::UiActionRegistry* actions) = 0;
+};
+
+struct ModuleDescriptor {
+  std::wstring_view id;
+  std::wstring_view route_id;
+  std::wstring_view screen_name;
+  int ui_resource_id = 0;
+  std::unique_ptr<ModuleController> (*create)() = nullptr;
+};
+
+}  // namespace modules

--- a/src/parent/logic/module_registry.cpp
+++ b/src/parent/logic/module_registry.cpp
@@ -1,0 +1,35 @@
+#include "parent/logic/module_registry.h"
+
+#include <algorithm>
+
+namespace modules {
+namespace {
+
+std::vector<const ModuleDescriptor*>& Descriptors() {
+  static std::vector<const ModuleDescriptor*> descriptors;
+  return descriptors;
+}
+
+}  // namespace
+
+bool ModuleRegistry::Register(const ModuleDescriptor* descriptor) {
+  if (descriptor == nullptr || descriptor->id.empty() || descriptor->route_id.empty() ||
+      descriptor->screen_name.empty() || descriptor->ui_resource_id <= 0 ||
+      descriptor->create == nullptr || Find(descriptor->id) != nullptr) {
+    return false;
+  }
+  Descriptors().push_back(descriptor);
+  return true;
+}
+
+const std::vector<const ModuleDescriptor*>& ModuleRegistry::All() { return Descriptors(); }
+
+const ModuleDescriptor* ModuleRegistry::Find(std::wstring_view id) {
+  const auto& descriptors = Descriptors();
+  const auto found = std::find_if(descriptors.begin(), descriptors.end(), [id](const auto* item) {
+    return item != nullptr && item->id == id;
+  });
+  return found == descriptors.end() ? nullptr : *found;
+}
+
+}  // namespace modules

--- a/src/parent/logic/module_registry.h
+++ b/src/parent/logic/module_registry.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <vector>
+
+#include "parent/logic/module_contract.h"
+
+namespace modules {
+
+class ModuleRegistry final {
+ public:
+  static bool Register(const ModuleDescriptor* descriptor);
+  static const std::vector<const ModuleDescriptor*>& All();
+  static const ModuleDescriptor* Find(std::wstring_view id);
+};
+
+class ModuleRegistrar final {
+ public:
+  explicit ModuleRegistrar(const ModuleDescriptor* descriptor) {
+    registered_ = ModuleRegistry::Register(descriptor);
+  }
+  bool registered() const { return registered_; }
+
+ private:
+  bool registered_ = false;
+};
+
+}  // namespace modules

--- a/src/parent/ui/config/embedded_settings_loader.cpp
+++ b/src/parent/ui/config/embedded_settings_loader.cpp
@@ -45,4 +45,26 @@ core::Status LoadEmbeddedSettingsDocument(
                          diagnostics, document);
 }
 
+core::Status LoadEmbeddedFeatureDocument(
+    void* module_handle, const std::vector<EmbeddedScreenResource>& resources,
+    std::vector<Diagnostic>* diagnostics,
+    std::unique_ptr<ResolvedUiDocument>* document) {
+  if (resources.empty()) {
+    return DHEPZ_ERR(core::ErrorCode::NotFound, L"No feature UI resource is registered");
+  }
+  HMODULE module = static_cast<HMODULE>(module_handle);
+  std::wstring core_text;
+  DHEPZ_RETURN_IF_ERROR(ReadResource(module, IDR_UI_CORE_JSON, &core_text));
+  json::Value core_value;
+  DHEPZ_RETURN_IF_ERROR(json::Parse(core_text, &core_value));
+  std::vector<ScreenSource> sources;
+  sources.reserve(resources.size());
+  for (const EmbeddedScreenResource& resource : resources) {
+    std::wstring text;
+    DHEPZ_RETURN_IF_ERROR(ReadResource(module, resource.resource_id, &text));
+    sources.push_back({resource.name, std::move(text)});
+  }
+  return ResolveDocument(core_value, sources, diagnostics, document);
+}
+
 }  // namespace ui::config

--- a/src/parent/ui/config/embedded_settings_loader.h
+++ b/src/parent/ui/config/embedded_settings_loader.h
@@ -8,8 +8,18 @@
 
 namespace ui::config {
 
+struct EmbeddedScreenResource {
+  std::wstring name;
+  int resource_id = 0;
+};
+
 core::Status LoadEmbeddedSettingsDocument(
     void* module, std::vector<Diagnostic>* diagnostics,
+    std::unique_ptr<ResolvedUiDocument>* document);
+
+core::Status LoadEmbeddedFeatureDocument(
+    void* module, const std::vector<EmbeddedScreenResource>& resources,
+    std::vector<Diagnostic>* diagnostics,
     std::unique_ptr<ResolvedUiDocument>* document);
 
 }  // namespace ui::config

--- a/src/parent/ui/config/resolved_ui_document.cpp
+++ b/src/parent/ui/config/resolved_ui_document.cpp
@@ -6,6 +6,30 @@
 namespace ui::config {
 namespace {
 
+bool ParseHexColor(const std::wstring& text, Rgba* out) {
+  if (out == nullptr || (text.size() != 7 && text.size() != 9) || text[0] != L'#') return false;
+  auto nibble = [](wchar_t value, unsigned int* out_value) {
+    if (value >= L'0' && value <= L'9') *out_value = static_cast<unsigned int>(value - L'0');
+    else if (value >= L'a' && value <= L'f') *out_value = static_cast<unsigned int>(value - L'a' + 10);
+    else if (value >= L'A' && value <= L'F') *out_value = static_cast<unsigned int>(value - L'A' + 10);
+    else return false;
+    return true;
+  };
+  unsigned int channels[4]{0, 0, 0, 255};
+  const int count = text.size() == 9 ? 4 : 3;
+  for (int channel = 0; channel < count; ++channel) {
+    unsigned int high = 0;
+    unsigned int low = 0;
+    if (!nibble(text[1 + channel * 2], &high) || !nibble(text[2 + channel * 2], &low)) {
+      return false;
+    }
+    channels[channel] = high * 16 + low;
+  }
+  *out = {static_cast<unsigned char>(channels[0]), static_cast<unsigned char>(channels[1]),
+          static_cast<unsigned char>(channels[2]), static_cast<unsigned char>(channels[3])};
+  return true;
+}
+
 const json::Value* CatalogProperties(const json::Value& core, std::wstring_view type) {
   const json::Value* components = core.ObjectField(L"components");
   const json::Value* catalog = components != nullptr ? components->Find(type) : nullptr;
@@ -85,6 +109,20 @@ const Route* ResolvedUiDocument::FindRoute(std::wstring_view route) const {
   return found == routes_.end() ? nullptr : &*found;
 }
 
+bool ResolvedUiDocument::Token(std::wstring_view theme, std::wstring_view name,
+                               Rgba* color) const {
+  for (std::size_t index = 0; index < theme_names_.size(); ++index) {
+    if (theme_names_[index] != theme) continue;
+    for (const auto& [token, value] : theme_tokens_[index]) {
+      if (token == name) {
+        if (color != nullptr) *color = value;
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
 core::Status ResolveDocument(const json::Value& core, const std::vector<ScreenSource>& sources,
                              std::vector<Diagnostic>* diagnostics,
                              std::unique_ptr<ResolvedUiDocument>* document) {
@@ -95,6 +133,22 @@ core::Status ResolveDocument(const json::Value& core, const std::vector<ScreenSo
   document->reset();
   DHEPZ_RETURN_IF_ERROR(ValidateCore(core, diagnostics));
   auto resolved = std::make_unique<ResolvedUiDocument>();
+  const json::Value* tokens = core.ObjectField(L"tokens");
+  if (tokens != nullptr) {
+    for (const auto& [theme_name, theme] : tokens->members()) {
+      std::vector<std::pair<std::wstring, Rgba>> colors;
+      if (theme.is_object()) {
+        for (const auto& [token_name, encoded] : theme.members()) {
+          Rgba color;
+          if (encoded.is_string() && ParseHexColor(encoded.AsString(), &color)) {
+            colors.emplace_back(token_name, color);
+          }
+        }
+      }
+      resolved->theme_names_.push_back(theme_name);
+      resolved->theme_tokens_.push_back(std::move(colors));
+    }
+  }
   std::wstring requested_initial_route;
   for (const ScreenSource& source : sources) {
     json::Value parsed;
@@ -117,7 +171,23 @@ core::Status ResolveDocument(const json::Value& core, const std::vector<ScreenSo
           return DHEPZ_ERR(core::ErrorCode::AlreadyExists,
                            L"duplicate UI route '" + route_id + L"'");
         }
-        resolved->routes_.push_back({route_id, BuildNode(core, item)});
+        Route route;
+        route.id = route_id;
+        route.root = BuildNode(core, item);
+        const std::wstring backdrop = item.StringField(L"backdrop");
+        if (!backdrop.empty()) {
+          if (backdrop.rfind(L"screen:", 0) == 0) {
+            route.backdrop_kind = Route::BackdropKind::Screen;
+            route.backdrop_value = backdrop.substr(7);
+          } else {
+            Rgba ignored;
+            route.backdrop_kind = resolved->Token(L"dark", backdrop, &ignored)
+                                      ? Route::BackdropKind::Color
+                                      : Route::BackdropKind::Image;
+            route.backdrop_value = backdrop;
+          }
+        }
+        resolved->routes_.push_back(std::move(route));
         return core::Ok();
       }
       const json::Value* children = item.ArrayField(L"children");
@@ -134,6 +204,13 @@ core::Status ResolveDocument(const json::Value& core, const std::vector<ScreenSo
   }
   if (resolved->routes_.empty()) {
     return DHEPZ_ERR(core::ErrorCode::NotFound, L"required UI route is missing");
+  }
+  for (const Route& route : resolved->routes_) {
+    if (route.backdrop_kind == Route::BackdropKind::Screen &&
+        (route.backdrop_value == route.id || resolved->FindRoute(route.backdrop_value) == nullptr)) {
+      return DHEPZ_ERR(core::ErrorCode::InvalidArgument,
+                       L"backdrop screen '" + route.backdrop_value + L"' is invalid");
+    }
   }
   if (!requested_initial_route.empty()) {
     if (resolved->FindRoute(requested_initial_route) == nullptr) {

--- a/src/parent/ui/config/resolved_ui_document.h
+++ b/src/parent/ui/config/resolved_ui_document.h
@@ -11,6 +11,13 @@
 
 namespace ui::config {
 
+struct Rgba {
+  unsigned char r = 0;
+  unsigned char g = 0;
+  unsigned char b = 0;
+  unsigned char a = 255;
+};
+
 struct ScreenSource {
   std::wstring name;
   std::wstring text;
@@ -41,7 +48,11 @@ class ComponentNode {
 };
 
 struct Route {
+  enum class BackdropKind { None, Color, Image, Screen };
+
   std::wstring id;
+  BackdropKind backdrop_kind = BackdropKind::None;
+  std::wstring backdrop_value;
   ComponentNode root;
 };
 
@@ -49,6 +60,7 @@ class ResolvedUiDocument final {
  public:
   const Route* FindRoute(std::wstring_view route) const;
   const std::wstring& initial_route() const { return initial_route_; }
+  bool Token(std::wstring_view theme, std::wstring_view name, Rgba* color) const;
 
  private:
   friend core::Status ResolveDocument(const json::Value&, const std::vector<ScreenSource>&,
@@ -56,6 +68,8 @@ class ResolvedUiDocument final {
                                       std::unique_ptr<ResolvedUiDocument>*);
   std::vector<Route> routes_;
   std::wstring initial_route_;
+  std::vector<std::wstring> theme_names_;
+  std::vector<std::vector<std::pair<std::wstring, Rgba>>> theme_tokens_;
 };
 
 core::Status ResolveDocument(const json::Value& core, const std::vector<ScreenSource>& sources,

--- a/src/parent/ui/contracts/ui_state.cpp
+++ b/src/parent/ui/contracts/ui_state.cpp
@@ -17,14 +17,18 @@ void UiState::Set(std::wstring path, UiValue value) {
   });
   if (found == values_.end()) {
     values_.emplace_back(std::move(path), std::move(value));
+    ++revision_;
   } else {
+    if (found->second == value) return;
     found->second = std::move(value);
+    ++revision_;
   }
 }
 
 bool UiState::Apply(const UiPatch& patch) {
+  const std::uint64_t before = revision_;
   for (const UiChange& change : patch.changes) Set(change.path, change.value);
-  return !patch.empty();
+  return revision_ != before || !patch.route.empty();
 }
 
 bool UiState::Bool(std::wstring_view path, bool fallback) const {

--- a/src/parent/ui/contracts/ui_state.h
+++ b/src/parent/ui/contracts/ui_state.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <string_view>
 #include <vector>
 
@@ -17,9 +18,11 @@ class UiState final {
   long long Integer(std::wstring_view path, long long fallback = 0) const;
   std::wstring Text(std::wstring_view path, std::wstring_view fallback = {}) const;
   const std::vector<std::wstring>* Strings(std::wstring_view path) const;
+  std::uint64_t revision() const { return revision_; }
 
  private:
   std::vector<std::pair<std::wstring, UiValue>> values_;
+  std::uint64_t revision_ = 0;
 };
 
 }  // namespace ui::application

--- a/src/parent/ui/runtime/focus_coordinator.cpp
+++ b/src/parent/ui/runtime/focus_coordinator.cpp
@@ -34,6 +34,8 @@ void FocusCoordinator::Clear() {
   index_ = kNoFocus;
 }
 
+void FocusCoordinator::Blur() { index_ = kNoFocus; }
+
 void FocusCoordinator::Rebuild(const layout::LayoutNode* tree) {
   const config::ComponentNode* previous = current();
   order_.clear();

--- a/src/parent/ui/runtime/focus_coordinator.h
+++ b/src/parent/ui/runtime/focus_coordinator.h
@@ -14,6 +14,7 @@ class FocusCoordinator final {
   explicit FocusCoordinator(const components::ComponentRegistry* registry);
 
   void Clear();
+  void Blur();
   void Rebuild(const layout::LayoutNode* tree);
   const config::ComponentNode* current() const;
   bool Focus(const config::ComponentNode* node);

--- a/src/parent/ui/runtime/layout_engine.cpp
+++ b/src/parent/ui/runtime/layout_engine.cpp
@@ -57,10 +57,17 @@ LayoutEngine::LayoutEngine(render::RenderBackend* backend,
     : backend_(backend), registry_(registry), state_(state) {}
 
 render::Size LayoutEngine::Measure(const config::ComponentNode& node, float max_width) {
+  const auto cached = std::find_if(measurement_cache_.begin(), measurement_cache_.end(),
+                                   [&node, max_width](const auto& entry) {
+                                     return entry.first == &node && entry.second.first == max_width;
+                                   });
+  if (cached != measurement_cache_.end()) return cached->second.second;
   const components::ComponentDescriptor* descriptor = registry_->Find(node.type());
-  return descriptor != nullptr && descriptor->measure != nullptr
-             ? descriptor->measure(node, *backend_, *state_, max_width)
-             : render::Size{max_width, 0.0f};
+  const render::Size measured = descriptor != nullptr && descriptor->measure != nullptr
+                                    ? descriptor->measure(node, *backend_, *state_, max_width)
+                                    : render::Size{max_width, 0.0f};
+  measurement_cache_.push_back({&node, {max_width, measured}});
+  return measured;
 }
 
 LayoutNode LayoutEngine::BuildGrid(const config::ComponentNode& node, render::Rect bounds,
@@ -236,9 +243,23 @@ LayoutNode LayoutEngine::Build(const config::ComponentNode& node,
 
 const LayoutNode& LayoutEngine::LayoutRoute(const config::ResolvedUiDocument& document,
                                             std::wstring_view route, render::Size size) {
+  const std::uint64_t revision = state_ != nullptr ? state_->revision() : 0;
+  if (cache_valid_ && cache_document_ == &document && cache_route_ == route &&
+      cache_size_.width == size.width && cache_size_.height == size.height &&
+      cache_revision_ == revision) {
+    return tree_;
+  }
+  if (cache_document_ != &document || cache_revision_ != revision) {
+    measurement_cache_.clear();
+  }
   tree_ = {};
   const config::Route* found = document.FindRoute(route);
   if (found != nullptr) tree_ = Build(found->root, {0.0f, 0.0f, size.width, size.height});
+  cache_document_ = &document;
+  cache_route_ = std::wstring(route);
+  cache_size_ = size;
+  cache_revision_ = revision;
+  cache_valid_ = true;
   return tree_;
 }
 

--- a/src/parent/ui/runtime/layout_engine.h
+++ b/src/parent/ui/runtime/layout_engine.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstdint>
+#include <utility>
 #include <vector>
 
 #include "render/render_backend.h"
@@ -37,6 +39,13 @@ class LayoutEngine final {
   const components::ComponentRegistry* registry_;
   const application::UiState* state_;
   LayoutNode tree_;
+  const config::ResolvedUiDocument* cache_document_ = nullptr;
+  std::wstring cache_route_;
+  render::Size cache_size_{};
+  std::uint64_t cache_revision_ = 0;
+  bool cache_valid_ = false;
+  std::vector<std::pair<const config::ComponentNode*, std::pair<float, render::Size>>>
+      measurement_cache_;
 };
 
 }  // namespace ui::layout

--- a/src/parent/ui/runtime/parent_ui.cpp
+++ b/src/parent/ui/runtime/parent_ui.cpp
@@ -33,9 +33,20 @@ core::Status ParentUi::Attach(shell::AppWindow* window,
       [this](float x, float y) { return presenter_->HandleDown(x, y); });
   window_->set_content_click_handler(
       [this](float x, float y) { return presenter_->HandleClick(x, y); });
+  window_->set_content_double_click_handler(
+      [this](float x, float y) { return presenter_->HandleDoubleClick(x, y); });
+  window_->set_content_context_handler([this](float x, float y) {
+    return presenter_->HandleContext(x, y, window_ != nullptr ? window_->hwnd() : nullptr);
+  });
   window_->set_content_wheel_handler(
       [this](float x, float y, int delta) { return presenter_->HandleWheel(x, y, delta); });
   return core::Ok();
+}
+
+bool ParentUi::ApplyPatch(const application::UiPatch& patch) {
+  const bool changed = state_.Apply(patch);
+  if (changed && window_ != nullptr) window_->RequestRepaint();
+  return changed;
 }
 
 void ParentUi::Detach() {
@@ -47,6 +58,8 @@ void ParentUi::Detach() {
     window_->set_content_move_handler({});
     window_->set_content_down_handler({});
     window_->set_content_click_handler({});
+    window_->set_content_double_click_handler({});
+    window_->set_content_context_handler({});
     window_->set_content_wheel_handler({});
   }
   presenter_.reset();

--- a/src/parent/ui/runtime/parent_ui.h
+++ b/src/parent/ui/runtime/parent_ui.h
@@ -27,6 +27,7 @@ class ParentUi final {
 
   core::Status Attach(shell::AppWindow* window, const config::ResolvedUiDocument* document,
                       application::UiActionRegistry* actions);
+  bool ApplyPatch(const application::UiPatch& patch);
   void Detach();
 
  private:

--- a/src/parent/ui/runtime/screen_presenter.cpp
+++ b/src/parent/ui/runtime/screen_presenter.cpp
@@ -1,5 +1,7 @@
 #include "parent/ui/runtime/screen_presenter.h"
 
+#include <algorithm>
+#include <utility>
 #include <windows.h>
 
 namespace ui::presenter {
@@ -10,6 +12,7 @@ ScreenPresenter::ScreenPresenter(render::RenderBackend* backend, application::Ui
       state_(state),
       actions_(actions),
       layout_(backend, &registry_, state),
+      backdrop_layout_(backend, &registry_, state),
       focus_(&registry_) {}
 
 void ScreenPresenter::SetDocument(const config::ResolvedUiDocument* document) {
@@ -20,6 +23,31 @@ void ScreenPresenter::SetDocument(const config::ResolvedUiDocument* document) {
   hovered_ = nullptr;
   pressed_ = nullptr;
   expanded_ = nullptr;
+  ApplyDocumentPalette();
+}
+
+void ScreenPresenter::ApplyDocumentPalette() {
+  if (document_ == nullptr) return;
+  auto assign = [this](std::wstring_view name, render::Color* target) {
+    config::Rgba value;
+    if (document_->Token(L"dark", name, &value)) {
+      *target = {value.r, value.g, value.b, value.a};
+    }
+  };
+  assign(L"surface", &palette_.surface);
+  assign(L"surface_alt", &palette_.control);
+  assign(L"border", &palette_.border);
+  assign(L"text", &palette_.text);
+  assign(L"accent", &palette_.focus);
+  assign(L"danger", &palette_.danger);
+  auto lighter = [](render::Color source, int amount) {
+    const auto channel = [amount](unsigned char value) {
+      return static_cast<unsigned char>(std::min(255, static_cast<int>(value) + amount));
+    };
+    return render::Color{channel(source.r), channel(source.g), channel(source.b), source.a};
+  };
+  palette_.control_hover = lighter(palette_.control, 14);
+  palette_.control_pressed = lighter(palette_.control, 28);
 }
 
 void ScreenPresenter::Prepare(render::Size size) {
@@ -34,6 +62,7 @@ void ScreenPresenter::Prepare(render::Size size) {
 void ScreenPresenter::Paint(const render::Rect& viewport) {
   if (tree_ == nullptr) return;
   backend_->PushTranslation({viewport.x, viewport.y});
+  PaintBackdrop();
   PaintNode(*tree_);
   if (expanded_ != nullptr) {
     const layout::LayoutNode* anchor = FindSource(*tree_, expanded_);
@@ -44,6 +73,33 @@ void ScreenPresenter::Paint(const render::Rect& viewport) {
     }
   }
   backend_->PopTranslation();
+}
+
+void ScreenPresenter::PaintBackdrop() {
+  if (document_ == nullptr) return;
+  const config::Route* route = document_->FindRoute(route_);
+  if (route == nullptr || route->backdrop_kind == config::Route::BackdropKind::None) return;
+  const render::Rect full{0.0f, 0.0f, viewport_size_.width, viewport_size_.height};
+  if (route->backdrop_kind == config::Route::BackdropKind::Color) {
+    config::Rgba color;
+    if (document_->Token(L"dark", route->backdrop_value, &color)) {
+      backend_->FillRect(full, {color.r, color.g, color.b, color.a});
+    }
+    return;
+  }
+  if (route->backdrop_kind == config::Route::BackdropKind::Image) {
+    const render::ImageHandle image = backend_->LoadImageFile(route->backdrop_value);
+    if (image != render::ImageHandle::Invalid) {
+      backend_->DrawImage(image, full, 1.0f);
+      backend_->ReleaseImage(image);
+    }
+    return;
+  }
+  if (route->backdrop_kind == config::Route::BackdropKind::Screen) {
+    const layout::LayoutNode& backdrop =
+        backdrop_layout_.LayoutRoute(*document_, route->backdrop_value, viewport_size_);
+    PaintNode(backdrop);
+  }
 }
 
 void ScreenPresenter::PaintNode(const layout::LayoutNode& node) {
@@ -119,14 +175,19 @@ bool ScreenPresenter::HandleMove(float x, float y) {
 
 bool ScreenPresenter::HandleDown(float x, float y) {
   if (expanded_ != nullptr) {
-    pressed_ = nullptr;
+    const layout::LayoutNode* hit = tree_ != nullptr ? Hit(*tree_, x, y) : nullptr;
+    pressed_ = hit != nullptr ? hit->source : nullptr;
     return true;
   }
   const layout::LayoutNode* hit = tree_ != nullptr ? Hit(*tree_, x, y) : nullptr;
   const config::ComponentNode* next = hit != nullptr ? hit->source : nullptr;
   const bool changed = pressed_ != next;
   pressed_ = next;
-  if (next != nullptr) focus_.Focus(next);
+  if (next != nullptr) {
+    focus_.Focus(next);
+  } else {
+    focus_.Blur();
+  }
   return changed || next != nullptr;
 }
 
@@ -159,24 +220,31 @@ bool ScreenPresenter::Activate(const config::ComponentNode* node) {
 
 bool ScreenPresenter::HandleClick(float x, float y) {
   if (tree_ == nullptr) return false;
+  bool dismissed_overlay = false;
   if (expanded_ != nullptr) {
     const layout::LayoutNode* anchor = FindSource(*tree_, expanded_);
     const components::ComponentDescriptor* descriptor = registry_.Find(expanded_->type());
+    components::ComponentResult overlay_result;
     if (anchor != nullptr && descriptor != nullptr && descriptor->overlay_pointer != nullptr) {
-      Dispatch(descriptor->overlay_pointer(*expanded_, *state_, {x, y}, anchor->bounds,
-                                           viewport_size_));
+      overlay_result = descriptor->overlay_pointer(*expanded_, *state_, {x, y},
+                                                   anchor->bounds, viewport_size_);
     }
     expanded_ = nullptr;
     hovered_ = nullptr;
-    pressed_ = nullptr;
-    return true;
+    dismissed_overlay = true;
+    if (overlay_result.handled || !overlay_result.patch.empty() ||
+        !overlay_result.event.action.empty()) {
+      pressed_ = nullptr;
+      return Dispatch(std::move(overlay_result));
+    }
   }
 
   if (const layout::LayoutNode* dialog = FindDialog(*tree_)) {
     const components::ComponentDescriptor* descriptor = registry_.Find(dialog->source->type());
     if (descriptor != nullptr && descriptor->pointer != nullptr) {
       const components::ComponentResult result =
-          descriptor->pointer(*dialog->source, *state_, {x, y}, dialog->bounds);
+          descriptor->pointer(*dialog->source, *state_, {x, y}, dialog->bounds,
+                              *backend_);
       if (result.handled || !result.patch.empty() || !result.event.action.empty()) {
         pressed_ = nullptr;
         return Dispatch(result);
@@ -188,17 +256,55 @@ bool ScreenPresenter::HandleClick(float x, float y) {
   const config::ComponentNode* released = hit != nullptr ? hit->source : nullptr;
   const config::ComponentNode* pressed = pressed_;
   pressed_ = nullptr;
-  if (released == nullptr || released != pressed || hit == nullptr) return pressed != nullptr;
+  if (released == nullptr || released != pressed || hit == nullptr) {
+    return dismissed_overlay || pressed != nullptr;
+  }
   const components::ComponentDescriptor* descriptor = registry_.Find(released->type());
-  if (descriptor == nullptr) return false;
-  if (descriptor->paint_overlay != nullptr) {
+  if (descriptor == nullptr) return dismissed_overlay;
+  const bool has_overlay = descriptor->paint_overlay != nullptr &&
+                           (descriptor->has_overlay == nullptr ||
+                            descriptor->has_overlay(*released, *state_));
+  if (has_overlay) {
+    if (descriptor->pointer != nullptr) {
+      Dispatch(descriptor->pointer(*released, *state_, {x, y}, hit->bounds,
+                                   *backend_));
+    }
     expanded_ = released;
     return true;
   }
   if (descriptor->pointer != nullptr) {
-    return Dispatch(descriptor->pointer(*released, *state_, {x, y}, hit->bounds));
+    return Dispatch(descriptor->pointer(*released, *state_, {x, y}, hit->bounds,
+                                        *backend_)) ||
+           dismissed_overlay;
   }
-  return Activate(released);
+  return Activate(released) || dismissed_overlay;
+}
+
+bool ScreenPresenter::HandleDoubleClick(float x, float y) {
+  const layout::LayoutNode* hit = tree_ != nullptr ? Hit(*tree_, x, y) : nullptr;
+  if (hit == nullptr || hit->source == nullptr) return false;
+  focus_.Focus(hit->source);
+  const components::ComponentDescriptor* descriptor = registry_.Find(hit->source->type());
+  return descriptor != nullptr && descriptor->double_click != nullptr
+             ? Dispatch(descriptor->double_click(*hit->source, *state_))
+             : false;
+}
+
+bool ScreenPresenter::HandleContext(float x, float y, void* owner_window) {
+  const config::ComponentNode* target = nullptr;
+  if (x >= 0.0f && y >= 0.0f && tree_ != nullptr) {
+    const layout::LayoutNode* hit = Hit(*tree_, x, y);
+    target = hit != nullptr ? hit->source : nullptr;
+  } else {
+    target = focus_.current();
+  }
+  if (target == nullptr) return false;
+  focus_.Focus(target);
+  expanded_ = nullptr;
+  const components::ComponentDescriptor* descriptor = registry_.Find(target->type());
+  return descriptor != nullptr && descriptor->context_menu != nullptr
+             ? Dispatch(descriptor->context_menu(*target, *state_, owner_window))
+             : false;
 }
 
 bool ScreenPresenter::HandleKey(int virtual_key) {
@@ -227,6 +333,7 @@ bool ScreenPresenter::HandleKey(int virtual_key) {
     return true;
   }
   if (descriptor != nullptr && descriptor->paint_overlay != nullptr &&
+      (descriptor->has_overlay == nullptr || descriptor->has_overlay(*current, *state_)) &&
       (virtual_key == VK_RETURN || virtual_key == VK_SPACE)) {
     expanded_ = expanded_ == current ? nullptr : current;
     return true;

--- a/src/parent/ui/runtime/screen_presenter.h
+++ b/src/parent/ui/runtime/screen_presenter.h
@@ -24,6 +24,8 @@ class ScreenPresenter final {
   bool HandleMove(float x, float y);
   bool HandleDown(float x, float y);
   bool HandleClick(float x, float y);
+  bool HandleDoubleClick(float x, float y);
+  bool HandleContext(float x, float y, void* owner_window);
   bool HandleKey(int virtual_key);
   bool HandleText(wchar_t character);
   bool HandleWheel(float x, float y, int delta);
@@ -35,6 +37,8 @@ class ScreenPresenter final {
                                        const config::ComponentNode* source) const;
   const layout::LayoutNode* FindDialog(const layout::LayoutNode& node) const;
   void PaintNode(const layout::LayoutNode& node);
+  void PaintBackdrop();
+  void ApplyDocumentPalette();
   bool Activate(const config::ComponentNode* node);
   bool Dispatch(components::ComponentResult result);
 
@@ -43,6 +47,7 @@ class ScreenPresenter final {
   application::UiActionRegistry* actions_;
   components::ComponentRegistry registry_;
   layout::LayoutEngine layout_;
+  layout::LayoutEngine backdrop_layout_;
   focus::FocusCoordinator focus_;
   const config::ResolvedUiDocument* document_ = nullptr;
   const layout::LayoutNode* tree_ = nullptr;

--- a/src/platform/folder_picker.cpp
+++ b/src/platform/folder_picker.cpp
@@ -1,0 +1,48 @@
+#include "platform/folder_picker.h"
+
+#include <windows.h>
+#include <shobjidl.h>
+
+namespace folder_picker {
+
+std::optional<std::wstring> Pick(void* owner_window, std::wstring_view initial_path) {
+  const HRESULT initialized = CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED);
+  const bool uninitialize = initialized == S_OK || initialized == S_FALSE;
+  IFileOpenDialog* dialog = nullptr;
+  HRESULT result = CoCreateInstance(CLSID_FileOpenDialog, nullptr, CLSCTX_INPROC_SERVER,
+                                    IID_PPV_ARGS(&dialog));
+  if (FAILED(result) || dialog == nullptr) {
+    if (uninitialize) CoUninitialize();
+    return std::nullopt;
+  }
+  DWORD options = 0;
+  if (SUCCEEDED(dialog->GetOptions(&options))) {
+    dialog->SetOptions(options | FOS_PICKFOLDERS | FOS_FORCEFILESYSTEM);
+  }
+  dialog->SetTitle(L"Pilih folder untuk terminal");
+  if (!initial_path.empty()) {
+    IShellItem* initial = nullptr;
+    const std::wstring path(initial_path);
+    if (SUCCEEDED(SHCreateItemFromParsingName(path.c_str(), nullptr, IID_PPV_ARGS(&initial)))) {
+      dialog->SetFolder(initial);
+      initial->Release();
+    }
+  }
+  std::optional<std::wstring> selected;
+  if (SUCCEEDED(dialog->Show(static_cast<HWND>(owner_window)))) {
+    IShellItem* item = nullptr;
+    if (SUCCEEDED(dialog->GetResult(&item)) && item != nullptr) {
+      PWSTR raw = nullptr;
+      if (SUCCEEDED(item->GetDisplayName(SIGDN_FILESYSPATH, &raw)) && raw != nullptr) {
+        selected = std::wstring(raw);
+        CoTaskMemFree(raw);
+      }
+      item->Release();
+    }
+  }
+  dialog->Release();
+  if (uninitialize) CoUninitialize();
+  return selected;
+}
+
+}  // namespace folder_picker

--- a/src/platform/folder_picker.h
+++ b/src/platform/folder_picker.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <optional>
+#include <string>
+#include <string_view>
+
+namespace folder_picker {
+
+std::optional<std::wstring> Pick(void* owner_window, std::wstring_view initial_path);
+
+}  // namespace folder_picker

--- a/src/platform/process.cpp
+++ b/src/platform/process.cpp
@@ -1,0 +1,227 @@
+#include "platform/process.h"
+
+#include <windows.h>
+#include <shellapi.h>
+
+#include <algorithm>
+#include <string>
+#include <vector>
+
+#include "platform/strings.h"
+
+namespace process {
+namespace {
+
+std::wstring ErrorText(DWORD code) {
+  wchar_t* raw = nullptr;
+  const DWORD size = FormatMessageW(
+      FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+      nullptr, code, 0, reinterpret_cast<wchar_t*>(&raw), 0, nullptr);
+  std::wstring text = size != 0 && raw != nullptr ? std::wstring(raw, size) : L"error " + std::to_wstring(code);
+  if (raw != nullptr) LocalFree(raw);
+  while (!text.empty() && (text.back() == L'\r' || text.back() == L'\n' || text.back() == L' ')) {
+    text.pop_back();
+  }
+  return text;
+}
+
+std::wstring Arguments(const std::vector<std::wstring>& arguments) {
+  std::wstring command;
+  for (const std::wstring& argument : arguments) {
+    if (!command.empty()) command.push_back(L' ');
+    command.append(str::QuoteArg(argument));
+  }
+  return command;
+}
+
+core::Status ResolveExecutable(std::wstring_view requested, std::wstring* resolved) {
+  if (resolved == nullptr || requested.empty()) {
+    return DHEPZ_ERR(core::ErrorCode::InvalidArgument, L"Process executable is required");
+  }
+  const std::wstring name(requested);
+  if (name.find_first_of(L"\\/") != std::wstring::npos) {
+    const DWORD attributes = GetFileAttributesW(name.c_str());
+    if (attributes == INVALID_FILE_ATTRIBUTES || (attributes & FILE_ATTRIBUTE_DIRECTORY) != 0) {
+      return DHEPZ_ERR(core::ErrorCode::NotFound, L"Executable was not found: " + name);
+    }
+    *resolved = name;
+    return core::Ok();
+  }
+  std::vector<wchar_t> buffer(MAX_PATH);
+  for (;;) {
+    const DWORD length = SearchPathW(nullptr, name.c_str(), nullptr,
+                                     static_cast<DWORD>(buffer.size()), buffer.data(), nullptr);
+    if (length == 0) {
+      return DHEPZ_ERR(core::ErrorCode::NotFound, L"Executable was not found: " + name);
+    }
+    if (length < buffer.size()) {
+      resolved->assign(buffer.data(), length);
+      return core::Ok();
+    }
+    buffer.resize(static_cast<std::size_t>(length) + 1);
+  }
+}
+
+std::wstring CommandLine(const modules::ProcessRequest& request,
+                         std::wstring_view executable) {
+  std::wstring command = L"\"" + std::wstring(executable) + L"\"";
+  const std::wstring arguments = Arguments(request.arguments);
+  if (!arguments.empty()) command.append(L" ").append(arguments);
+  return command;
+}
+
+core::Status StartCreateProcess(const modules::ProcessRequest& request, HANDLE output) {
+  std::wstring executable;
+  DHEPZ_RETURN_IF_ERROR(ResolveExecutable(request.executable, &executable));
+  std::wstring command = CommandLine(request, executable);
+  STARTUPINFOW startup{};
+  startup.cb = sizeof(startup);
+  if (output != nullptr) {
+    startup.dwFlags |= STARTF_USESTDHANDLES;
+    startup.hStdOutput = output;
+    startup.hStdError = output;
+    startup.hStdInput = GetStdHandle(STD_INPUT_HANDLE);
+  }
+  PROCESS_INFORMATION info{};
+  const DWORD flags = request.hidden ? CREATE_NO_WINDOW : 0;
+  const BOOL started = CreateProcessW(
+      executable.c_str(), command.data(), nullptr, nullptr, output != nullptr, flags,
+      nullptr, request.working_directory.empty() ? nullptr : request.working_directory.c_str(),
+      &startup, &info);
+  if (!started) {
+    return DHEPZ_ERR(core::ErrorCode::IoError,
+                     L"Cannot start " + request.executable + L": " + ErrorText(GetLastError()));
+  }
+  CloseHandle(info.hThread);
+  CloseHandle(info.hProcess);
+  return core::Ok();
+}
+
+std::wstring DecodeOutput(const std::string& bytes) {
+  if (bytes.empty()) return {};
+  const bool utf16 = bytes.size() >= 2 &&
+                     ((static_cast<unsigned char>(bytes[0]) == 0xFF &&
+                       static_cast<unsigned char>(bytes[1]) == 0xFE) ||
+                      (bytes.size() >= 4 && bytes[1] == '\0' && bytes[3] == '\0'));
+  if (utf16) {
+    const std::size_t offset = static_cast<unsigned char>(bytes[0]) == 0xFF ? 2 : 0;
+    std::wstring text;
+    text.reserve((bytes.size() - offset) / 2);
+    for (std::size_t index = offset; index + 1 < bytes.size(); index += 2) {
+      const unsigned int value = static_cast<unsigned char>(bytes[index]) |
+                                 (static_cast<unsigned int>(static_cast<unsigned char>(bytes[index + 1])) << 8);
+      if (value != 0) text.push_back(static_cast<wchar_t>(value));
+    }
+    return text;
+  }
+  auto decode = [&bytes](UINT code_page, DWORD flags) {
+    const int needed = MultiByteToWideChar(code_page, flags, bytes.data(),
+                                            static_cast<int>(bytes.size()), nullptr, 0);
+    std::wstring text(needed > 0 ? static_cast<std::size_t>(needed) : 0, L'\0');
+    if (needed > 0) {
+      MultiByteToWideChar(code_page, flags, bytes.data(), static_cast<int>(bytes.size()),
+                          text.data(), needed);
+    }
+    return text;
+  };
+  std::wstring text = decode(CP_UTF8, MB_ERR_INVALID_CHARS);
+  return text.empty() ? decode(CP_OEMCP, 0) : text;
+}
+
+}  // namespace
+
+core::Status Start(const modules::ProcessRequest& request) {
+  if (request.executable.empty()) {
+    return DHEPZ_ERR(core::ErrorCode::InvalidArgument, L"Process executable is required");
+  }
+  if (!request.elevated) return StartCreateProcess(request, nullptr);
+
+  std::wstring executable;
+  DHEPZ_RETURN_IF_ERROR(ResolveExecutable(request.executable, &executable));
+  const std::wstring arguments = Arguments(request.arguments);
+  SHELLEXECUTEINFOW execute{};
+  execute.cbSize = sizeof(execute);
+  execute.fMask = SEE_MASK_NOCLOSEPROCESS | SEE_MASK_FLAG_NO_UI;
+  execute.lpVerb = L"runas";
+  execute.lpFile = executable.c_str();
+  execute.lpParameters = arguments.empty() ? nullptr : arguments.c_str();
+  execute.lpDirectory = request.working_directory.empty() ? nullptr : request.working_directory.c_str();
+  execute.nShow = SW_SHOWNORMAL;
+  if (!ShellExecuteExW(&execute)) {
+    const DWORD error = GetLastError();
+    return DHEPZ_ERR(error == ERROR_CANCELLED ? core::ErrorCode::Cancelled : core::ErrorCode::IoError,
+                     L"Cannot start elevated process: " + ErrorText(error));
+  }
+  if (execute.hProcess != nullptr) CloseHandle(execute.hProcess);
+  return core::Ok();
+}
+
+core::Status Run(const modules::ProcessRequest& request, std::wstring* standard_output) {
+  if (standard_output == nullptr || request.executable.empty() || request.elevated) {
+    return DHEPZ_ERR(core::ErrorCode::InvalidArgument, L"Captured process arguments are invalid");
+  }
+  standard_output->clear();
+  std::wstring executable;
+  DHEPZ_RETURN_IF_ERROR(ResolveExecutable(request.executable, &executable));
+  SECURITY_ATTRIBUTES security{sizeof(security), nullptr, TRUE};
+  HANDLE read_pipe = nullptr;
+  HANDLE write_pipe = nullptr;
+  if (!CreatePipe(&read_pipe, &write_pipe, &security, 0) ||
+      !SetHandleInformation(read_pipe, HANDLE_FLAG_INHERIT, 0)) {
+    if (read_pipe != nullptr) CloseHandle(read_pipe);
+    if (write_pipe != nullptr) CloseHandle(write_pipe);
+    return DHEPZ_ERR(core::ErrorCode::IoError, L"Cannot create process output pipe");
+  }
+
+  std::wstring command = CommandLine(request, executable);
+  STARTUPINFOW startup{};
+  startup.cb = sizeof(startup);
+  startup.dwFlags = STARTF_USESTDHANDLES;
+  startup.hStdOutput = write_pipe;
+  startup.hStdError = write_pipe;
+  startup.hStdInput = GetStdHandle(STD_INPUT_HANDLE);
+  PROCESS_INFORMATION info{};
+  const BOOL started = CreateProcessW(
+      executable.c_str(), command.data(), nullptr, nullptr, TRUE, CREATE_NO_WINDOW,
+      nullptr, request.working_directory.empty() ? nullptr : request.working_directory.c_str(),
+      &startup, &info);
+  CloseHandle(write_pipe);
+  if (!started) {
+    CloseHandle(read_pipe);
+    return DHEPZ_ERR(core::ErrorCode::IoError,
+                     L"Cannot run " + request.executable + L": " + ErrorText(GetLastError()));
+  }
+  CloseHandle(info.hThread);
+
+  std::string bytes;
+  char buffer[4096];
+  for (;;) {
+    DWORD available = 0;
+    if (!PeekNamedPipe(read_pipe, nullptr, 0, nullptr, &available, nullptr)) break;
+    if (available != 0) {
+      DWORD received = 0;
+      const DWORD wanted = (std::min)(available, static_cast<DWORD>(sizeof(buffer)));
+      if (!ReadFile(read_pipe, buffer, wanted, &received, nullptr) || received == 0) break;
+      bytes.append(buffer, received);
+      continue;
+    }
+    if (WaitForSingleObject(info.hProcess, 10) == WAIT_OBJECT_0) break;
+  }
+  for (;;) {
+    DWORD received = 0;
+    if (!ReadFile(read_pipe, buffer, sizeof(buffer), &received, nullptr) || received == 0) break;
+    bytes.append(buffer, received);
+  }
+  DWORD exit_code = 1;
+  GetExitCodeProcess(info.hProcess, &exit_code);
+  CloseHandle(info.hProcess);
+  CloseHandle(read_pipe);
+  *standard_output = DecodeOutput(bytes);
+  if (exit_code != 0) {
+    return DHEPZ_ERR(core::ErrorCode::IoError,
+                     request.executable + L" exited with code " + std::to_wstring(exit_code));
+  }
+  return core::Ok();
+}
+
+}  // namespace process

--- a/src/platform/process.h
+++ b/src/platform/process.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <string>
+
+#include "core/status.h"
+#include "parent/logic/module_contract.h"
+
+namespace process {
+
+core::Status Start(const modules::ProcessRequest& request);
+core::Status Run(const modules::ProcessRequest& request, std::wstring* standard_output);
+
+}  // namespace process

--- a/src/render/gdi_backend.cpp
+++ b/src/render/gdi_backend.cpp
@@ -621,6 +621,51 @@ void GdiBackend::DrawTextRun(std::wstring_view text, const Rect& bounds, const T
   impl_->ForceOpaqueAlpha(visible);
 }
 
+void GdiBackend::DrawEditableTextRun(std::wstring_view text, const Rect& bounds,
+                                     const TextStyle& style, Color color,
+                                     const EditableTextVisual& visual) {
+  if (!impl_->in_paint_scope || impl_->buffer_dc == nullptr) return;
+  HFONT font = impl_->FontFor(style);
+  if (font == nullptr) return;
+
+  const HGDIOBJ previous = SelectObject(impl_->buffer_dc, font);
+  const auto advance = [this, text](std::size_t count) {
+    if (count == 0) return 0.0f;
+    SIZE extent{};
+    const int length = static_cast<int>(std::min(count, text.size()));
+    if (!GetTextExtentPoint32W(impl_->buffer_dc, text.data(), length, &extent)) return 0.0f;
+    return impl_->Logical(extent.cx);
+  };
+
+  const std::size_t caret = std::min(visual.caret, text.size());
+  const std::size_t selection_start = std::min(visual.selection_start, text.size());
+  const std::size_t selection_end = std::min(visual.selection_end, text.size());
+  const float caret_width = advance(caret);
+  const float full_width = advance(text.size());
+  const float selection_left = advance(std::min(selection_start, selection_end));
+  const float selection_right = advance(std::max(selection_start, selection_end));
+  const float offset = caret_width > bounds.width - 2.0f
+                           ? bounds.width - caret_width - 2.0f
+                           : 0.0f;
+  if (previous != nullptr && previous != HGDI_ERROR) SelectObject(impl_->buffer_dc, previous);
+
+  PushClip(bounds);
+  if (selection_start != selection_end) {
+    FillRect({bounds.x + offset + selection_left, bounds.y + 5.0f,
+              std::max(1.0f, selection_right - selection_left),
+              std::max(1.0f, bounds.height - 10.0f)},
+             visual.selection_color);
+  }
+  DrawTextRun(text,
+              {bounds.x + offset, bounds.y, std::max(bounds.width, full_width),
+               bounds.height},
+              style, color, TextAlign::Left, VerticalAlign::Middle);
+  FillRect({bounds.x + offset + caret_width, bounds.y + 6.0f, 1.0f,
+            std::max(1.0f, bounds.height - 12.0f)},
+           visual.caret_color);
+  PopClip();
+}
+
 void GdiBackend::DrawImage(ImageHandle image, const Rect& dest, float opacity) {
   if (!impl_->in_paint_scope || impl_->pixels == nullptr || opacity <= 0.0f) return;
   const ImageData* source_ptr = impl_->cache->Image(static_cast<std::uint64_t>(image));

--- a/src/render/gdi_backend.h
+++ b/src/render/gdi_backend.h
@@ -103,6 +103,9 @@ class GdiBackend final : public RenderBackend {
                          float stroke_width) override;
   void DrawTextRun(std::wstring_view text, const Rect& bounds, const TextStyle& style, Color color,
                 TextAlign horizontal, VerticalAlign vertical) override;
+  void DrawEditableTextRun(std::wstring_view text, const Rect& bounds,
+                           const TextStyle& style, Color color,
+                           const EditableTextVisual& visual) override;
   void DrawImage(ImageHandle image, const Rect& dest, float opacity) override;
 
   // RenderBackend — clip and translation stacks.

--- a/src/render/render_backend.h
+++ b/src/render/render_backend.h
@@ -48,6 +48,7 @@
 // acceptance criteria.
 #pragma once
 
+#include <cstddef>
 #include <cstdint>
 #include <string>
 #include <string_view>
@@ -122,6 +123,14 @@ struct TextStyle {
   bool italic = false;
 };
 
+struct EditableTextVisual {
+  std::size_t selection_start = 0;
+  std::size_t selection_end = 0;
+  std::size_t caret = 0;
+  Color selection_color{};
+  Color caret_color{};
+};
+
 // Opaque, backend-owned. Zero is never a valid handle.
 enum class ImageHandle : std::uint64_t { Invalid = 0 };
 
@@ -172,7 +181,16 @@ class RenderBackend {
   virtual void StrokeRoundedRect(const Rect& rect, const CornerRadius& radius, Color color,
                                  float stroke_width) = 0;
   virtual void DrawTextRun(std::wstring_view text, const Rect& bounds, const TextStyle& style,
-                        Color color, TextAlign horizontal, VerticalAlign vertical) = 0;
+                         Color color, TextAlign horizontal, VerticalAlign vertical) = 0;
+  // Editable text needs glyph-exact selection and caret placement. The
+  // backend already owns the font metrics used to draw the run, so those
+  // pixels stay here instead of being estimated by an input component.
+  virtual void DrawEditableTextRun(std::wstring_view text, const Rect& bounds,
+                                   const TextStyle& style, Color color,
+                                   const EditableTextVisual& visual) {
+    (void)visual;
+    DrawTextRun(text, bounds, style, color, TextAlign::Left, VerticalAlign::Middle);
+  }
   virtual void DrawImage(ImageHandle image, const Rect& dest, float opacity) = 0;
 
   // Clip and translation stacks. Every Push must be balanced by a Pop

--- a/src/ui/app_window/app_window.cpp
+++ b/src/ui/app_window/app_window.cpp
@@ -62,6 +62,7 @@ bool AppWindow::Create(void* instance, float content_width, float content_height
 
   WNDCLASSEXW window_class{};
   window_class.cbSize = sizeof(window_class);
+  window_class.style = CS_DBLCLKS;
   window_class.lpfnWndProc = reinterpret_cast<WNDPROC>(&AppWindow::WindowProc);
   window_class.hInstance = static_cast<HINSTANCE>(instance);
   window_class.hCursor = LoadCursorW(nullptr, IDC_ARROW);
@@ -165,8 +166,25 @@ void AppWindow::set_content_click_handler(std::function<bool(float, float)> hand
   content_click_handler_ = std::move(handler);
 }
 
+void AppWindow::set_content_double_click_handler(std::function<bool(float, float)> handler) {
+  content_double_click_handler_ = std::move(handler);
+}
+
+void AppWindow::set_content_context_handler(std::function<bool(float, float)> handler) {
+  content_context_handler_ = std::move(handler);
+}
+
 void AppWindow::set_content_wheel_handler(std::function<bool(float, float, int)> handler) {
   content_wheel_handler_ = std::move(handler);
+}
+
+void AppWindow::set_native_message_handler(
+    std::function<bool(unsigned int, long long)> handler) {
+  native_message_handler_ = std::move(handler);
+}
+
+void AppWindow::RequestRepaint() {
+  if (hwnd_ != nullptr && visible()) RenderFullFrame();
 }
 
 int AppWindow::ButtonCount() const {
@@ -469,6 +487,7 @@ long long __stdcall AppWindow::WindowProc(void* window, unsigned int message,
 
 long long AppWindow::HandleMessage(void* window_handle, unsigned int message,
                                    unsigned long long wparam, long long lparam) {
+  if (native_message_handler_ && native_message_handler_(message, lparam)) return 0;
   HWND window = static_cast<HWND>(window_handle);
   if (message == drain_message_ && signals_) {
     signals_->DrainMessage();
@@ -605,6 +624,34 @@ long long AppWindow::HandleMessage(void* window_handle, unsigned int message,
           break;
         case CaptionButton::None:
           break;
+      }
+      return 0;
+    }
+    case WM_LBUTTONDBLCLK: {
+      if (content_double_click_handler_) {
+        const render::Rect viewport = ContentViewport();
+        const float x = Logical(GET_X_LPARAM(lparam)) - viewport.x;
+        const float y = Logical(GET_Y_LPARAM(lparam)) - viewport.y;
+        if (x >= 0.0f && y >= 0.0f && x < viewport.width && y < viewport.height &&
+            content_double_click_handler_(x, y)) {
+          RenderFullFrame();
+        }
+      }
+      return 0;
+    }
+    case WM_CONTEXTMENU: {
+      if (content_context_handler_) {
+        float x = -1.0f;
+        float y = -1.0f;
+        if (static_cast<short>(LOWORD(lparam)) != -1 ||
+            static_cast<short>(HIWORD(lparam)) != -1) {
+          POINT point{GET_X_LPARAM(lparam), GET_Y_LPARAM(lparam)};
+          ScreenToClient(window, &point);
+          const render::Rect viewport = ContentViewport();
+          x = Logical(point.x) - viewport.x;
+          y = Logical(point.y) - viewport.y;
+        }
+        if (content_context_handler_(x, y)) RenderFullFrame();
       }
       return 0;
     }

--- a/src/ui/app_window/app_window.h
+++ b/src/ui/app_window/app_window.h
@@ -119,8 +119,15 @@ class AppWindow final {
   void set_content_move_handler(std::function<bool(float x_logical, float y_logical)> handler);
   void set_content_down_handler(std::function<bool(float x_logical, float y_logical)> handler);
   void set_content_click_handler(std::function<bool(float x_logical, float y_logical)> handler);
+  void set_content_double_click_handler(
+      std::function<bool(float x_logical, float y_logical)> handler);
+  void set_content_context_handler(
+      std::function<bool(float x_logical, float y_logical)> handler);
   void set_content_wheel_handler(
       std::function<bool(float x_logical, float y_logical, int delta)> handler);
+  void set_native_message_handler(
+      std::function<bool(unsigned int message, long long lparam)> handler);
+  void RequestRepaint();
 
  private:
   static long long __stdcall WindowProc(void* window, unsigned int message,
@@ -158,7 +165,10 @@ class AppWindow final {
   std::function<bool(float, float)> content_move_handler_;
   std::function<bool(float, float)> content_down_handler_;
   std::function<bool(float, float)> content_click_handler_;
+  std::function<bool(float, float)> content_double_click_handler_;
+  std::function<bool(float, float)> content_context_handler_;
   std::function<bool(float, float, int)> content_wheel_handler_;
+  std::function<bool(unsigned int, long long)> native_message_handler_;
   std::uint32_t last_os_signals_ = 0;
   unsigned int drain_message_ = 0;
   float dpi_ = 96.0f;

--- a/src/ui/components/button/button_component.cpp
+++ b/src/ui/components/button/button_component.cpp
@@ -23,13 +23,17 @@ void Paint(const config::ComponentNode& node, const render::Rect& bounds,
   if (node.GetString(L"variant") == L"danger" && (visual.hovered || visual.pressed)) {
     fill = palette.danger;
   }
+  const render::CornerRadius radius = CornerRadiusFor(node);
   if (node.GetString(L"variant") != L"subtle" || visual.hovered || visual.pressed) {
-    backend.FillRoundedRect(bounds, render::CornerRadius::Uniform(5.0f), fill);
+    backend.FillRoundedRect(bounds, radius, fill);
   }
   if (node.GetString(L"variant") != L"subtle") {
-    backend.StrokeRoundedRect(bounds, render::CornerRadius::Uniform(5.0f), palette.border, 1.0f);
+    backend.StrokeRoundedRect(bounds, radius, palette.border, 1.0f);
   }
-  backend.DrawTextRun(node.GetString(L"label"), bounds, {}, palette.text,
+  render::TextStyle label_style;
+  label_style.family = node.GetString(L"font_family", L"Segoe UI");
+  label_style.size_px = static_cast<float>(node.GetInt(L"font_size", 14));
+  backend.DrawTextRun(node.GetString(L"label"), bounds, label_style, palette.text,
                       render::TextAlign::Center, render::VerticalAlign::Middle);
   PaintFocus(bounds, visual, palette, backend);
 }

--- a/src/ui/components/combo/combo_component.cpp
+++ b/src/ui/components/combo/combo_component.cpp
@@ -90,11 +90,11 @@ ComponentResult OverlayPointer(const config::ComponentNode& node,
                                const application::UiState& state, render::Point point,
                                const render::Rect& anchor, render::Size viewport) {
   const std::vector<std::wstring>* items = BoundStrings(node, L"items_binding", state);
-  if (items == nullptr || items->empty()) return ActionResult(node);
+  if (items == nullptr || items->empty()) return {};
   const render::Rect popup = PopupBounds(node, anchor, viewport, items->size());
-  if (!popup.contains(point)) return ActionResult(node);
+  if (!popup.contains(point)) return {};
   const std::size_t index = static_cast<std::size_t>((point.y - popup.y) / kRowHeight);
-  if (index >= items->size()) return ActionResult(node);
+  if (index >= items->size()) return {};
   return BindingResult(node, L"selected_value_binding", (*items)[index], true);
 }
 }  // namespace

--- a/src/ui/components/component.h
+++ b/src/ui/components/component.h
@@ -46,7 +46,7 @@ using TextInputFn = ComponentResult (*)(const config::ComponentNode&,
                                         const application::UiState&, wchar_t);
 using PointerFn = ComponentResult (*)(const config::ComponentNode&,
                                       const application::UiState&, render::Point,
-                                      const render::Rect&);
+                                      const render::Rect&, render::RenderBackend&);
 using WheelFn = ComponentResult (*)(const config::ComponentNode&,
                                     const application::UiState&, int);
 using OverlayPaintFn = void (*)(const config::ComponentNode&, const render::Rect&,
@@ -55,6 +55,12 @@ using OverlayPaintFn = void (*)(const config::ComponentNode&, const render::Rect
 using OverlayPointerFn = ComponentResult (*)(const config::ComponentNode&,
                                              const application::UiState&, render::Point,
                                              const render::Rect&, render::Size);
+using DoubleClickFn = ComponentResult (*)(const config::ComponentNode&,
+                                          const application::UiState&);
+using ContextMenuFn = ComponentResult (*)(const config::ComponentNode&,
+                                          const application::UiState&, void* owner_window);
+using HasOverlayFn = bool (*)(const config::ComponentNode&,
+                              const application::UiState&);
 
 struct ComponentDescriptor {
   std::wstring_view type;
@@ -69,6 +75,9 @@ struct ComponentDescriptor {
   WheelFn wheel = nullptr;
   OverlayPaintFn paint_overlay = nullptr;
   OverlayPointerFn overlay_pointer = nullptr;
+  DoubleClickFn double_click = nullptr;
+  ContextMenuFn context_menu = nullptr;
+  HasOverlayFn has_overlay = nullptr;
 };
 
 }  // namespace ui::components

--- a/src/ui/components/component_helpers.cpp
+++ b/src/ui/components/component_helpers.cpp
@@ -89,6 +89,20 @@ render::TextAlign TextAlignFor(const config::ComponentNode& node) {
   return render::TextAlign::Left;
 }
 
+render::CornerRadius CornerRadiusFor(const config::ComponentNode& node, float fallback) {
+  render::CornerRadius radius = render::CornerRadius::Uniform(fallback);
+  const std::wstring edge = node.GetString(L"join_edge", L"none");
+  if (edge == L"start" || edge == L"both") {
+    radius.top_left = 0.0f;
+    radius.bottom_left = 0.0f;
+  }
+  if (edge == L"end" || edge == L"both") {
+    radius.top_right = 0.0f;
+    radius.bottom_right = 0.0f;
+  }
+  return radius;
+}
+
 void PaintFocus(const render::Rect& bounds, const ComponentVisualState& visual,
                 const ComponentPalette& palette, render::RenderBackend& backend, float radius) {
   if (!visual.focused) return;

--- a/src/ui/components/component_helpers.h
+++ b/src/ui/components/component_helpers.h
@@ -25,6 +25,8 @@ ComponentResult ActionResult(const config::ComponentNode& node,
                              application::UiValue payload = {});
 render::TextStyle TextStyleFor(const config::ComponentNode& node);
 render::TextAlign TextAlignFor(const config::ComponentNode& node);
+render::CornerRadius CornerRadiusFor(const config::ComponentNode& node,
+                                     float fallback = 5.0f);
 void PaintFocus(const render::Rect& bounds, const ComponentVisualState& visual,
                 const ComponentPalette& palette, render::RenderBackend& backend,
                 float radius = 5.0f);

--- a/src/ui/components/dialog/dialog_component.cpp
+++ b/src/ui/components/dialog/dialog_component.cpp
@@ -33,7 +33,8 @@ ComponentResult Key(const config::ComponentNode& node, const application::UiStat
 }
 
 ComponentResult Pointer(const config::ComponentNode& node, const application::UiState&,
-                        render::Point point, const render::Rect& bounds) {
+                        render::Point point, const render::Rect& bounds,
+                        render::RenderBackend&) {
   if (!node.GetBool(L"dismiss_outside_click")) return {};
   if (!DialogPanelBounds(node, bounds).contains(point)) {
     return BindingResult(node, L"open_binding", false, true);

--- a/src/ui/components/input/input_component.cpp
+++ b/src/ui/components/input/input_component.cpp
@@ -1,15 +1,34 @@
 #include "ui/components/input/input_component.h"
 
 #include <algorithm>
+#include <string>
 #include <utility>
+#include <vector>
 #include <windows.h>
 
 #include "ui/components/component_helpers.h"
 
 namespace ui::components {
 namespace {
-render::Size Measure(const config::ComponentNode& node, render::RenderBackend&,
+constexpr float kSuggestionRowHeight = 30.0f;
+constexpr UINT kMenuCut = 1;
+constexpr UINT kMenuCopy = 2;
+constexpr UINT kMenuPaste = 3;
+constexpr UINT kMenuSelectAll = 4;
+
+struct Selection {
+  std::size_t caret = 0;
+  std::size_t anchor = 0;
+  std::size_t begin() const { return std::min(caret, anchor); }
+  std::size_t end() const { return std::max(caret, anchor); }
+  bool empty() const { return caret == anchor; }
+};
+
+render::Size Measure(const config::ComponentNode& node, render::RenderBackend& backend,
                      const application::UiState&, float max_width) {
+  // Layout is outside the paint scope, so this warms the exact font metrics
+  // later used by the backend's editable-text drawing primitive.
+  backend.MeasureText(L"Mg", {}, 0.0f);
   const float width = std::min(max_width, static_cast<float>(node.GetInt(L"width", 240)));
   const float default_height = node.GetString(L"mode") == L"multiline" ? 96.0f : 34.0f;
   return {width, static_cast<float>(node.GetInt(L"height",
@@ -20,54 +39,291 @@ std::wstring Value(const config::ComponentNode& node, const application::UiState
   return BoundText(node, L"value_binding", state);
 }
 
-ComponentResult Changed(const config::ComponentNode& node, std::wstring value) {
-  return BindingResult(node, L"value_binding", std::move(value), true);
+std::wstring EditorKey(const config::ComponentNode& node, std::wstring_view field) {
+  std::wstring key = L"__ui.input.";
+  key.append(node.id().empty() ? node.GetString(L"value_binding") : node.id());
+  key.push_back(L'.');
+  key.append(field);
+  return key;
+}
+
+Selection ReadSelection(const config::ComponentNode& node,
+                        const application::UiState& state, std::size_t length) {
+  const std::size_t caret = static_cast<std::size_t>(
+      std::clamp(state.Integer(EditorKey(node, L"caret"), static_cast<long long>(length)),
+                 0LL, static_cast<long long>(length)));
+  const std::size_t anchor = static_cast<std::size_t>(
+      std::clamp(state.Integer(EditorKey(node, L"anchor"), static_cast<long long>(caret)),
+                 0LL, static_cast<long long>(length)));
+  return {caret, anchor};
+}
+
+void AddSelection(application::UiPatch* patch, const config::ComponentNode& node,
+                  Selection selection) {
+  patch->changes.push_back(
+      {EditorKey(node, L"caret"), static_cast<long long>(selection.caret)});
+  patch->changes.push_back(
+      {EditorKey(node, L"anchor"), static_cast<long long>(selection.anchor)});
+}
+
+ComponentResult Select(const config::ComponentNode& node, Selection selection) {
+  ComponentResult result;
+  result.handled = true;
+  AddSelection(&result.patch, node, selection);
+  return result;
+}
+
+ComponentResult Changed(const config::ComponentNode& node, std::wstring value,
+                        Selection selection) {
+  ComponentResult result = BindingResult(node, L"value_binding", std::move(value), true);
+  AddSelection(&result.patch, node, selection);
+  return result;
+}
+
+bool ClipboardHasText() { return IsClipboardFormatAvailable(CF_UNICODETEXT) != FALSE; }
+
+std::wstring ClipboardText() {
+  if (!OpenClipboard(nullptr)) return {};
+  const HANDLE data = GetClipboardData(CF_UNICODETEXT);
+  const wchar_t* text = data != nullptr
+                            ? static_cast<const wchar_t*>(GlobalLock(data))
+                            : nullptr;
+  const std::wstring value = text != nullptr ? std::wstring(text) : std::wstring{};
+  if (text != nullptr) GlobalUnlock(data);
+  CloseClipboard();
+  return value;
+}
+
+bool PutClipboardText(std::wstring_view value) {
+  if (!OpenClipboard(nullptr)) return false;
+  if (!EmptyClipboard()) {
+    CloseClipboard();
+    return false;
+  }
+  const SIZE_T bytes = (value.size() + 1) * sizeof(wchar_t);
+  HGLOBAL memory = GlobalAlloc(GMEM_MOVEABLE, bytes);
+  if (memory == nullptr) {
+    CloseClipboard();
+    return false;
+  }
+  wchar_t* destination = static_cast<wchar_t*>(GlobalLock(memory));
+  if (destination == nullptr) {
+    GlobalFree(memory);
+    CloseClipboard();
+    return false;
+  }
+  std::copy(value.begin(), value.end(), destination);
+  destination[value.size()] = L'\0';
+  GlobalUnlock(memory);
+  if (SetClipboardData(CF_UNICODETEXT, memory) == nullptr) {
+    GlobalFree(memory);
+    CloseClipboard();
+    return false;
+  }
+  CloseClipboard();
+  return true;
+}
+
+ComponentResult Copy(const config::ComponentNode& node,
+                     const application::UiState& state, bool cut) {
+  if (node.GetBool(L"password")) return {};
+  std::wstring value = Value(node, state);
+  const Selection selection = ReadSelection(node, state, value.size());
+  const std::wstring_view selected = std::wstring_view(value).substr(
+      selection.begin(), selection.end() - selection.begin());
+  if (selection.empty() || !PutClipboardText(selected)) return {};
+  if (!cut || node.GetBool(L"read_only")) {
+    ComponentResult result;
+    result.handled = true;
+    return result;
+  }
+  value.erase(selection.begin(), selection.end() - selection.begin());
+  return Changed(node, std::move(value), {selection.begin(), selection.begin()});
+}
+
+ComponentResult Paste(const config::ComponentNode& node,
+                      const application::UiState& state) {
+  if (node.GetBool(L"read_only")) return {};
+  std::wstring inserted = ClipboardText();
+  if (inserted.empty()) return {};
+  if (node.GetString(L"mode") != L"multiline") {
+    inserted.erase(std::remove_if(inserted.begin(), inserted.end(), [](wchar_t value) {
+                     return value == L'\r' || value == L'\n';
+                   }),
+                   inserted.end());
+  }
+  std::wstring value = Value(node, state);
+  const Selection selection = ReadSelection(node, state, value.size());
+  const std::size_t maximum = static_cast<std::size_t>(node.GetInt(L"maximum_length", 4096));
+  const std::size_t retained = value.size() - (selection.end() - selection.begin());
+  if (retained >= maximum) inserted.clear();
+  if (inserted.size() > maximum - std::min(maximum, retained)) {
+    inserted.resize(maximum - std::min(maximum, retained));
+  }
+  value.replace(selection.begin(), selection.end() - selection.begin(), inserted);
+  const std::size_t caret = selection.begin() + inserted.size();
+  return Changed(node, std::move(value), {caret, caret});
+}
+
+render::Rect PopupBounds(const config::ComponentNode& node, const render::Rect& anchor,
+                         render::Size viewport, std::size_t count) {
+  const std::size_t maximum = static_cast<std::size_t>(
+      std::max(1LL, node.GetInt(L"maximum_visible_items", 6)));
+  const float height = kSuggestionRowHeight * static_cast<float>(std::min(count, maximum));
+  float y = anchor.bottom();
+  if (y + height > viewport.height) y = std::max(0.0f, anchor.y - height);
+  return {anchor.x, y, anchor.width, height};
+}
+
+const std::vector<std::wstring>* Suggestions(const config::ComponentNode& node,
+                                             const application::UiState& state) {
+  return BoundStrings(node, L"suggestions_binding", state);
+}
+
+bool HasOverlay(const config::ComponentNode& node,
+                const application::UiState& state) {
+  const std::vector<std::wstring>* items = Suggestions(node, state);
+  return items != nullptr && !items->empty();
 }
 
 void Paint(const config::ComponentNode& node, const render::Rect& bounds,
            const ComponentVisualState& visual, const ComponentPalette& palette,
            const application::UiState& state, render::RenderBackend& backend) {
-  backend.FillRoundedRect(bounds, render::CornerRadius::Uniform(5.0f), palette.control);
-  backend.StrokeRoundedRect(bounds, render::CornerRadius::Uniform(5.0f),
+  const render::CornerRadius radius = CornerRadiusFor(node);
+  backend.FillRoundedRect(bounds, radius, palette.control);
+  backend.StrokeRoundedRect(bounds, radius,
                             visual.focused ? palette.focus : palette.border,
                             visual.focused ? 2.0f : 1.0f);
   std::wstring value = Value(node, state);
   const bool placeholder = value.empty();
   if (placeholder) value = node.GetString(L"placeholder");
   if (!placeholder && node.GetBool(L"password")) value.assign(value.size(), L'•');
-  if (visual.focused && !node.GetBool(L"read_only")) value.push_back(L'|');
+
+  const render::TextStyle style{};
+  const render::Rect text_bounds{bounds.x + 9.0f, bounds.y + 2.0f,
+                                 std::max(0.0f, bounds.width - 18.0f),
+                                 std::max(0.0f, bounds.height - 4.0f)};
   const std::wstring align = node.GetString(L"horizontal_align");
   const render::TextAlign text_align = align == L"center"
                                            ? render::TextAlign::Center
                                            : align == L"end" ? render::TextAlign::Right
                                                              : render::TextAlign::Left;
-  backend.DrawTextRun(value,
-                      {bounds.x + 9.0f, bounds.y + 2.0f,
-                       std::max(0.0f, bounds.width - 18.0f), bounds.height - 4.0f},
-                      {}, placeholder ? palette.border : palette.text, text_align,
-                      node.GetString(L"mode") == L"multiline"
-                          ? render::VerticalAlign::Top
-                          : render::VerticalAlign::Middle);
+  if (placeholder || !visual.focused) {
+    backend.DrawTextRun(value, text_bounds, style,
+                        placeholder ? palette.border : palette.text, text_align,
+                        node.GetString(L"mode") == L"multiline"
+                            ? render::VerticalAlign::Top
+                            : render::VerticalAlign::Middle);
+    return;
+  }
+
+  const Selection selection = ReadSelection(node, state, value.size());
+  backend.DrawEditableTextRun(
+      value, text_bounds, style, palette.text,
+      {selection.begin(), selection.end(), selection.caret,
+       palette.control_pressed, palette.text});
+}
+
+ComponentResult Pointer(const config::ComponentNode& node,
+                        const application::UiState& state, render::Point point,
+                        const render::Rect& bounds, render::RenderBackend& backend) {
+  const std::wstring value = Value(node, state);
+  if (value.empty()) return Select(node, {0, 0});
+
+  const render::TextStyle style{};
+  const render::Rect text_bounds{bounds.x + 9.0f, bounds.y + 2.0f,
+                                 std::max(0.0f, bounds.width - 18.0f),
+                                 std::max(0.0f, bounds.height - 4.0f)};
+  const Selection current = ReadSelection(node, state, value.size());
+  const float current_advance = backend.MeasureText(
+      std::wstring_view(value).substr(0, current.caret), style, 0.0f).width;
+  const float offset = current_advance > text_bounds.width - 2.0f
+                           ? text_bounds.width - current_advance - 2.0f
+                           : 0.0f;
+  const float target = std::max(0.0f, point.x - text_bounds.x - offset);
+
+  std::size_t low = 0;
+  std::size_t high = value.size();
+  while (low < high) {
+    const std::size_t middle = low + (high - low) / 2;
+    const float edge = backend.MeasureText(
+        std::wstring_view(value).substr(0, middle + 1), style, 0.0f).width;
+    if (edge < target) {
+      low = middle + 1;
+    } else {
+      high = middle;
+    }
+  }
+  std::size_t caret = low;
+  if (caret < value.size()) {
+    const float left = backend.MeasureText(
+        std::wstring_view(value).substr(0, caret), style, 0.0f).width;
+    const float right = backend.MeasureText(
+        std::wstring_view(value).substr(0, caret + 1), style, 0.0f).width;
+    if (target >= left + (right - left) / 2.0f) ++caret;
+  }
+  return Select(node, {caret, caret});
+}
+
+ComponentResult DoubleClick(const config::ComponentNode& node,
+                            const application::UiState& state) {
+  const std::size_t end = Value(node, state).size();
+  return Select(node, {end, 0});
 }
 
 ComponentResult Key(const config::ComponentNode& node, const application::UiState& state,
                     int key) {
-  if (node.GetBool(L"read_only")) return {};
   std::wstring value = Value(node, state);
-  if (key == VK_BACK) {
-    if (value.empty()) return {};
-    value.pop_back();
-    return Changed(node, std::move(value));
+  Selection selection = ReadSelection(node, state, value.size());
+  const bool control = (GetKeyState(VK_CONTROL) & 0x8000) != 0;
+  const bool shift = (GetKeyState(VK_SHIFT) & 0x8000) != 0;
+  if (control && key == 'A') return Select(node, {value.size(), 0});
+  if (control && key == 'C') return Copy(node, state, false);
+  if (control && key == 'X') return Copy(node, state, true);
+  if (control && key == 'V') return Paste(node, state);
+  if (key == VK_LEFT || key == VK_RIGHT || key == VK_HOME || key == VK_END) {
+    std::size_t next = selection.caret;
+    if (key == VK_HOME) next = 0;
+    if (key == VK_END) next = value.size();
+    if (key == VK_LEFT) {
+      next = !shift && !selection.empty() ? selection.begin()
+                                          : (selection.caret == 0 ? 0 : selection.caret - 1);
+    }
+    if (key == VK_RIGHT) {
+      next = !shift && !selection.empty()
+                 ? selection.end()
+                 : std::min(value.size(), selection.caret + 1);
+    }
+    return Select(node, {next, shift ? selection.anchor : next});
   }
-  if (key == VK_DELETE) {
-    if (value.empty()) return {};
-    value.clear();
-    return Changed(node, std::move(value));
+  if (node.GetBool(L"read_only")) return {};
+  if (key == VK_BACK || key == VK_DELETE) {
+    if (selection.empty()) {
+      if (key == VK_BACK && selection.caret > 0) {
+        selection.anchor = selection.caret - 1;
+      } else if (key == VK_DELETE && selection.caret < value.size()) {
+        selection.anchor = selection.caret + 1;
+      } else {
+        ComponentResult handled;
+        handled.handled = true;
+        return handled;
+      }
+    }
+    const std::size_t begin = selection.begin();
+    value.erase(begin, selection.end() - begin);
+    return Changed(node, std::move(value), {begin, begin});
   }
-  if (key == VK_RETURN && node.GetString(L"mode") == L"multiline" &&
-      value.size() < static_cast<std::size_t>(node.GetInt(L"maximum_length", 4096))) {
-    value.push_back(L'\n');
-    return Changed(node, std::move(value));
+  if (key == VK_RETURN && node.GetString(L"mode") == L"multiline") {
+    const std::size_t maximum = static_cast<std::size_t>(node.GetInt(L"maximum_length", 4096));
+    if (value.size() - (selection.end() - selection.begin()) >= maximum) return {};
+    value.replace(selection.begin(), selection.end() - selection.begin(), 1, L'\n');
+    const std::size_t caret = selection.begin() + 1;
+    return Changed(node, std::move(value), {caret, caret});
+  }
+  if (key == VK_RETURN || key == VK_SPACE) {
+    ComponentResult handled;
+    handled.handled = true;
+    return handled;
   }
   return {};
 }
@@ -76,9 +332,78 @@ ComponentResult TextInput(const config::ComponentNode& node,
                           const application::UiState& state, wchar_t character) {
   if (node.GetBool(L"read_only") || character < L' ' || character == 0x7F) return {};
   std::wstring value = Value(node, state);
-  if (value.size() >= static_cast<std::size_t>(node.GetInt(L"maximum_length", 4096))) return {};
-  value.push_back(character);
-  return Changed(node, std::move(value));
+  const Selection selection = ReadSelection(node, state, value.size());
+  const std::size_t maximum = static_cast<std::size_t>(node.GetInt(L"maximum_length", 4096));
+  if (value.size() - (selection.end() - selection.begin()) >= maximum) return {};
+  value.replace(selection.begin(), selection.end() - selection.begin(), 1, character);
+  const std::size_t caret = selection.begin() + 1;
+  return Changed(node, std::move(value), {caret, caret});
+}
+
+void PaintOverlay(const config::ComponentNode& node, const render::Rect& anchor,
+                  render::Size viewport, const ComponentPalette& palette,
+                  const application::UiState& state, render::RenderBackend& backend) {
+  const std::vector<std::wstring>* items = Suggestions(node, state);
+  if (items == nullptr || items->empty()) return;
+  const render::Rect popup = PopupBounds(node, anchor, viewport, items->size());
+  backend.FillRoundedRect(popup, render::CornerRadius::Uniform(5.0f), palette.surface);
+  backend.StrokeRoundedRect(popup, render::CornerRadius::Uniform(5.0f), palette.border, 1.0f);
+  const std::wstring current = Value(node, state);
+  const std::size_t visible = static_cast<std::size_t>(popup.height / kSuggestionRowHeight);
+  for (std::size_t index = 0; index < std::min(items->size(), visible); ++index) {
+    const render::Rect row{popup.x + 2.0f,
+                           popup.y + 2.0f + kSuggestionRowHeight * index,
+                           popup.width - 4.0f, kSuggestionRowHeight - 2.0f};
+    if ((*items)[index] == current) backend.FillRect(row, palette.control_pressed);
+    backend.DrawTextRun((*items)[index], {row.x + 7.0f, row.y, row.width - 14.0f, row.height},
+                        {}, palette.text, render::TextAlign::Left,
+                        render::VerticalAlign::Middle);
+  }
+}
+
+ComponentResult OverlayPointer(const config::ComponentNode& node,
+                               const application::UiState& state, render::Point point,
+                               const render::Rect& anchor, render::Size viewport) {
+  const std::vector<std::wstring>* items = Suggestions(node, state);
+  if (items == nullptr || items->empty()) return {};
+  const render::Rect popup = PopupBounds(node, anchor, viewport, items->size());
+  if (!popup.contains(point)) return {};
+  const std::size_t index = static_cast<std::size_t>((point.y - popup.y) /
+                                                     kSuggestionRowHeight);
+  if (index >= items->size()) return {};
+  const std::wstring& selected = (*items)[index];
+  return Changed(node, selected, {selected.size(), selected.size()});
+}
+
+ComponentResult ContextMenu(const config::ComponentNode& node,
+                            const application::UiState& state, void* owner_window) {
+  const std::wstring value = Value(node, state);
+  const Selection selection = ReadSelection(node, state, value.size());
+  const bool editable = !node.GetBool(L"read_only");
+  const bool copyable = !selection.empty() && !node.GetBool(L"password");
+  HMENU menu = CreatePopupMenu();
+  if (menu == nullptr) return {};
+  AppendMenuW(menu, MF_STRING | (editable && copyable ? MF_ENABLED : MF_GRAYED),
+              kMenuCut, L"Cut");
+  AppendMenuW(menu, MF_STRING | (copyable ? MF_ENABLED : MF_GRAYED), kMenuCopy, L"Copy");
+  AppendMenuW(menu, MF_STRING | (editable && ClipboardHasText() ? MF_ENABLED : MF_GRAYED),
+              kMenuPaste, L"Paste");
+  AppendMenuW(menu, MF_SEPARATOR, 0, nullptr);
+  AppendMenuW(menu, MF_STRING | (!value.empty() ? MF_ENABLED : MF_GRAYED),
+              kMenuSelectAll, L"Select all");
+  POINT point{};
+  GetCursorPos(&point);
+  const UINT command = TrackPopupMenu(menu, TPM_RETURNCMD | TPM_RIGHTBUTTON,
+                                      point.x, point.y, 0,
+                                      static_cast<HWND>(owner_window), nullptr);
+  DestroyMenu(menu);
+  if (command == kMenuCut) return Copy(node, state, true);
+  if (command == kMenuCopy) return Copy(node, state, false);
+  if (command == kMenuPaste) return Paste(node, state);
+  if (command == kMenuSelectAll) return Select(node, {value.size(), 0});
+  ComponentResult handled;
+  handled.handled = true;
+  return handled;
 }
 }  // namespace
 
@@ -86,6 +411,12 @@ ComponentDescriptor CreateInputComponent() {
   ComponentDescriptor descriptor{L"input", false, &Measure, &Paint, &TabFocusable, nullptr};
   descriptor.key = &Key;
   descriptor.text_input = &TextInput;
+  descriptor.pointer = &Pointer;
+  descriptor.paint_overlay = &PaintOverlay;
+  descriptor.overlay_pointer = &OverlayPointer;
+  descriptor.double_click = &DoubleClick;
+  descriptor.context_menu = &ContextMenu;
+  descriptor.has_overlay = &HasOverlay;
   return descriptor;
 }
 }  // namespace ui::components

--- a/src/ui/components/list/list_component.cpp
+++ b/src/ui/components/list/list_component.cpp
@@ -52,7 +52,8 @@ void Paint(const config::ComponentNode& node, const render::Rect& bounds,
 }
 
 ComponentResult Pointer(const config::ComponentNode& node, const application::UiState& state,
-                        render::Point point, const render::Rect& bounds) {
+                        render::Point point, const render::Rect& bounds,
+                        render::RenderBackend&) {
   if (node.GetString(L"selection") == L"none") return ActionResult(node);
   const std::vector<std::wstring>* items = BoundStrings(node, L"items_binding", state);
   if (items == nullptr || items->empty() || !bounds.contains(point)) return {};

--- a/src/ui/components/scrollbar/scrollbar_component.cpp
+++ b/src/ui/components/scrollbar/scrollbar_component.cpp
@@ -51,7 +51,8 @@ ComponentResult SetValue(const config::ComponentNode& node, long long value) {
 }
 
 ComponentResult Pointer(const config::ComponentNode& node, const application::UiState&,
-                        render::Point point, const render::Rect& bounds) {
+                        render::Point point, const render::Rect& bounds,
+                        render::RenderBackend&) {
   const bool horizontal = node.GetString(L"orientation") == L"horizontal";
   const float extent = horizontal ? bounds.width : bounds.height;
   if (extent <= 0.0f || !bounds.contains(point)) return {};

--- a/src/ui/components/text/text_component.cpp
+++ b/src/ui/components/text/text_component.cpp
@@ -1,5 +1,7 @@
 #include "ui/components/text/text_component.h"
 
+#include <algorithm>
+
 #include "ui/components/component_helpers.h"
 
 namespace ui::components {
@@ -9,7 +11,12 @@ render::Size Measure(const config::ComponentNode& node, render::RenderBackend& b
   const std::wstring binding = node.GetString(L"text_binding");
   const std::wstring text =
       binding.empty() ? node.GetString(L"text") : state.Text(binding, node.GetString(L"text"));
-  return backend.MeasureText(text, TextStyleFor(node), max_width);
+  render::Size measured = backend.MeasureText(text, TextStyleFor(node), max_width);
+  const long long width = node.GetInt(L"width");
+  const long long height = node.GetInt(L"height");
+  if (width > 0) measured.width = std::min(max_width, static_cast<float>(width));
+  if (height > 0) measured.height = static_cast<float>(height);
+  return measured;
 }
 
 void Paint(const config::ComponentNode& node, const render::Rect& bounds,

--- a/tests/dhepz_tests.vcxproj
+++ b/tests/dhepz_tests.vcxproj
@@ -120,6 +120,7 @@
   <ItemGroup>
     <ClCompile Include="**\*.cpp" />
     <ClCompile Include="..\src\core\**\*.cpp" />
+    <ClCompile Include="..\src\modules\**\*.cpp" />
     <ClCompile Include="..\src\parent\**\*.cpp" />
     <ClCompile Include="..\src\platform\**\*.cpp" />
     <ClCompile Include="..\src\render\**\*.cpp" />

--- a/tests/modules/terminal_module_test.cpp
+++ b/tests/modules/terminal_module_test.cpp
@@ -1,0 +1,219 @@
+#include <atomic>
+#include <algorithm>
+#include <filesystem>
+#include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "core/json.h"
+#include "framework/test_case.h"
+#include "parent/logic/module_registry.h"
+#include "parent/ui/config/resolved_ui_document.h"
+#include "parent/ui/contracts/ui_state.h"
+#include "platform/files.h"
+
+namespace {
+
+std::filesystem::path RepositoryRoot() {
+  return std::filesystem::path(__FILE__).parent_path().parent_path().parent_path();
+}
+
+std::wstring Read(const std::filesystem::path& path) {
+  std::wstring text;
+  if (!files::ReadText(path.wstring(), &text).ok()) {
+    testing::Fail("could not read P4 UI asset", __FILE__, __LINE__);
+  }
+  return text;
+}
+
+class FakeHost final : public modules::ModuleHost,
+                       public modules::BackgroundCapabilities {
+ public:
+  std::wstring DefaultDirectory() const override { return L"C:\\work"; }
+
+  std::optional<std::wstring> PickFolder(std::wstring_view) override {
+    return L"C:\\picked";
+  }
+
+  void RunBackground(modules::BackgroundWork work,
+                     modules::BackgroundComplete complete) override {
+    pending_status_ = work(*this, cancelled_);
+    pending_complete_ = std::move(complete);
+  }
+
+  void Publish(ui::application::UiPatch patch) override {
+    published_.push_back(std::move(patch));
+  }
+
+  void CloseWindowIfUnpinned() override { ++close_if_unpinned_requests_; }
+
+  bool DirectoryExists(std::wstring_view) const override { return true; }
+  bool FileExists(std::wstring_view) const override { return true; }
+
+  core::Status StartProcess(const modules::ProcessRequest& request) const override {
+    started_.push_back(request);
+    return start_status_;
+  }
+
+  core::Status RunProcess(const modules::ProcessRequest& request,
+                          std::wstring* output) const override {
+    if (output == nullptr) {
+      return DHEPZ_ERR(core::ErrorCode::InvalidArgument, L"output required");
+    }
+    output->clear();
+    if (request.executable == L"wsl.exe" && request.arguments.size() >= 2 &&
+        request.arguments[0] == L"-l") {
+      *output = L"Debian\r\n";
+    } else if (request.executable == L"wsl.exe" &&
+               !request.arguments.empty() && request.arguments.back() == L"C:/work") {
+      *output = L"/mnt/c/work\n";
+    }
+    ran_.push_back(request);
+    return core::Ok();
+  }
+
+  void Complete() {
+    if (pending_complete_) pending_complete_(pending_status_);
+    pending_complete_ = {};
+  }
+
+  mutable std::vector<modules::ProcessRequest> started_;
+  mutable std::vector<modules::ProcessRequest> ran_;
+  std::vector<ui::application::UiPatch> published_;
+  core::Status start_status_;
+  int close_if_unpinned_requests_ = 0;
+
+ private:
+  std::atomic<bool> cancelled_{false};
+  core::Status pending_status_;
+  modules::BackgroundComplete pending_complete_;
+};
+
+}  // namespace
+
+DHEPZ_TEST(P4Terminal, DescriptorJsonAndCoreContractResolveTogether) {
+  const modules::ModuleDescriptor* descriptor = modules::ModuleRegistry::Find(L"terminal");
+  DHEPZ_CHECK(descriptor != nullptr);
+  DHEPZ_CHECK_EQ(descriptor->route_id, std::wstring_view(L"terminal"));
+
+  json::Value core_catalog;
+  DHEPZ_CHECK(json::Parse(Read(RepositoryRoot() / L"assets" / L"ui" / L"core.json"),
+                          &core_catalog)
+                  .ok());
+  std::vector<ui::config::Diagnostic> diagnostics;
+  std::unique_ptr<ui::config::ResolvedUiDocument> document;
+  DHEPZ_CHECK(ui::config::ResolveDocument(
+                  core_catalog,
+                  {{std::wstring(descriptor->screen_name),
+                    Read(RepositoryRoot() / L"src" / L"modules" / L"terminal" /
+                         L"terminal.json")}},
+                  &diagnostics, &document)
+                  .ok());
+  DHEPZ_CHECK(document != nullptr);
+  DHEPZ_CHECK(document->FindRoute(L"terminal") != nullptr);
+  ui::config::Rgba accent;
+  DHEPZ_CHECK(document->Token(L"dark", L"accent", &accent));
+}
+
+DHEPZ_TEST(P4Terminal, ActionsUseTheSameExplicitWindowsTerminalProfilesAsV1) {
+  const modules::ModuleDescriptor* descriptor = modules::ModuleRegistry::Find(L"terminal");
+  DHEPZ_CHECK(descriptor != nullptr);
+  std::unique_ptr<modules::ModuleController> controller = descriptor->create();
+  DHEPZ_CHECK(controller != nullptr);
+
+  FakeHost host;
+  ui::application::UiActionRegistry actions;
+  DHEPZ_CHECK(controller->Bind(&host, &actions).ok());
+  ui::application::UiState state;
+  DHEPZ_CHECK(state.Apply(controller->InitialState(host)));
+
+  ui::application::UiEvent browse{L"terminal.browse", L"browse-folder", {}};
+  DHEPZ_CHECK(state.Apply(actions.Dispatch(browse, state)));
+  DHEPZ_CHECK_EQ(state.Text(L"terminal.path"), std::wstring(L"C:\\picked"));
+
+  state.Set(L"terminal.path", std::wstring(L"C:\\work"));
+  state.Set(L"terminal.venv", true);
+  ui::application::UiEvent wsl{L"terminal.launch.wsl", L"ubuntu-wsl", {}};
+  DHEPZ_CHECK(state.Apply(actions.Dispatch(wsl, state)));
+  host.Complete();
+  DHEPZ_CHECK_FALSE(host.started_.empty());
+  const modules::ProcessRequest& request = host.started_.back();
+  DHEPZ_CHECK_EQ(request.executable, std::wstring(L"wt.exe"));
+  DHEPZ_CHECK_FALSE(request.elevated);
+  DHEPZ_CHECK(std::find(request.arguments.begin(), request.arguments.end(), L"Ubuntu") !=
+              request.arguments.end());
+  DHEPZ_CHECK(std::find(request.arguments.begin(), request.arguments.end(), L"-p") !=
+              request.arguments.end());
+  DHEPZ_CHECK(std::find_if(request.arguments.begin(), request.arguments.end(),
+                           [](const auto& argument) {
+                             return argument.find(L".venv-wsl/bin/activate") !=
+                                    std::wstring::npos;
+                           }) != request.arguments.end());
+  DHEPZ_CHECK(std::find_if(host.ran_.begin(), host.ran_.end(), [](const auto& process) {
+                return std::any_of(process.arguments.begin(), process.arguments.end(),
+                                   [](const auto& argument) {
+                                     return argument.find(L".venv-wsl") !=
+                                            std::wstring::npos;
+                                   });
+              }) != host.ran_.end());
+
+  ui::application::UiEvent normal{L"terminal.launch.default", L"windows-terminal", {}};
+  const ui::application::UiPatch normal_patch = actions.Dispatch(normal, state);
+  DHEPZ_CHECK_FALSE(normal_patch.empty());
+  (void)state.Apply(normal_patch);
+  host.Complete();
+  DHEPZ_CHECK_FALSE(host.started_.back().elevated);
+  DHEPZ_CHECK(std::find(host.started_.back().arguments.begin(),
+                        host.started_.back().arguments.end(), L"PowerShell") !=
+              host.started_.back().arguments.end());
+  DHEPZ_CHECK(std::find(host.started_.back().arguments.begin(),
+                        host.started_.back().arguments.end(), L"pwsh.exe") !=
+              host.started_.back().arguments.end());
+  DHEPZ_CHECK(std::find_if(host.started_.back().arguments.begin(),
+                           host.started_.back().arguments.end(), [](const auto& argument) {
+                             return argument.find(L"Activate.ps1") != std::wstring::npos;
+                           }) != host.started_.back().arguments.end());
+
+  ui::application::UiEvent admin{L"terminal.launch.admin", L"windows-terminal-admin", {}};
+  const ui::application::UiPatch admin_patch = actions.Dispatch(admin, state);
+  DHEPZ_CHECK_FALSE(admin_patch.empty());
+  (void)state.Apply(admin_patch);
+  host.Complete();
+  DHEPZ_CHECK(host.started_.back().elevated);
+  DHEPZ_CHECK(std::find(host.started_.back().arguments.begin(),
+                        host.started_.back().arguments.end(), L"PowerShell") !=
+              host.started_.back().arguments.end());
+}
+
+DHEPZ_TEST(P4Terminal, SuccessfulLaunchClosesOnlyThroughTheParentRequest) {
+  const modules::ModuleDescriptor* descriptor = modules::ModuleRegistry::Find(L"terminal");
+  DHEPZ_CHECK(descriptor != nullptr);
+  std::unique_ptr<modules::ModuleController> controller = descriptor->create();
+  DHEPZ_CHECK(controller != nullptr);
+
+  FakeHost host;
+  ui::application::UiActionRegistry actions;
+  DHEPZ_CHECK(controller->Bind(&host, &actions).ok());
+  ui::application::UiState state;
+  DHEPZ_CHECK(state.Apply(controller->InitialState(host)));
+
+  ui::application::UiEvent launch{L"terminal.launch.default", L"windows-terminal", {}};
+  DHEPZ_CHECK(state.Apply(actions.Dispatch(launch, state)));
+  host.Complete();
+  DHEPZ_CHECK_EQ(host.close_if_unpinned_requests_, 1);
+
+  std::unique_ptr<modules::ModuleController> failed_controller = descriptor->create();
+  DHEPZ_CHECK(failed_controller != nullptr);
+  FakeHost failed_host;
+  failed_host.start_status_ =
+      DHEPZ_ERR(core::ErrorCode::Internal, L"Windows Terminal could not be opened");
+  ui::application::UiActionRegistry failed_actions;
+  DHEPZ_CHECK(failed_controller->Bind(&failed_host, &failed_actions).ok());
+  ui::application::UiState failed_state;
+  DHEPZ_CHECK(failed_state.Apply(failed_controller->InitialState(failed_host)));
+  DHEPZ_CHECK(failed_state.Apply(failed_actions.Dispatch(launch, failed_state)));
+  failed_host.Complete();
+  DHEPZ_CHECK_EQ(failed_host.close_if_unpinned_requests_, 0);
+}


### PR DESCRIPTION
## Summary
- wire the Terminal child module through the parent-owned ModuleHost contract
- provide folder selection, recent paths, optional Python venv preparation, Windows Terminal admin/default launches, and Ubuntu WSL launch
- complete the generic UI interactions required by the Terminal screen
- close the DHEPZ window after a successful launch when its chrome pin is off; keep it visible when pinned or when launch fails

## Validation
- Release build passed
- full Release suite: 147/147 passed

Tab reorder and multi-row behavior remain deferred.