### PR TITLE
chore: migrate DHEPZ to Visual Studio 2026

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     # is only meaningful if the image it runs on does not move underneath it —
     # otherwise a runner image update silently changes the binary and a
     # performance regression cannot be attributed to a code change.
-    runs-on: windows-2022
+    runs-on: windows-2025-vs2026
     timeout-minutes: 30
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   release:
-    runs-on: windows-2022
+    runs-on: windows-2025-vs2026
     timeout-minutes: 40
 
     steps:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # dhepz — agent operating rules
 
-Windows Win32 C++20 tray-resident launcher. MSBuild (`v143`, `/std:c++20 /W4 /WX`, static CRT, Unicode).
+Windows Win32 C++20 tray-resident launcher. MSBuild (`v145`, `/std:c++20 /W4 /WX`, static CRT, Unicode).
 The plan lives at `.docs/plan.md` (gitignored, single live copy). Read it before proposing architecture.
 
 ## Non-negotiable goals

--- a/src/dhepz.vcxproj
+++ b/src/dhepz.vcxproj
@@ -26,16 +26,16 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
-    <VCToolsVersion>14.44.35207</VCToolsVersion>
+    <PlatformToolset>v145</PlatformToolset>
+    <VCToolsVersion>14.51.36231</VCToolsVersion>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
-    <VCToolsVersion>14.44.35207</VCToolsVersion>
+    <PlatformToolset>v145</PlatformToolset>
+    <VCToolsVersion>14.51.36231</VCToolsVersion>
     <!-- LTCG. Part of why an installed native EXE can hit the cold-start budget. -->
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>

--- a/tests/dhepz_tests.vcxproj
+++ b/tests/dhepz_tests.vcxproj
@@ -26,16 +26,16 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
-    <VCToolsVersion>14.44.35207</VCToolsVersion>
+    <PlatformToolset>v145</PlatformToolset>
+    <VCToolsVersion>14.51.36231</VCToolsVersion>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
-    <VCToolsVersion>14.44.35207</VCToolsVersion>
+    <PlatformToolset>v145</PlatformToolset>
+    <VCToolsVersion>14.51.36231</VCToolsVersion>
     <CharacterSet>Unicode</CharacterSet>
     <!-- Deliberately no WholeProgramOptimization. The Release suite exists to
          test the same code the shipped binary runs, and LTCG only slows the

--- a/tools/Build.ps1
+++ b/tools/Build.ps1
@@ -58,14 +58,14 @@ if (-not $SkipChecks) {
 
 $vswhere = Join-Path ${env:ProgramFiles(x86)} 'Microsoft Visual Studio\Installer\vswhere.exe'
 if (-not (Test-Path -LiteralPath $vswhere -PathType Leaf)) {
-    throw "vswhere.exe not found at '$vswhere'. Install Visual Studio 2022 C++ Build Tools."
+    throw "vswhere.exe not found at '$vswhere'. Install Visual Studio 2026 with the Desktop development with C++ workload."
 }
 
 $msbuild = & $vswhere -latest -products * -requires Microsoft.Component.MSBuild `
     -find 'MSBuild\**\Bin\MSBuild.exe' | Select-Object -First 1
 
 if (-not $msbuild) {
-    throw 'MSBuild for Visual Studio 2022 was not found. Install the Microsoft.Component.MSBuild component.'
+    throw 'MSBuild for Visual Studio 2026 was not found. Install the Microsoft.Component.MSBuild component.'
 }
 
 $target = if ($Rebuild) { 'Rebuild' } else { 'Build' }
@@ -75,8 +75,8 @@ $arguments = @(
     '/m', '/nologo', '/v:minimal', "/t:$target",
     "/p:Configuration=$Configuration",
     "/p:Platform=$Platform",
-    '/p:PlatformToolset=v143',
-    '/p:VCToolsVersion=14.44.35207',
+    '/p:PlatformToolset=v145',
+    '/p:VCToolsVersion=14.51.36231',
     '/p:WindowsTargetPlatformVersion=10.0.26100.0',
     '/p:PreferredToolArchitecture=x64'
 )

--- a/tools/Measure-Performance.ps1
+++ b/tools/Measure-Performance.ps1
@@ -51,6 +51,8 @@ $className = 'dhepz.InfrastructureWindow'
 $installDir = Join-Path $env:LOCALAPPDATA 'dhepz\baseline'
 $installedExe = Join-Path $installDir 'dhepz.exe'
 $buildTreeExe = Join-Path $repositoryRoot 'build\x64\Release\dhepz.exe'
+$buildTreeRuntime = Join-Path $repositoryRoot 'build\x64\Release\velopack_libc.dll'
+$installedRuntime = Join-Path $installDir 'velopack_libc.dll'
 
 if (-not $SkipChecks) {
     & (Join-Path $PSScriptRoot 'Test-Toolchain.ps1') -SkipDotnet
@@ -61,12 +63,14 @@ if (-not $SkipChecks) {
 
 # --- Deploy ---------------------------------------------------------------
 
-if (-not (Test-Path -LiteralPath $buildTreeExe -PathType Leaf)) {
-    throw "No Release build at '$buildTreeExe'. Run tools\Build.ps1 -Configuration Release first."
+if (-not (Test-Path -LiteralPath $buildTreeExe -PathType Leaf) -or
+    -not (Test-Path -LiteralPath $buildTreeRuntime -PathType Leaf)) {
+    throw "Release output is incomplete. Expected '$buildTreeExe' and '$buildTreeRuntime'. Run tools\Build.ps1 -Configuration Release first."
 }
 New-Item -ItemType Directory -Path $installDir -Force | Out-Null
 Copy-Item -LiteralPath $buildTreeExe -Destination $installedExe -Force
-Write-Host "Deployed $installedExe" -ForegroundColor Cyan
+Copy-Item -LiteralPath $buildTreeRuntime -Destination $installedRuntime -Force
+Write-Host "Deployed $installedExe and $installedRuntime" -ForegroundColor Cyan
 
 # --- Native helpers ---------------------------------------------------------
 
@@ -182,7 +186,7 @@ $ramGb = [math]::Round((Get-CimInstance Win32_ComputerSystem).TotalPhysicalMemor
 $vswhere = Join-Path ${env:ProgramFiles(x86)} 'Microsoft Visual Studio\Installer\vswhere.exe'
 $vsVersion = (& $vswhere -latest -products * -format value -property installationVersion 2>$null)
 $installation = & $vswhere -latest -products * -format json | ConvertFrom-Json | Select-Object -First 1
-$compiler = Join-Path $installation.installationPath 'VC\Tools\MSVC\14.44.35207\bin\Hostx64\x64\cl.exe'
+$compiler = Join-Path $installation.installationPath 'VC\Tools\MSVC\14.51.36231\bin\Hostx64\x64\cl.exe'
 $clVersion = if (Test-Path -LiteralPath $compiler) { (Get-Item -LiteralPath $compiler).VersionInfo.FileVersion } else { '(not found)' }
 
 # --- Report -------------------------------------------------------------------
@@ -200,7 +204,7 @@ $report = [ordered]@{
     }
     toolchain         = [ordered]@{
         visualStudio = $vsVersion
-        vcTools      = '14.44.35207'
+        vcTools      = '14.51.36231'
         cl           = $clVersion
         windowsSdk   = '10.0.26100.0'
     }
@@ -238,5 +242,5 @@ Write-Host "  CPU = $($report.idle.cpuPercent)%   threads = $threadsAtStart"
 Write-Host "  private bytes = $privateAtStart -> $privateAtEnd (drift $($report.idle.privateDriftBytes) B)"
 Write-Host "  GDI objects = $($report.idle.gdiObjects)   USER objects = $($report.idle.userObjects)"
 Write-Host "Machine: $env:COMPUTERNAME / $cpuModel / $ramGb GB / Windows $($report.machine.windows)"
-Write-Host "Toolchain: VS $vsVersion, VC 14.44.35207, cl $clVersion, SDK 10.0.26100.0"
+Write-Host "Toolchain: VS $vsVersion, VC 14.51.36231, cl $clVersion, SDK 10.0.26100.0"
 Write-Host "Report: artifacts\baseline.json" -ForegroundColor Cyan

--- a/tools/Test-Toolchain.ps1
+++ b/tools/Test-Toolchain.ps1
@@ -23,9 +23,9 @@ $ErrorActionPreference = 'Stop'
 Set-StrictMode -Version Latest
 
 $expected = [ordered]@{
-    visualStudioPrefix = '17.14.'
-    vcToolsVersion     = '14.44.35207'
-    compilerPrefix     = '19.44.352'
+    visualStudioPrefix = '18.9.'
+    vcToolsVersion     = '14.51.36231'
+    compilerPrefix     = '19.51.362'
     windowsSdkVersion  = '10.0.26100.0'
     dotnetSdkPrefix    = '9.0.3'
 }
@@ -34,7 +34,7 @@ $problems = [System.Collections.Generic.List[string]]::new()
 
 $vswhere = Join-Path ${env:ProgramFiles(x86)} 'Microsoft Visual Studio\Installer\vswhere.exe'
 if (-not (Test-Path -LiteralPath $vswhere -PathType Leaf)) {
-    throw "vswhere.exe not found at '$vswhere'. Install Visual Studio 2022 C++ Build Tools."
+    throw "vswhere.exe not found at '$vswhere'. Install Visual Studio 2026 with the Desktop development with C++ workload."
 }
 
 $installation = & $vswhere -latest -products * `
@@ -42,7 +42,7 @@ $installation = & $vswhere -latest -products * `
     -format json | ConvertFrom-Json | Select-Object -First 1
 
 if (-not $installation) {
-    throw 'No Visual Studio 2022 installation with the C++ x64 toolset was found. Install the "Desktop development with C++" workload, or the VC.Tools.x86.x64 component in Build Tools.'
+    throw 'No Visual Studio 2026 installation with the C++ x64 toolset was found. Install the "Desktop development with C++" workload, or the VC.Tools.x86.x64 component in Build Tools.'
 }
 
 $msbuildPath  = Join-Path $installation.installationPath 'MSBuild\Current\Bin\MSBuild.exe'
@@ -60,7 +60,7 @@ $actual = [ordered]@{
 }
 
 if (-not $actual.visualStudio.StartsWith($expected.visualStudioPrefix, [StringComparison]::Ordinal)) {
-    $problems.Add("Visual Studio $($expected.visualStudioPrefix)x expected, found $($actual.visualStudio). Update Visual Studio 2022, or adjust the pin in this script and re-record the performance baseline (issue #13).")
+    $problems.Add("Visual Studio $($expected.visualStudioPrefix)x expected, found $($actual.visualStudio). Update Visual Studio 2026, or adjust the pin in this script and re-record the performance baseline (issue #13).")
 }
 
 if ($actual.msbuild -eq '(not found)') {


### PR DESCRIPTION
## Summary\n- migrate the native C++ toolchain from v143/MSVC 14.44 to v145/MSVC 14.51\n- align local build, toolchain verification, performance metadata, and GitHub Actions runners with Visual Studio 2026\n- deploy velopack_libc.dll alongside the baseline executable\n\n## Validation\n- tools/Test-Toolchain.ps1\n- Debug test runner: pass\n- Release test runner: pass\n- 20-run VS 2026 performance baseline: 0 failures, 0% idle CPU, no measured memory or handle drift\n- git diff --check