### PR TITLE
Add persistent terminal state and GitHub updater

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,127 @@
+name: release
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: Version increment after the first release
+        required: true
+        default: patch
+        type: choice
+        options: [patch, minor, major]
+
+permissions:
+  checks: read
+  contents: write
+
+concurrency:
+  group: dhepz-release
+  cancel-in-progress: false
+
+jobs:
+  release:
+    runs-on: windows-2022
+    timeout-minutes: 40
+
+    steps:
+      - name: Require main branch
+        if: github.ref != 'refs/heads/main'
+        shell: pwsh
+        run: throw 'Release harus dijalankan dari branch main.'
+
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - uses: microsoft/setup-msbuild@v3
+
+      - uses: actions/setup-dotnet@v6
+        with:
+          dotnet-version: 9.0.304
+
+      - name: Require green CI for this commit
+        shell: pwsh
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          $response = gh api 'repos/${{ github.repository }}/commits/${{ github.sha }}/check-runs' | ConvertFrom-Json
+          $green = @($response.check_runs | Where-Object {
+            $_.name -eq 'build' -and $_.conclusion -eq 'success'
+          })
+          if ($green.Count -eq 0) {
+            throw 'The build check has not passed for this exact commit.'
+          }
+
+      - name: Determine release version
+        id: version
+        shell: pwsh
+        run: |
+          $version = ./tools/Get-ReleaseVersion.ps1 -Bump '${{ inputs.bump }}'
+          "version=$version" >> $env:GITHUB_OUTPUT
+
+      - name: Prepare release notes
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Path artifacts -Force | Out-Null
+          $previousTag = git tag --sort=-v:refname | Select-Object -First 1
+          $lines = if ($previousTag) {
+            @(git log "$previousTag..HEAD" --pretty=format:'- %s')
+          } else {
+            @('- Initial installer and GitHub updater release.')
+          }
+          @(
+            "# dhepz ${{ steps.version.outputs.version }}"
+            ''
+            $lines
+          ) | Set-Content -LiteralPath artifacts/release-notes.md -Encoding utf8
+
+      - name: Download previous Velopack release
+        shell: pwsh
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          $releases = @(gh release list --limit 1 --json tagName | ConvertFrom-Json)
+          if ($releases.Count -gt 0) {
+            dotnet tool restore
+            dotnet vpk download github `
+              --repoUrl 'https://github.com/${{ github.repository }}' `
+              --outputDir Releases `
+              --token $env:GITHUB_TOKEN
+          } else {
+            Write-Host 'No previous release; full package only.'
+          }
+
+      - name: Package release
+        shell: pwsh
+        run: |
+          ./tools/Build-Release.ps1 `
+            -Version '${{ steps.version.outputs.version }}' `
+            -ReleaseNotes artifacts/release-notes.md
+
+      - name: Publish GitHub Release
+        shell: pwsh
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          dotnet vpk upload github `
+            --repoUrl 'https://github.com/${{ github.repository }}' `
+            --outputDir Releases `
+            --token $env:GITHUB_TOKEN `
+            --publish `
+            --releaseName 'dhepz ${{ steps.version.outputs.version }}' `
+            --tag 'v${{ steps.version.outputs.version }}' `
+            --targetCommitish '${{ github.sha }}'
+
+      - name: Release summary
+        shell: pwsh
+        run: |
+          $setup = Get-ChildItem Releases -Filter '*-Setup.exe' |
+            Sort-Object LastWriteTime -Descending |
+            Select-Object -First 1
+          $hash = (Get-FileHash -LiteralPath $setup.FullName -Algorithm SHA256).Hash
+          @(
+            "## dhepz ${{ steps.version.outputs.version }}"
+            ''
+            "Installer: $($setup.Name)"
+            "SHA-256: ``$hash``"
+          ) >> $env:GITHUB_STEP_SUMMARY

--- a/assets/ui/core.json
+++ b/assets/ui/core.json
@@ -32,7 +32,9 @@
       "id": { "kind": "string" },
       "style": { "kind": "string" },
       "visible": { "kind": "bool", "default": true },
+      "visible_binding": { "kind": "binding" },
       "enabled": { "kind": "bool", "default": true },
+      "enabled_binding": { "kind": "binding" },
       "accessible_name": { "kind": "string" },
       "width": { "kind": "int" },
       "height": { "kind": "int" },
@@ -116,6 +118,7 @@
     "button": {
       "properties": {
         "label": { "kind": "text", "required": true },
+        "label_binding": { "kind": "binding" },
         "action": { "kind": "string", "required": true },
         "variant": {
           "kind": "enum",
@@ -188,6 +191,21 @@
         "interactive": { "kind": "bool", "default": false },
         "selected_binding": { "kind": "binding" },
         "tab_stop": { "kind": "bool", "default": false },
+        "direction": {
+          "kind": "enum",
+          "values": ["row", "column", "grid", "flow"],
+          "default": "column"
+        },
+        "align": {
+          "kind": "enum",
+          "values": ["start", "center", "end", "stretch"],
+          "default": "stretch"
+        },
+        "justify": {
+          "kind": "enum",
+          "values": ["start", "center", "end", "space-between"],
+          "default": "start"
+        },
         "padding": { "kind": "object" },
         "gap": { "kind": "int", "default": 8 }
       }

--- a/assets/ui/screens/settings.json
+++ b/assets/ui/screens/settings.json
@@ -2,7 +2,85 @@
   "components": [
     {
       "type": "screen",
-      "route_id": "settings"
+      "route_id": "settings",
+      "show_in_tabs": false,
+      "children": [
+        {
+          "type": "container",
+          "direction": "column",
+          "padding": { "top": 10, "right": 10, "bottom": 10, "left": 10 },
+          "gap": 10,
+          "children": [
+            {
+              "type": "card",
+              "interactive": false,
+              "height": 88,
+              "direction": "row",
+              "align": "center",
+              "padding": { "top": 8, "right": 8, "bottom": 8, "left": 8 },
+              "gap": 10,
+              "children": [
+                {
+                  "type": "container",
+                  "direction": "column",
+                  "width": 260,
+                  "gap": 3,
+                  "children": [
+                    {
+                      "type": "text",
+                      "text": "Updates",
+                      "variant": "title",
+                      "height": 24
+                    },
+                    {
+                      "type": "text",
+                      "text": "Version 0.0.0",
+                      "text_binding": "settings.update.version",
+                      "variant": "caption",
+                      "height": 14
+                    },
+                    {
+                      "type": "text",
+                      "text": "Siap memeriksa pembaruan.",
+                      "text_binding": "settings.update.status",
+                      "variant": "caption",
+                      "height": 28
+                    }
+                  ]
+                },
+                {
+                  "type": "container",
+                  "direction": "column",
+                  "justify": "center",
+                  "width": 80,
+                  "gap": 6,
+                  "children": [
+                    {
+                      "type": "button",
+                      "id": "check-update",
+                      "label": "Check now",
+                      "action": "settings.update.check",
+                      "enabled_binding": "settings.update.can_check",
+                      "height": 32
+                    },
+                    {
+                      "type": "button",
+                      "id": "install-update",
+                      "label": "Update & Restart",
+                      "label_binding": "settings.update.install_label",
+                      "action": "settings.update.install",
+                      "variant": "primary",
+                      "visible_binding": "settings.update.available",
+                      "enabled_binding": "settings.update.can_install",
+                      "height": 32
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/src/dhepz.vcxproj
+++ b/src/dhepz.vcxproj
@@ -48,6 +48,7 @@
     <IntDir>$(SolutionDir)build\obj\$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
     <GeneratedDir>$(SolutionDir)build\generated\</GeneratedDir>
     <TargetName>dhepz</TargetName>
+    <VelopackRoot>$(SolutionDir)build\deps\velopack-1.2.0</VelopackRoot>
   </PropertyGroup>
 
   <!-- Version strings reach both cl and rc through a generated header rather
@@ -87,7 +88,7 @@
       <PreprocessorDefinitions>
         UNICODE;_UNICODE;WIN32_LEAN_AND_MEAN;NOMINMAX;WINVER=0x0A00;_WIN32_WINNT=0x0A00;DHEPZ_VERSION_MAJOR=$(DhepzVersionMajor);DHEPZ_VERSION_MINOR=$(DhepzVersionMinor);DHEPZ_VERSION_PATCH=$(DhepzVersionPatch);DHEPZ_VERSION_BUILD=$(DhepzVersionBuild);%(PreprocessorDefinitions)
       </PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(ProjectDir);$(GeneratedDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir);$(GeneratedDir);$(VelopackRoot)\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalOptions>/utf-8 /Zc:__cplusplus /Zc:preprocessor /Zc:inline %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
@@ -101,7 +102,8 @@
       <!-- /CETCOMPAT and HighEntropyVA are the two most commonly forgotten
            hardening flags; both are set deliberately. -->
       <AdditionalOptions>/CETCOMPAT %(AdditionalOptions)</AdditionalOptions>
-      <AdditionalDependencies>user32.lib;gdi32.lib;shell32.lib;shlwapi.lib;advapi32.lib;ole32.lib;windowsapp.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>$(VelopackRoot)\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>user32.lib;gdi32.lib;shell32.lib;shlwapi.lib;advapi32.lib;ole32.lib;windowsapp.lib;velopack_libc_win_x64_msvc.dll.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <Manifest>
       <AdditionalManifestFiles>$(ProjectDir)app.manifest</AdditionalManifestFiles>
@@ -158,6 +160,11 @@
     <ResourceCompile Include="app.rc" />
     <ResourceCompile Include="modules\**\*.rc" />
   </ItemGroup>
+
+  <Target Name="CopyVelopackRuntime" AfterTargets="Build">
+    <Copy SourceFiles="$(VelopackRoot)\lib\velopack_libc_win_x64_msvc.dll"
+          DestinationFiles="$(OutDir)velopack_libc.dll" />
+  </Target>
 
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,6 +8,7 @@
 #include "orchestrator/window_orchestrator.h"
 #include "parent/logic/module_registry.h"
 #include "platform/performance_trace.h"
+#include "platform/app_update_service.h"
 #include "platform/tray_process.h"
 #include "parent/ui/config/embedded_settings_loader.h"
 
@@ -38,6 +39,8 @@ int APIENTRY wWinMain(_In_ HINSTANCE instance,
   UNREFERENCED_PARAMETER(previous);
   UNREFERENCED_PARAMETER(command_line);
   UNREFERENCED_PARAMETER(show_command);
+
+  update::RunVelopackStartup();
 
   static_assert(dhepz::version::kMajor >= 0,
                 "version.props must reach the compiler as defines");

--- a/src/modules/terminal/terminal_module.cpp
+++ b/src/modules/terminal/terminal_module.cpp
@@ -246,8 +246,9 @@ core::Status Launch(const BackgroundCapabilities& capabilities, LaunchKind kind,
 class TerminalController final : public ModuleController {
  public:
   ui::application::UiPatch InitialState(const ModuleHost& host) const override {
-    ui::application::UiPatch patch;
     const std::wstring default_directory = host.DefaultDirectory();
+    ui::application::UiState state;
+    ui::application::UiPatch patch;
     Add(&patch, L"terminal.path", default_directory);
     Add(&patch, L"terminal.recent_paths",
         default_directory.empty() ? std::vector<std::wstring>{}
@@ -255,6 +256,11 @@ class TerminalController final : public ModuleController {
     Add(&patch, L"terminal.venv", false);
     Add(&patch, L"terminal.status", std::wstring{});
     Add(&patch, L"terminal.busy", false);
+    (void)state.Apply(patch);
+    (void)state.Apply(host.RestoredState(L"terminal."));
+    const std::wstring restored_path = state.Text(L"terminal.path", default_directory);
+    Add(&patch, L"terminal.path", restored_path);
+    Add(&patch, L"terminal.recent_paths", RecentPaths(state, restored_path));
     return patch;
   }
 
@@ -292,6 +298,7 @@ class TerminalController final : public ModuleController {
     return actions->Register(std::move(action), [this, kind](const auto&, const auto& state) {
       const std::wstring path = state.Text(L"terminal.path");
       const bool prepare_venv = state.Bool(L"terminal.venv");
+      const std::vector<std::wstring> recent_paths = RecentPaths(state, path);
       CancelPendingVenv();
       std::shared_ptr<std::atomic<bool>> request_cancelled;
       if (prepare_venv) {
@@ -299,11 +306,15 @@ class TerminalController final : public ModuleController {
         pending_venv_ = request_cancelled;
       }
       host_->RunBackground(
-          [kind, path, prepare_venv, request_cancelled](
+          [kind, path, prepare_venv, recent_paths, request_cancelled](
               const BackgroundCapabilities& capabilities,
               const std::atomic<bool>& cancelled) {
-            return Launch(capabilities, kind, path, prepare_venv, cancelled,
-                          request_cancelled.get());
+            DHEPZ_RETURN_IF_ERROR(Launch(capabilities, kind, path, prepare_venv,
+                                         cancelled, request_cancelled.get()));
+            ui::application::UiPatch persisted;
+            Add(&persisted, L"terminal.path", path);
+            Add(&persisted, L"terminal.recent_paths", recent_paths);
+            return capabilities.PersistState(persisted);
           },
           [this, request_cancelled](const core::Status& status) {
             if (request_cancelled != nullptr && request_cancelled->load()) return;
@@ -316,7 +327,7 @@ class TerminalController final : public ModuleController {
           });
       ui::application::UiPatch pending;
       Add(&pending, L"terminal.busy", true);
-      Add(&pending, L"terminal.recent_paths", RecentPaths(state, path));
+      Add(&pending, L"terminal.recent_paths", recent_paths);
       Add(&pending, L"terminal.status",
           prepare_venv ? std::wstring(L"Checking Python venv...")
                        : std::wstring(L"Opening terminal..."));

--- a/src/orchestrator/module_host.cpp
+++ b/src/orchestrator/module_host.cpp
@@ -3,6 +3,7 @@
 #include <windows.h>
 
 #include "parent/ui/runtime/parent_ui.h"
+#include "parent/logic/module_state_store.h"
 #include "platform/folder_picker.h"
 #include "platform/paths.h"
 #include "platform/process.h"
@@ -12,8 +13,9 @@
 namespace orchestrator {
 
 ModuleHostAdapter::ModuleHostAdapter(shell::AppWindow* window,
-                                     ui::containers::ParentUi* parent)
-    : window_(window), parent_(parent) {}
+                                     ui::containers::ParentUi* parent,
+                                     modules::ModuleStateStore* state_store)
+    : window_(window), parent_(parent), state_store_(state_store) {}
 
 ModuleHostAdapter::~ModuleHostAdapter() { Shutdown(); }
 
@@ -73,6 +75,11 @@ void ModuleHostAdapter::Shutdown() {
 
 std::wstring ModuleHostAdapter::DefaultDirectory() const { return paths::ExecutableDir(); }
 
+ui::application::UiPatch ModuleHostAdapter::RestoredState(std::wstring_view prefix) const {
+  return state_store_ != nullptr ? state_store_->Restore(prefix)
+                                 : ui::application::UiPatch{};
+}
+
 std::optional<std::wstring> ModuleHostAdapter::PickFolder(std::wstring_view initial_path) {
   return folder_picker::Pick(window_ != nullptr ? window_->hwnd() : nullptr, initial_path);
 }
@@ -116,6 +123,12 @@ core::Status ModuleHostAdapter::StartProcess(const modules::ProcessRequest& requ
 core::Status ModuleHostAdapter::RunProcess(const modules::ProcessRequest& request,
                                            std::wstring* standard_output) const {
   return process::Run(request, standard_output);
+}
+
+core::Status ModuleHostAdapter::PersistState(const ui::application::UiPatch& patch) const {
+  return state_store_ != nullptr
+             ? state_store_->Save(patch)
+             : DHEPZ_ERR(core::ErrorCode::Internal, L"Module state store is unavailable");
 }
 
 }  // namespace orchestrator

--- a/src/orchestrator/module_host.h
+++ b/src/orchestrator/module_host.h
@@ -17,12 +17,17 @@ namespace worker {
 class Worker;
 }
 
+namespace modules {
+class ModuleStateStore;
+}
+
 namespace orchestrator {
 
 class ModuleHostAdapter final : public modules::ModuleHost,
                                 public modules::BackgroundCapabilities {
  public:
-  ModuleHostAdapter(shell::AppWindow* window, ui::containers::ParentUi* parent);
+  ModuleHostAdapter(shell::AppWindow* window, ui::containers::ParentUi* parent,
+                    modules::ModuleStateStore* state_store);
   ~ModuleHostAdapter() override;
 
   ModuleHostAdapter(const ModuleHostAdapter&) = delete;
@@ -34,6 +39,7 @@ class ModuleHostAdapter final : public modules::ModuleHost,
   void Shutdown();
 
   std::wstring DefaultDirectory() const override;
+  ui::application::UiPatch RestoredState(std::wstring_view prefix) const override;
   std::optional<std::wstring> PickFolder(std::wstring_view initial_path) override;
   void RunBackground(modules::BackgroundWork work,
                      modules::BackgroundComplete complete) override;
@@ -45,10 +51,12 @@ class ModuleHostAdapter final : public modules::ModuleHost,
   core::Status StartProcess(const modules::ProcessRequest& request) const override;
   core::Status RunProcess(const modules::ProcessRequest& request,
                           std::wstring* standard_output) const override;
+  core::Status PersistState(const ui::application::UiPatch& patch) const override;
 
  private:
   shell::AppWindow* window_ = nullptr;
   ui::containers::ParentUi* parent_ = nullptr;
+  modules::ModuleStateStore* state_store_ = nullptr;
   std::unique_ptr<worker::Worker> worker_;
   unsigned int completion_message_ = 0;
   std::uint64_t generation_ = 0;

--- a/src/orchestrator/window_orchestrator.cpp
+++ b/src/orchestrator/window_orchestrator.cpp
@@ -7,10 +7,12 @@
 #include "core/status.h"
 #include "orchestrator/module_host.h"
 #include "parent/logic/module_contract.h"
+#include "parent/logic/module_state_store.h"
 #include "parent/ui/contracts/ui_action_registry.h"
 #include "parent/ui/runtime/parent_ui.h"
 #include "ui/app_window/app_window.h"
 #include "ui/settings/settings_window.h"
+#include "platform/paths.h"
 
 namespace orchestrator {
 
@@ -35,7 +37,11 @@ WindowOrchestrator::WindowOrchestrator(
     : instance_(instance),
       settings_document_(settings_document),
       feature_document_(feature_document),
-      feature_(feature) {}
+      feature_(feature),
+      state_store_(std::make_unique<modules::ModuleStateStore>(
+          paths::Join(paths::StateDir(), L"settings.json"))) {
+  (void)state_store_->Load();
+}
 
 WindowOrchestrator::~WindowOrchestrator() { CloseAll(); }
 
@@ -50,7 +56,8 @@ bool WindowOrchestrator::OpenWindow() {
 
   auto item = std::make_unique<WindowSession>();
   if (!item->window.Create(instance_, 400.0f, 360.0f)) return false;
-  item->host = std::make_unique<ModuleHostAdapter>(&item->window, &item->parent_ui);
+  item->host = std::make_unique<ModuleHostAdapter>(&item->window, &item->parent_ui,
+                                                   state_store_.get());
   if (!item->host->Start().ok()) return false;
   item->module = feature_->create();
   if (item->module == nullptr) return false;

--- a/src/orchestrator/window_orchestrator.h
+++ b/src/orchestrator/window_orchestrator.h
@@ -8,6 +8,7 @@ class ResolvedUiDocument;
 }
 
 namespace modules {
+class ModuleStateStore;
 struct ModuleDescriptor;
 }
 
@@ -35,6 +36,7 @@ class WindowOrchestrator final {
   const ui::config::ResolvedUiDocument* settings_document_ = nullptr;
   const ui::config::ResolvedUiDocument* feature_document_ = nullptr;
   const modules::ModuleDescriptor* feature_ = nullptr;
+  std::unique_ptr<modules::ModuleStateStore> state_store_;
   std::vector<std::unique_ptr<WindowSession>> windows_;
 };
 

--- a/src/parent/logic/module_contract.h
+++ b/src/parent/logic/module_contract.h
@@ -28,6 +28,7 @@ class BackgroundCapabilities {
   virtual core::Status StartProcess(const ProcessRequest& request) const = 0;
   virtual core::Status RunProcess(const ProcessRequest& request,
                                   std::wstring* standard_output) const = 0;
+  virtual core::Status PersistState(const ui::application::UiPatch& patch) const = 0;
 };
 
 using BackgroundWork = std::function<core::Status(
@@ -38,6 +39,7 @@ class ModuleHost {
  public:
   virtual ~ModuleHost() = default;
   virtual std::wstring DefaultDirectory() const = 0;
+  virtual ui::application::UiPatch RestoredState(std::wstring_view prefix) const = 0;
   virtual std::optional<std::wstring> PickFolder(std::wstring_view initial_path) = 0;
   virtual void RunBackground(BackgroundWork work, BackgroundComplete complete) = 0;
   virtual void Publish(ui::application::UiPatch patch) = 0;

--- a/src/parent/logic/module_state_store.cpp
+++ b/src/parent/logic/module_state_store.cpp
@@ -1,0 +1,101 @@
+#include "parent/logic/module_state_store.h"
+
+#include <algorithm>
+#include <utility>
+
+#include "core/json.h"
+#include "platform/files.h"
+
+namespace modules {
+namespace {
+
+json::Value ToJson(const ui::application::UiValue& value) {
+  if (const bool* typed = std::get_if<bool>(&value)) return json::Value::Bool(*typed);
+  if (const long long* typed = std::get_if<long long>(&value)) {
+    return json::Value::Number(std::to_wstring(*typed), static_cast<double>(*typed));
+  }
+  if (const std::wstring* typed = std::get_if<std::wstring>(&value)) {
+    return json::Value::String(*typed);
+  }
+  if (const auto* typed = std::get_if<std::vector<std::wstring>>(&value)) {
+    json::Value array = json::Value::Array();
+    for (const std::wstring& item : *typed) array.Append(json::Value::String(item));
+    return array;
+  }
+  return json::Value::Null();
+}
+
+ui::application::UiValue FromJson(const json::Value& value) {
+  if (value.is_bool()) return value.AsBool();
+  if (value.is_number()) return static_cast<long long>(value.AsNumber());
+  if (value.is_string()) return value.AsString();
+  if (value.is_array()) {
+    std::vector<std::wstring> items;
+    for (const json::Value& item : value.items()) {
+      if (item.is_string()) items.push_back(item.AsString());
+    }
+    return items;
+  }
+  return std::monostate{};
+}
+
+}  // namespace
+
+ModuleStateStore::ModuleStateStore(std::wstring path) : path_(std::move(path)) {}
+
+core::Status ModuleStateStore::Load() {
+  std::wstring text;
+  const core::Status read = files::ReadText(path_, &text);
+  if (!read.ok()) {
+    if (read.Code() == core::ErrorCode::NotFound) return core::Ok();
+    return read;
+  }
+  json::Value root;
+  DHEPZ_RETURN_IF_ERROR(json::Parse(text, &root));
+  if (!root.is_object()) {
+    return DHEPZ_ERR(core::ErrorCode::ParseError, L"settings.json must contain an object");
+  }
+
+  ui::application::UiPatch loaded;
+  for (const auto& [path, value] : root.members()) {
+    loaded.changes.push_back({path, FromJson(value)});
+  }
+  std::scoped_lock lock(mutex_);
+  state_ = std::move(loaded);
+  return core::Ok();
+}
+
+ui::application::UiPatch ModuleStateStore::Restore(std::wstring_view prefix) const {
+  std::scoped_lock lock(mutex_);
+  ui::application::UiPatch restored;
+  for (const ui::application::UiChange& change : state_.changes) {
+    if (change.path.starts_with(prefix)) restored.changes.push_back(change);
+  }
+  return restored;
+}
+
+core::Status ModuleStateStore::Save(const ui::application::UiPatch& patch) {
+  std::scoped_lock lock(mutex_);
+  ui::application::UiPatch next = state_;
+  for (const ui::application::UiChange& change : patch.changes) {
+    const auto found = std::find_if(next.changes.begin(), next.changes.end(),
+                                    [&change](const auto& item) {
+                                      return item.path == change.path;
+                                    });
+    if (found == next.changes.end()) {
+      next.changes.push_back(change);
+    } else {
+      found->value = change.value;
+    }
+  }
+
+  json::Value root = json::Value::Object();
+  for (const ui::application::UiChange& change : next.changes) {
+    root.Set(change.path, ToJson(change.value));
+  }
+  DHEPZ_RETURN_IF_ERROR(files::WriteTextAtomic(path_, json::Serialize(root)));
+  state_ = std::move(next);
+  return core::Ok();
+}
+
+}  // namespace modules

--- a/src/parent/logic/module_state_store.h
+++ b/src/parent/logic/module_state_store.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <mutex>
+#include <string>
+#include <string_view>
+
+#include "core/status.h"
+#include "parent/ui/contracts/ui_contract.h"
+
+namespace modules {
+
+class ModuleStateStore final {
+ public:
+  explicit ModuleStateStore(std::wstring path);
+
+  core::Status Load();
+  ui::application::UiPatch Restore(std::wstring_view prefix) const;
+  core::Status Save(const ui::application::UiPatch& patch);
+
+ private:
+  std::wstring path_;
+  mutable std::mutex mutex_;
+  ui::application::UiPatch state_;
+};
+
+}  // namespace modules

--- a/src/parent/ui/runtime/layout_engine.cpp
+++ b/src/parent/ui/runtime/layout_engine.cpp
@@ -26,6 +26,12 @@ Padding ReadPadding(const config::ComponentNode& node) {
   return padding;
 }
 
+bool IsVisible(const config::ComponentNode& node,
+               const application::UiState& state) {
+  return components::BoundBool(node, L"visible_binding", state,
+                               node.GetBool(L"visible", true));
+}
+
 render::Rect ContentBounds(const config::ComponentNode& node, const render::Rect& bounds) {
   render::Rect base = node.type() == L"dialog"
                           ? components::DialogPanelBounds(node, bounds)
@@ -76,7 +82,8 @@ LayoutNode LayoutEngine::BuildGrid(const config::ComponentNode& node, render::Re
                                                node.GetString(L"overflow") != L"visible"};
   std::vector<std::size_t> regular;
   for (std::size_t index = 0; index < node.children().size(); ++index) {
-    if (node.children()[index].type() != L"dialog") regular.push_back(index);
+    if (node.children()[index].type() != L"dialog" &&
+        IsVisible(node.children()[index], *state_)) regular.push_back(index);
   }
   const std::size_t count = regular.size();
   if (count == 0) {
@@ -116,7 +123,7 @@ LayoutNode LayoutEngine::BuildFlow(const config::ComponentNode& node, render::Re
   float y = content.y;
   float line_height = 0.0f;
   for (const config::ComponentNode& child : node.children()) {
-    if (child.type() == L"dialog") continue;
+    if (child.type() == L"dialog" || !IsVisible(child, *state_)) continue;
     render::Size desired = Measure(child, content.width);
     if (desired.width <= 0.0f) desired.width = content.width;
     if (desired.height <= 0.0f) desired.height = 34.0f;
@@ -156,7 +163,7 @@ LayoutNode LayoutEngine::BuildContainer(const config::ComponentNode& node, rende
   std::size_t flexible = 0;
   for (std::size_t index = 0; index < node.children().size(); ++index) {
     const config::ComponentNode& child = node.children()[index];
-    if (child.type() == L"dialog") continue;
+    if (child.type() == L"dialog" || !IsVisible(child, *state_)) continue;
     regular.push_back(index);
     render::Size size = Measure(child, content.width);
     const float main = row ? size.width : size.height;
@@ -219,7 +226,9 @@ LayoutNode LayoutEngine::BuildContainer(const config::ComponentNode& node, rende
 
 LayoutNode LayoutEngine::Build(const config::ComponentNode& node,
                                const render::Rect& available) {
-  if (!node.GetBool(L"visible", true)) return {&node, {}, {}, false};
+  if (!IsVisible(node, *state_)) {
+    return {&node, {}, {}, false};
+  }
   if (node.type() == L"dialog" &&
       !components::BoundBool(node, L"open_binding", *state_)) {
     return {&node, {}, {}, false};

--- a/src/parent/ui/runtime/screen_presenter.cpp
+++ b/src/parent/ui/runtime/screen_presenter.cpp
@@ -4,6 +4,8 @@
 #include <utility>
 #include <windows.h>
 
+#include "ui/components/component_helpers.h"
+
 namespace ui::presenter {
 
 ScreenPresenter::ScreenPresenter(render::RenderBackend* backend, application::UiState* state,
@@ -110,7 +112,8 @@ void ScreenPresenter::PaintNode(const layout::LayoutNode& node) {
     visual.hovered = node.source == hovered_;
     visual.pressed = node.source == pressed_;
     visual.focused = node.source == focus_.current();
-    visual.enabled = node.source->GetBool(L"enabled", true);
+    visual.enabled = components::BoundBool(*node.source, L"enabled_binding", *state_,
+                                           node.source->GetBool(L"enabled", true));
     descriptor->paint(*node.source, node.bounds, visual, palette_, *state_, *backend_);
   }
   if (node.clip_children) backend_->PushClip(node.bounds);
@@ -125,7 +128,9 @@ const layout::LayoutNode* ScreenPresenter::Hit(const layout::LayoutNode& node, f
   for (auto child = node.children.rbegin(); child != node.children.rend(); ++child) {
     if (const layout::LayoutNode* hit = Hit(*child, x, y)) return hit;
   }
-  if (!node.bounds.contains({x, y}) || !node.source->GetBool(L"enabled", true)) return nullptr;
+  if (!node.bounds.contains({x, y}) ||
+      !components::BoundBool(*node.source, L"enabled_binding", *state_,
+                             node.source->GetBool(L"enabled", true))) return nullptr;
   const components::ComponentDescriptor* descriptor = registry_.Find(node.source->type());
   if (descriptor == nullptr) return nullptr;
   const bool focusable = descriptor->can_focus != nullptr && descriptor->can_focus(*node.source);

--- a/src/platform/app_update_service.cpp
+++ b/src/platform/app_update_service.cpp
@@ -1,0 +1,145 @@
+#include "platform/app_update_service.h"
+
+#include <windows.h>
+
+#include <algorithm>
+#include <cstdlib>
+#include <exception>
+#include <utility>
+
+#pragma warning(push)
+#pragma warning(disable : 4100)
+#include <Velopack.hpp>
+#pragma warning(pop)
+
+#include "app_version.h"
+#include "platform/strings.h"
+
+namespace update {
+namespace {
+
+constexpr const char* kGithubRepositoryUrl = "https://github.com/yuzhayo/dhepz";
+constexpr const wchar_t* kLocalSourceVariable = L"DHEPZ_UPDATE_SOURCE";
+
+std::wstring Wide(std::string_view text) {
+  std::wstring result;
+  return str::FromUtf8(text, &result).ok() ? result : L"Unknown update error";
+}
+
+std::wstring ErrorText(const std::exception& error) {
+  const std::wstring converted = Wide(error.what());
+  return converted.empty() ? L"Unknown update error" : converted;
+}
+
+std::unique_ptr<Velopack::UpdateManager> CreateManager() {
+  wchar_t source[32768]{};
+  const DWORD count = GetEnvironmentVariableW(kLocalSourceVariable, source,
+                                               static_cast<DWORD>(std::size(source)));
+  if (count > 0 && count < std::size(source)) {
+    std::string utf8;
+    if (str::ToUtf8(std::wstring_view(source, count), &utf8).ok()) {
+      return std::make_unique<Velopack::UpdateManager>(utf8);
+    }
+  }
+  return std::make_unique<Velopack::UpdateManager>(
+      std::make_unique<Velopack::GithubSource>(kGithubRepositoryUrl, "", false));
+}
+
+}  // namespace
+
+AppUpdateService::AppUpdateService() {
+  snapshot_.current_version = dhepz::version::kString;
+  snapshot_.status = L"Pembaruan aktif setelah aplikasi di-install.";
+  try {
+    manager_ = CreateManager();
+    const std::string installed = manager_->GetCurrentVersion();
+    if (!installed.empty()) snapshot_.current_version = Wide(installed);
+    snapshot_.supported = !installed.empty() || manager_->IsPortable();
+    snapshot_.can_check = snapshot_.supported;
+    snapshot_.status = snapshot_.supported ? L"Siap memeriksa pembaruan."
+                                           : L"Pembaruan aktif setelah aplikasi di-install.";
+  } catch (const std::exception&) {
+    manager_.reset();
+  }
+}
+
+AppUpdateService::~AppUpdateService() = default;
+
+Snapshot AppUpdateService::snapshot() const { return snapshot_; }
+
+Snapshot AppUpdateService::Check() {
+  if (manager_ == nullptr || !snapshot_.supported) return snapshot_;
+  try {
+    const std::optional<Velopack::UpdateInfo> found = manager_->CheckForUpdates();
+    if (!found.has_value()) {
+      available_update_.reset();
+      snapshot_.available_version.clear();
+      snapshot_.status = L"Aplikasi sudah versi terbaru.";
+      snapshot_.available = false;
+      snapshot_.can_check = true;
+      snapshot_.can_install = false;
+      snapshot_.busy = false;
+      return snapshot_;
+    }
+    available_update_ = std::make_unique<Velopack::UpdateInfo>(*found);
+    snapshot_.available_version = Wide(found->TargetFullRelease.Version);
+    snapshot_.status = L"Versi " + snapshot_.available_version + L" tersedia.";
+    snapshot_.available = true;
+    snapshot_.can_check = true;
+    snapshot_.can_install = true;
+    snapshot_.busy = false;
+  } catch (const std::exception& error) {
+    snapshot_.status = L"Pemeriksaan gagal: " + ErrorText(error);
+    snapshot_.can_check = true;
+    snapshot_.can_install = available_update_ != nullptr;
+    snapshot_.busy = false;
+  }
+  return snapshot_;
+}
+
+Snapshot AppUpdateService::Download(const Progress& progress) {
+  if (manager_ == nullptr || available_update_ == nullptr) return Check();
+  try {
+    struct ProgressContext {
+      const Progress* callback = nullptr;
+    } context{&progress};
+    manager_->DownloadUpdates(
+        *available_update_,
+        [](void* user_data, size_t value) {
+          const auto* context = static_cast<const ProgressContext*>(user_data);
+          if (context != nullptr && context->callback != nullptr && *context->callback) {
+            (*context->callback)(static_cast<int>(std::min<size_t>(100, value)));
+          }
+        },
+        &context);
+    snapshot_.progress = 100;
+    snapshot_.status = L"Pembaruan siap. Memulai ulang aplikasi...";
+    snapshot_.busy = false;
+    snapshot_.can_check = false;
+    snapshot_.can_install = false;
+  } catch (const std::exception& error) {
+    snapshot_.status = L"Pembaruan gagal: " + ErrorText(error);
+    snapshot_.busy = false;
+    snapshot_.can_check = true;
+    snapshot_.can_install = available_update_ != nullptr;
+  }
+  return snapshot_;
+}
+
+bool AppUpdateService::ScheduleRestart(std::wstring* error) {
+  if (manager_ == nullptr || available_update_ == nullptr) {
+    if (error != nullptr) *error = L"Tidak ada pembaruan yang siap dipasang.";
+    return false;
+  }
+  try {
+    manager_->WaitExitThenApplyUpdates(*available_update_, false, true, {});
+    return true;
+  } catch (const std::exception& exception) {
+    if (error != nullptr) *error = ErrorText(exception);
+    return false;
+  }
+}
+
+void RunVelopackStartup() { Velopack::VelopackApp::Build().Run(); }
+
+}  // namespace update

--- a/src/platform/app_update_service.h
+++ b/src/platform/app_update_service.h
@@ -1,0 +1,54 @@
+#pragma once
+
+#include <functional>
+#include <memory>
+#include <string>
+
+namespace Velopack {
+class UpdateManager;
+struct UpdateInfo;
+}
+
+namespace update {
+
+struct Snapshot {
+  std::wstring current_version;
+  std::wstring available_version;
+  std::wstring status;
+  long long progress = 0;
+  bool supported = false;
+  bool can_check = false;
+  bool can_install = false;
+  bool busy = false;
+  bool available = false;
+};
+
+// Thin platform adapter around Velopack. It deliberately exposes synchronous
+// operations: Settings owns the worker boundary, so this class never touches UI
+// state or creates a resident thread.
+class AppUpdateService final {
+ public:
+  using Progress = std::function<void(int)>;
+
+  AppUpdateService();
+  ~AppUpdateService();
+
+  AppUpdateService(const AppUpdateService&) = delete;
+  AppUpdateService& operator=(const AppUpdateService&) = delete;
+
+  Snapshot snapshot() const;
+  Snapshot Check();
+  Snapshot Download(const Progress& progress);
+  bool ScheduleRestart(std::wstring* error);
+
+ private:
+  std::unique_ptr<Velopack::UpdateManager> manager_;
+  std::unique_ptr<Velopack::UpdateInfo> available_update_;
+  Snapshot snapshot_;
+};
+
+// Must run at the beginning of wWinMain so install/update lifecycle arguments
+// are consumed before dhepz creates its tray or windows.
+void RunVelopackStartup();
+
+}  // namespace update

--- a/src/ui/components/button/button_component.cpp
+++ b/src/ui/components/button/button_component.cpp
@@ -7,17 +7,19 @@
 namespace ui::components {
 namespace {
 render::Size Measure(const config::ComponentNode& node, render::RenderBackend& backend,
-                     const application::UiState&, float max_width) {
-  const render::Size label = backend.MeasureText(node.GetString(L"label"), {}, max_width);
+                     const application::UiState& state, float max_width) {
+  const std::wstring label =
+      BoundText(node, L"label_binding", state, node.GetString(L"label"));
+  const render::Size measured_label = backend.MeasureText(label, {}, max_width);
   const float width = static_cast<float>(node.GetInt(
-      L"width", static_cast<long long>(std::max(32.0f, label.width + 18.0f))));
+      L"width", static_cast<long long>(std::max(32.0f, measured_label.width + 18.0f))));
   const float height = static_cast<float>(node.GetInt(L"height", 32));
   return {std::min(max_width, width), height};
 }
 
 void Paint(const config::ComponentNode& node, const render::Rect& bounds,
            const ComponentVisualState& visual, const ComponentPalette& palette,
-           const application::UiState&, render::RenderBackend& backend) {
+           const application::UiState& state, render::RenderBackend& backend) {
   render::Color fill = visual.pressed ? palette.control_pressed
                                       : visual.hovered ? palette.control_hover : palette.control;
   if (node.GetString(L"variant") == L"danger" && (visual.hovered || visual.pressed)) {
@@ -33,7 +35,8 @@ void Paint(const config::ComponentNode& node, const render::Rect& bounds,
   render::TextStyle label_style;
   label_style.family = node.GetString(L"font_family", L"Segoe UI");
   label_style.size_px = static_cast<float>(node.GetInt(L"font_size", 14));
-  backend.DrawTextRun(node.GetString(L"label"), bounds, label_style, palette.text,
+  backend.DrawTextRun(BoundText(node, L"label_binding", state, node.GetString(L"label")),
+                      bounds, label_style, palette.text,
                       render::TextAlign::Center, render::VerticalAlign::Middle);
   PaintFocus(bounds, visual, palette, backend);
 }

--- a/src/ui/settings/settings_update_controller.cpp
+++ b/src/ui/settings/settings_update_controller.cpp
@@ -1,0 +1,151 @@
+#include "ui/settings/settings_update_controller.h"
+
+#include <windows.h>
+
+#include <atomic>
+#include <utility>
+
+#include "core/status.h"
+#include "parent/ui/runtime/parent_ui.h"
+#include "platform/worker.h"
+#include "ui/app_window/app_window.h"
+
+namespace ui::settings {
+namespace {
+
+constexpr std::wstring_view kCheckAction = L"settings.update.check";
+constexpr std::wstring_view kInstallAction = L"settings.update.install";
+
+struct UpdateResult {
+  update::Snapshot snapshot;
+  bool restart = false;
+};
+
+}  // namespace
+
+SettingsUpdateController::SettingsUpdateController() = default;
+SettingsUpdateController::~SettingsUpdateController() { Detach(); }
+
+core::Status SettingsUpdateController::Attach(shell::AppWindow* window,
+                                              containers::ParentUi* parent,
+                                              application::UiActionRegistry* actions) {
+  if (window == nullptr || !window->alive() || parent == nullptr || actions == nullptr) {
+    return DHEPZ_ERR(core::ErrorCode::InvalidArgument,
+                     L"Settings updater requires live dependencies");
+  }
+  Detach();
+  window_ = window;
+  parent_ = parent;
+  completion_message_ = RegisterWindowMessageW(L"dhepz.settings.update.complete.v1");
+  if (completion_message_ == 0) {
+    return DHEPZ_ERR(core::ErrorCode::Internal,
+                     L"Settings update completion message registration failed");
+  }
+  worker_ = std::make_unique<worker::Worker>(window_->hwnd(), completion_message_);
+  generation_ = worker_->CreateGeneration();
+  window_->set_native_message_handler([this](unsigned int message, long long lparam) {
+    if (message != completion_message_ || worker_ == nullptr) return false;
+    worker::Worker::Settle(lparam);
+    worker_->JoinFinished();
+    return true;
+  });
+  const auto check = [this](const application::UiEvent&, const application::UiState&) {
+    return BeginCheck();
+  };
+  const auto install = [this](const application::UiEvent&, const application::UiState&) {
+    return BeginInstall();
+  };
+  if (!(actions->Has(kCheckAction) ? actions->Replace(kCheckAction, check)
+                                  : actions->Register(std::wstring(kCheckAction), check)) ||
+      !(actions->Has(kInstallAction) ? actions->Replace(kInstallAction, install)
+                                    : actions->Register(std::wstring(kInstallAction), install))) {
+    Detach();
+    return DHEPZ_ERR(core::ErrorCode::Internal, L"Settings update actions could not be bound");
+  }
+  return core::Ok();
+}
+
+void SettingsUpdateController::Detach() {
+  if (worker_ != nullptr) {
+    worker_->InvalidateGeneration(generation_);
+    worker_->Shutdown();
+  }
+  if (window_ != nullptr) window_->set_native_message_handler({});
+  worker_.reset();
+  generation_ = 0;
+  completion_message_ = 0;
+  parent_ = nullptr;
+  window_ = nullptr;
+}
+
+application::UiPatch SettingsUpdateController::InitialPatch() const {
+  return PatchFor(service_.snapshot());
+}
+
+application::UiPatch SettingsUpdateController::PatchFor(
+    const update::Snapshot& snapshot) const {
+  std::wstring install_label = L"Update";
+  return {{{L"settings.update.version", L"Version " + snapshot.current_version},
+           {L"settings.update.status", snapshot.status},
+           {L"settings.update.install_label", std::move(install_label)},
+           {L"settings.update.can_check", snapshot.can_check},
+           {L"settings.update.can_install", snapshot.can_install},
+           {L"settings.update.available", snapshot.available}},
+          {}};
+}
+
+application::UiPatch SettingsUpdateController::BeginCheck() {
+  if (worker_ == nullptr || !service_.snapshot().can_check) return {};
+  update::Snapshot busy = service_.snapshot();
+  busy.status = L"Memeriksa pembaruan...";
+  busy.busy = true;
+  busy.can_check = false;
+  busy.can_install = false;
+  worker_->Submit(
+      [this](const std::atomic<bool>& cancelled) {
+        if (cancelled.load()) return std::shared_ptr<void>{};
+        auto result = std::make_shared<UpdateResult>();
+        result->snapshot = service_.Check();
+        return std::static_pointer_cast<void>(result);
+      },
+      [this](std::shared_ptr<void> cargo) {
+        const auto result = std::static_pointer_cast<UpdateResult>(std::move(cargo));
+        if (result != nullptr && parent_ != nullptr) parent_->ApplyPatch(PatchFor(result->snapshot));
+      },
+      generation_);
+  return PatchFor(busy);
+}
+
+application::UiPatch SettingsUpdateController::BeginInstall() {
+  if (worker_ == nullptr || !service_.snapshot().can_install) return {};
+  update::Snapshot busy = service_.snapshot();
+  busy.status = L"Mengunduh pembaruan...";
+  busy.busy = true;
+  busy.can_check = false;
+  busy.can_install = false;
+  worker_->Submit(
+      [this](const std::atomic<bool>& cancelled) {
+        auto result = std::make_shared<UpdateResult>();
+        result->snapshot = service_.Download([&cancelled](int) {
+          // Velopack's C callback cannot cancel the transfer, but retaining
+          // the flag here keeps the job compatible with the worker contract.
+          (void)cancelled.load();
+        });
+        if (result->snapshot.progress == 100) {
+          std::wstring error;
+          result->restart = service_.ScheduleRestart(&error);
+          if (!result->restart && !error.empty()) result->snapshot.status = L"Pembaruan gagal: " + error;
+        }
+        return std::static_pointer_cast<void>(result);
+      },
+      [this](std::shared_ptr<void> cargo) {
+        const auto result = std::static_pointer_cast<UpdateResult>(std::move(cargo));
+        if (result == nullptr) return;
+        if (parent_ != nullptr) parent_->ApplyPatch(PatchFor(result->snapshot));
+        if (result->restart) PostQuitMessage(0);
+      },
+      generation_);
+  return PatchFor(busy);
+}
+
+}  // namespace ui::settings

--- a/src/ui/settings/settings_update_controller.h
+++ b/src/ui/settings/settings_update_controller.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <cstdint>
+#include <memory>
+
+#include "core/status.h"
+#include "parent/ui/contracts/ui_action_registry.h"
+#include "platform/app_update_service.h"
+
+namespace shell {
+class AppWindow;
+}
+
+namespace ui::containers {
+class ParentUi;
+}
+
+namespace worker {
+class Worker;
+}
+
+namespace ui::settings {
+
+class SettingsUpdateController final {
+ public:
+  SettingsUpdateController();
+  ~SettingsUpdateController();
+
+  core::Status Attach(shell::AppWindow* window, containers::ParentUi* parent,
+                      application::UiActionRegistry* actions);
+  void Detach();
+  application::UiPatch InitialPatch() const;
+
+ private:
+  application::UiPatch PatchFor(const update::Snapshot& snapshot) const;
+  application::UiPatch BeginCheck();
+  application::UiPatch BeginInstall();
+
+  update::AppUpdateService service_;
+  shell::AppWindow* window_ = nullptr;
+  containers::ParentUi* parent_ = nullptr;
+  std::unique_ptr<worker::Worker> worker_;
+  unsigned int completion_message_ = 0;
+  std::uint64_t generation_ = 0;
+};
+
+}  // namespace ui::settings

--- a/src/ui/settings/settings_window.cpp
+++ b/src/ui/settings/settings_window.cpp
@@ -28,18 +28,28 @@ core::Status SettingsWindow::Open(void* instance, void* owner_window,
   if (!window_.Create(instance, 400.0f, 360.0f)) {
     return DHEPZ_ERR(core::ErrorCode::Internal, L"Settings window creation failed");
   }
+  const core::Status updater = updater_.Attach(&window_, &parent_ui_, &actions_);
+  if (!updater.ok()) {
+    window_.Destroy();
+    return updater;
+  }
   const core::Status attached = parent_ui_.Attach(&window_, document, &actions_);
   if (!attached.ok()) {
+    updater_.Detach();
     window_.Destroy();
     return attached;
   }
+  parent_ui_.ApplyPatch(updater_.InitialPatch());
+  window_.set_close_handler([this] { Close(); });
   window_.PlaceBeside(owner_window);
   window_.Show();
   return core::Ok();
 }
 
 void SettingsWindow::Close() {
+  updater_.Detach();
   parent_ui_.Detach();
+  window_.set_close_handler({});
   window_.Destroy();
 }
 

--- a/src/ui/settings/settings_window.h
+++ b/src/ui/settings/settings_window.h
@@ -5,6 +5,7 @@
 #include "parent/ui/contracts/ui_action_registry.h"
 #include "parent/ui/runtime/parent_ui.h"
 #include "ui/app_window/app_window.h"
+#include "ui/settings/settings_update_controller.h"
 
 namespace ui::settings {
 
@@ -28,6 +29,7 @@ class SettingsWindow final {
   application::UiActionRegistry actions_;
   shell::AppWindow window_;
   containers::ParentUi parent_ui_;
+  SettingsUpdateController updater_;
 };
 
 }  // namespace ui::settings

--- a/tests/dhepz_tests.vcxproj
+++ b/tests/dhepz_tests.vcxproj
@@ -49,6 +49,7 @@
     <IntDir>$(SolutionDir)build\obj\$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
     <GeneratedDir>$(SolutionDir)build\generated\</GeneratedDir>
     <TargetName>dhepz_tests</TargetName>
+    <VelopackRoot>$(SolutionDir)build\deps\velopack-1.2.0</VelopackRoot>
   </PropertyGroup>
 
   <ItemDefinitionGroup>
@@ -70,7 +71,7 @@
            then ..\src so it can include "core/status.h" exactly as the app does.
            A test that includes a header by a different path than production
            code is a test of a different header. -->
-      <AdditionalIncludeDirectories>$(ProjectDir);$(ProjectDir)..\src;$(GeneratedDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir);$(ProjectDir)..\src;$(GeneratedDir);$(VelopackRoot)\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalOptions>/utf-8 /Zc:__cplusplus /Zc:preprocessor /Zc:inline %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
@@ -81,7 +82,8 @@
       <DataExecutionPrevention>true</DataExecutionPrevention>
       <HighEntropyVA>true</HighEntropyVA>
       <ControlFlowGuard>Guard</ControlFlowGuard>
-      <AdditionalDependencies>user32.lib;gdi32.lib;shell32.lib;shlwapi.lib;advapi32.lib;ole32.lib;windowsapp.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>$(VelopackRoot)\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>user32.lib;gdi32.lib;shell32.lib;shlwapi.lib;advapi32.lib;ole32.lib;windowsapp.lib;velopack_libc_win_x64_msvc.dll.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
 
@@ -129,6 +131,11 @@
     <ClInclude Include="**\*.h" />
     <ResourceCompile Include="app_icon.rc" />
   </ItemGroup>
+
+  <Target Name="CopyVelopackRuntime" AfterTargets="Build">
+    <Copy SourceFiles="$(VelopackRoot)\lib\velopack_libc_win_x64_msvc.dll"
+          DestinationFiles="$(OutDir)velopack_libc.dll" />
+  </Target>
 
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/tests/modules/module_state_store_test.cpp
+++ b/tests/modules/module_state_store_test.cpp
@@ -1,0 +1,39 @@
+#include <filesystem>
+#include <windows.h>
+
+#include "framework/test_case.h"
+#include "parent/logic/module_state_store.h"
+#include "parent/ui/contracts/ui_state.h"
+
+namespace {
+
+std::filesystem::path TempStateFile() {
+  return std::filesystem::temp_directory_path() /
+         (L"dhepz-module-state-" + std::to_wstring(GetCurrentProcessId()) + L".json");
+}
+
+}  // namespace
+
+DHEPZ_TEST(ModuleStateStore, RoundTripsTerminalPathAndHistory) {
+  const std::filesystem::path path = TempStateFile();
+  std::error_code ignored;
+  std::filesystem::remove(path, ignored);
+
+  modules::ModuleStateStore writer(path.wstring());
+  ui::application::UiPatch patch;
+  patch.changes.push_back({L"terminal.path", std::wstring(L"C:\\saved")});
+  patch.changes.push_back(
+      {L"terminal.recent_paths", std::vector<std::wstring>{L"C:\\saved", L"D:\\old"}});
+  DHEPZ_CHECK(writer.Save(patch).ok());
+
+  modules::ModuleStateStore reader(path.wstring());
+  DHEPZ_CHECK(reader.Load().ok());
+  ui::application::UiState state;
+  DHEPZ_CHECK(state.Apply(reader.Restore(L"terminal.")));
+  DHEPZ_CHECK_EQ(state.Text(L"terminal.path"), std::wstring(L"C:\\saved"));
+  const std::vector<std::wstring>* history = state.Strings(L"terminal.recent_paths");
+  DHEPZ_CHECK(history != nullptr);
+  DHEPZ_CHECK_EQ(history->size(), static_cast<std::size_t>(2));
+
+  std::filesystem::remove(path, ignored);
+}

--- a/tests/modules/terminal_module_test.cpp
+++ b/tests/modules/terminal_module_test.cpp
@@ -13,6 +13,7 @@
 #include "parent/ui/config/resolved_ui_document.h"
 #include "parent/ui/contracts/ui_state.h"
 #include "platform/files.h"
+#include "ui/components/input/input_component.h"
 
 namespace {
 
@@ -32,6 +33,10 @@ class FakeHost final : public modules::ModuleHost,
                        public modules::BackgroundCapabilities {
  public:
   std::wstring DefaultDirectory() const override { return L"C:\\work"; }
+
+  ui::application::UiPatch RestoredState(std::wstring_view) const override {
+    return restored_;
+  }
 
   std::optional<std::wstring> PickFolder(std::wstring_view) override {
     return L"C:\\picked";
@@ -74,6 +79,11 @@ class FakeHost final : public modules::ModuleHost,
     return core::Ok();
   }
 
+  core::Status PersistState(const ui::application::UiPatch& patch) const override {
+    persisted_.push_back(patch);
+    return core::Ok();
+  }
+
   void Complete() {
     if (pending_complete_) pending_complete_(pending_status_);
     pending_complete_ = {};
@@ -82,6 +92,8 @@ class FakeHost final : public modules::ModuleHost,
   mutable std::vector<modules::ProcessRequest> started_;
   mutable std::vector<modules::ProcessRequest> ran_;
   std::vector<ui::application::UiPatch> published_;
+  ui::application::UiPatch restored_;
+  mutable std::vector<ui::application::UiPatch> persisted_;
   core::Status start_status_;
   int close_if_unpinned_requests_ = 0;
 
@@ -216,4 +228,46 @@ DHEPZ_TEST(P4Terminal, SuccessfulLaunchClosesOnlyThroughTheParentRequest) {
   DHEPZ_CHECK(failed_state.Apply(failed_actions.Dispatch(launch, failed_state)));
   failed_host.Complete();
   DHEPZ_CHECK_EQ(failed_host.close_if_unpinned_requests_, 0);
+}
+
+DHEPZ_TEST(P4Terminal, RestoresAndPersistsPathHistoryForTheInputDropdown) {
+  const modules::ModuleDescriptor* descriptor = modules::ModuleRegistry::Find(L"terminal");
+  DHEPZ_CHECK(descriptor != nullptr);
+  std::unique_ptr<modules::ModuleController> controller = descriptor->create();
+  DHEPZ_CHECK(controller != nullptr);
+
+  FakeHost host;
+  host.restored_.changes.push_back({L"terminal.path", std::wstring(L"C:\\saved")});
+  host.restored_.changes.push_back(
+      {L"terminal.recent_paths",
+       std::vector<std::wstring>{L"C:\\saved", L"D:\\previous"}});
+  ui::application::UiState state;
+  DHEPZ_CHECK(state.Apply(controller->InitialState(host)));
+  DHEPZ_CHECK_EQ(state.Text(L"terminal.path"), std::wstring(L"C:\\saved"));
+  const std::vector<std::wstring>* restored = state.Strings(L"terminal.recent_paths");
+  DHEPZ_CHECK(restored != nullptr);
+  DHEPZ_CHECK_EQ(restored->size(), static_cast<std::size_t>(2));
+
+  ui::config::ComponentNode input(L"input", L"terminal-path");
+  input.SetProperty(L"suggestions_binding",
+                    json::Value::String(L"terminal.recent_paths"));
+  const ui::components::ComponentDescriptor descriptor_component =
+      ui::components::CreateInputComponent();
+  DHEPZ_CHECK(descriptor_component.has_overlay != nullptr);
+  DHEPZ_CHECK(descriptor_component.has_overlay(input, state));
+
+  ui::application::UiActionRegistry actions;
+  DHEPZ_CHECK(controller->Bind(&host, &actions).ok());
+  state.Set(L"terminal.path", std::wstring(L"E:\\next"));
+  ui::application::UiEvent launch{L"terminal.launch.default", L"windows-terminal", {}};
+  DHEPZ_CHECK(state.Apply(actions.Dispatch(launch, state)));
+  host.Complete();
+  DHEPZ_CHECK_EQ(host.persisted_.size(), static_cast<std::size_t>(1));
+  ui::application::UiState persisted;
+  DHEPZ_CHECK(persisted.Apply(host.persisted_.front()));
+  DHEPZ_CHECK_EQ(persisted.Text(L"terminal.path"), std::wstring(L"E:\\next"));
+  const std::vector<std::wstring>* history = persisted.Strings(L"terminal.recent_paths");
+  DHEPZ_CHECK(history != nullptr);
+  DHEPZ_CHECK_EQ(history->size(), static_cast<std::size_t>(3));
+  DHEPZ_CHECK_EQ(history->front(), std::wstring(L"E:\\next"));
 }

--- a/tools/Build-Release.ps1
+++ b/tools/Build-Release.ps1
@@ -1,0 +1,83 @@
+param(
+    [string] $Version = (& (Join-Path $PSScriptRoot 'Get-ProjectVersion.ps1')),
+    [string] $PublishDirectory = (Join-Path $PSScriptRoot '..\artifacts\publish'),
+    [string] $OutputDirectory = (Join-Path $PSScriptRoot '..\Releases'),
+    [string] $ReleaseNotes
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+if ($Version -notmatch '^\d+\.\d+\.\d+$') {
+    throw 'Version harus menggunakan semver tiga bagian, contoh 0.1.0.'
+}
+
+$repositoryRoot = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..'))
+$repositoryPrefix = $repositoryRoot.TrimEnd('\') + '\'
+$publishPath = [System.IO.Path]::GetFullPath($PublishDirectory)
+$outputPath = [System.IO.Path]::GetFullPath($OutputDirectory)
+foreach ($path in @($publishPath, $outputPath)) {
+    if (-not $path.StartsWith($repositoryPrefix, [StringComparison]::OrdinalIgnoreCase)) {
+        throw "Output harus berada di dalam repository: $path"
+    }
+}
+
+if (Test-Path -LiteralPath $publishPath) {
+    Remove-Item -LiteralPath $publishPath -Recurse -Force
+}
+New-Item -ItemType Directory -Path $publishPath -Force | Out-Null
+New-Item -ItemType Directory -Path $outputPath -Force | Out-Null
+
+& (Join-Path $PSScriptRoot 'Build.ps1') -Configuration Release -Version $Version
+if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+$releaseBuild = Join-Path $repositoryRoot 'build\x64\Release'
+foreach ($name in @('dhepz.exe', 'velopack_libc.dll')) {
+    $source = Join-Path $releaseBuild $name
+    if (-not (Test-Path -LiteralPath $source -PathType Leaf)) {
+        throw "File paket tidak ditemukan: $source"
+    }
+    Copy-Item -LiteralPath $source -Destination $publishPath -Force
+}
+
+& dotnet tool restore
+if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+$packArguments = @(
+    'vpk', 'pack',
+    # Keep the replaceable install tree separate from
+    # %LOCALAPPDATA%\dhepz\state, exactly as Open-terminal V1 separates its
+    # package id from its state directory.
+    '--packId', 'dhepzLauncher',
+    '--packVersion', $Version,
+    '--packDir', $publishPath,
+    '--mainExe', 'dhepz.exe',
+    '--packTitle', 'dhepz',
+    '--packAuthors', 'yuzhayo',
+    '--icon', (Join-Path $repositoryRoot 'assets\app.ico'),
+    '--outputDir', $outputPath,
+    '--runtime', 'win-x64',
+    '--shortcuts', 'Desktop,StartMenuRoot'
+)
+if (-not [string]::IsNullOrWhiteSpace($ReleaseNotes)) {
+    $notesPath = [System.IO.Path]::GetFullPath($ReleaseNotes)
+    if (-not (Test-Path -LiteralPath $notesPath -PathType Leaf)) {
+        throw "Release notes tidak ditemukan: $notesPath"
+    }
+    $packArguments += @('--releaseNotes', $notesPath)
+}
+
+& dotnet @packArguments
+if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+$setup = Get-ChildItem -LiteralPath $outputPath -Filter '*-Setup.exe' |
+    Sort-Object LastWriteTime -Descending |
+    Select-Object -First 1
+if (-not $setup) {
+    throw 'Velopack tidak menghasilkan installer Setup.exe.'
+}
+
+[pscustomobject]@{
+    Version = $Version
+    Setup = $setup.FullName
+    Sha256 = (Get-FileHash -LiteralPath $setup.FullName -Algorithm SHA256).Hash
+} | ConvertTo-Json

--- a/tools/Get-ProjectVersion.ps1
+++ b/tools/Get-ProjectVersion.ps1
@@ -1,0 +1,12 @@
+param(
+    [string] $Project = (Join-Path $PSScriptRoot '..\version.props')
+)
+
+$ErrorActionPreference = 'Stop'
+$content = Get-Content -LiteralPath $Project -Raw
+$match = [regex]::Match($content, '<DhepzVersion>(?<version>\d+\.\d+\.\d+)</DhepzVersion>')
+if (-not $match.Success) {
+    throw "DhepzVersion semver tiga bagian tidak ditemukan di $Project."
+}
+
+$match.Groups['version'].Value

--- a/tools/Get-ReleaseVersion.ps1
+++ b/tools/Get-ReleaseVersion.ps1
@@ -1,0 +1,32 @@
+param(
+    [ValidateSet('patch', 'minor', 'major')]
+    [string] $Bump = 'patch',
+    [string] $Project = (Join-Path $PSScriptRoot '..\version.props')
+)
+
+$ErrorActionPreference = 'Stop'
+$projectVersion = [Version]::Parse((& (Join-Path $PSScriptRoot 'Get-ProjectVersion.ps1') -Project $Project))
+$tagVersions = @(git tag --list 'v*' | ForEach-Object {
+    $parsed = [Version]::new()
+    if ([Version]::TryParse($_.TrimStart('v'), [ref] $parsed) -and $parsed.Revision -le 0) {
+        $parsed
+    }
+})
+
+if ($tagVersions.Count -eq 0) {
+    "$($projectVersion.Major).$($projectVersion.Minor).$($projectVersion.Build)"
+    exit 0
+}
+
+$latest = $tagVersions | Sort-Object -Descending | Select-Object -First 1
+if ($projectVersion -gt $latest) {
+    "$($projectVersion.Major).$($projectVersion.Minor).$($projectVersion.Build)"
+    exit 0
+}
+
+$next = switch ($Bump) {
+    'patch' { [Version]::new($latest.Major, $latest.Minor, $latest.Build + 1) }
+    'minor' { [Version]::new($latest.Major, $latest.Minor + 1, 0) }
+    'major' { [Version]::new($latest.Major + 1, 0, 0) }
+}
+"$($next.Major).$($next.Minor).$($next.Build)"


### PR DESCRIPTION
## Summary
- persist terminal path and history through the parent-owned state store
- add the compact Settings update card and explicit GitHub update actions
- add Velopack Windows packaging and an automatically versioned release workflow

## Validation
- Debug: 148/148 passed
- Release: 149/149 passed