### PR TITLE
Phase 5: declare Terminal settings page contract

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -123,7 +123,12 @@ int APIENTRY wWinMain(_In_ HINSTANCE instance,
     BootstrapFailed(17, message.c_str());
   }
   for (const modules::ModuleDescriptor* descriptor : module_descriptors) {
-    if (feature_document->FindRoute(descriptor->route_id) == nullptr) {
+    const bool main_route_missing =
+        feature_document->FindRoute(descriptor->route_id) == nullptr;
+    const bool settings_route_missing =
+        !descriptor->settings_route_id.empty() &&
+        feature_document->FindRoute(descriptor->settings_route_id) == nullptr;
+    if (main_route_missing || settings_route_missing) {
       tray_process.Shutdown();
       BootstrapFailed(18, L"A module route is missing from its UI document.");
     }

--- a/src/modules/terminal/terminal.json
+++ b/src/modules/terminal/terminal.json
@@ -104,6 +104,12 @@
           ]
         }
       ]
+    },
+    {
+      "type": "screen",
+      "route_id": "terminal.settings",
+      "show_in_tabs": false,
+      "children": []
     }
   ]
 }

--- a/src/modules/terminal/terminal_module.cpp
+++ b/src/modules/terminal/terminal_module.cpp
@@ -350,7 +350,7 @@ std::unique_ptr<ModuleController> CreateTerminalController() {
 
 const ModuleDescriptor kTerminalDescriptor{
     L"terminal", L"terminal", L"modules/terminal/terminal.json", IDR_TERMINAL_SCREEN_JSON,
-    &CreateTerminalController};
+    &CreateTerminalController, L"terminal.settings"};
 const ModuleRegistrar kTerminalRegistration(&kTerminalDescriptor);
 
 }  // namespace

--- a/src/parent/logic/module_contract.h
+++ b/src/parent/logic/module_contract.h
@@ -60,6 +60,7 @@ struct ModuleDescriptor {
   std::wstring_view screen_name;
   int ui_resource_id = 0;
   std::unique_ptr<ModuleController> (*create)() = nullptr;
+  std::wstring_view settings_route_id;
 };
 
 }  // namespace modules

--- a/tests/modules/terminal_module_test.cpp
+++ b/tests/modules/terminal_module_test.cpp
@@ -109,6 +109,8 @@ DHEPZ_TEST(P4Terminal, DescriptorJsonAndCoreContractResolveTogether) {
   const modules::ModuleDescriptor* descriptor = modules::ModuleRegistry::Find(L"terminal");
   DHEPZ_CHECK(descriptor != nullptr);
   DHEPZ_CHECK_EQ(descriptor->route_id, std::wstring_view(L"terminal"));
+  DHEPZ_CHECK_EQ(descriptor->settings_route_id,
+                 std::wstring_view(L"terminal.settings"));
 
   json::Value core_catalog;
   DHEPZ_CHECK(json::Parse(Read(RepositoryRoot() / L"assets" / L"ui" / L"core.json"),
@@ -125,6 +127,9 @@ DHEPZ_TEST(P4Terminal, DescriptorJsonAndCoreContractResolveTogether) {
                   .ok());
   DHEPZ_CHECK(document != nullptr);
   DHEPZ_CHECK(document->FindRoute(L"terminal") != nullptr);
+  const ui::config::Route* settings = document->FindRoute(L"terminal.settings");
+  DHEPZ_CHECK(settings != nullptr);
+  DHEPZ_CHECK_FALSE(settings->show_in_tabs);
   ui::config::Rgba accent;
   DHEPZ_CHECK(document->Token(L"dark", L"accent", &accent));
 }


### PR DESCRIPTION
Closes #129.

Adds a generic optional settings route to ModuleDescriptor, validates it in the production composition path, and declares a hidden terminal.settings page without inventing Settings controls.